### PR TITLE
#33 - fix(sonar): Sonarqube configurations had to be switched to CICD for security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,11 @@ jobs:
       - name: SonarCloud Scan
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+          SONAR_ORGANIZATION_KEY: ${{ secrets.SONAR_ORGANIZATION_KEY }}
         run: |
-          npx sonar-scanner -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+          npx sonar-scanner \
+            -Dsonar.projectKey=$SONAR_PROJECT_KEY \
+            -Dsonar.organization=$SONAR_ORGANIZATION_KEY \
+            -Dsonar.login=$SONAR_TOKEN
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist
 tmp
 /out-tsc
 
+
+
 # dependencies
 node_modules
 
@@ -105,6 +107,7 @@ Desktop.ini
 apps/frontend/.env
 .env.local
 .env.*.local
+.env
 
 # Miscellaneous
 **/*.bak

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,3 @@
-# Project Identification for SonarCloud
-sonar.projectKey=your-sonarcloud-project-key  # Replace with your SonarCloud project key
-sonar.organization=your-organization-key  # Replace with your SonarCloud organization key
-
 # SonarCloud URL and Token
 sonar.host.url=https://sonarcloud.io
 


### PR DESCRIPTION
### Summary
This PR simplifies the SonarCloud integration by moving sensitive project information (such as the project key and organization key) from `sonar-project.properties` to secure environment variables in the CI/CD pipeline. This approach improves security and flexibility by handling sensitive details only within GitHub Secrets, rather than hardcoding them in version-controlled files.

### Changes Made
- **Removed Sensitive Keys from `sonar-project.properties`**:
  - Removed `sonar.projectKey` and `sonar.organization` from `sonar-project.properties` to prevent exposure of sensitive information in version-controlled files.
- **Configured GitHub Actions to Use Secrets**:
  - Updated the GitHub Actions workflow to load `SONAR_PROJECT_KEY` and `SONAR_ORGANIZATION_KEY` from GitHub Secrets during the SonarCloud scan step.
  - Passed these keys as arguments to `sonar-scanner` in the workflow, enabling secure SonarCloud analysis without relying on plaintext values in the properties file.

### Testing Instructions
1. Verify that the `SONAR_PROJECT_KEY` and `SONAR_ORGANIZATION_KEY` secrets are correctly configured in the repository’s GitHub Secrets.
2. Ensure that the CI/CD workflow completes successfully and that SonarCloud receives the project and organization keys correctly during the scan.
3. Confirm that no sensitive data is exposed in `sonar-project.properties`.

### Additional Notes
- **Security**: This update minimizes sensitive information in the repository by leveraging GitHub Secrets for SonarCloud keys.
- **Flexibility**: The CI/CD pipeline is now more secure and adaptable to future updates, as sensitive details are stored only in GitHub Secrets.

This change helps to ensure secure handling of SonarCloud credentials, keeping project configuration clean and focused.
