### PR TITLE
#88 - Fix(UI): Fixed the gap preventing full-screen elements

### DIFF
--- a/apps/frontend/src/app/components/Sidebar.tsx
+++ b/apps/frontend/src/app/components/Sidebar.tsx
@@ -11,10 +11,10 @@ const terrainImage = '/assets/Terrain_layer.png';
 
 const SidebarContainer = styled.div`
   width: 100px;
-  background: #005ea6;
+  background: #00447E;
   color: white;
   position: fixed;
-  bottom: 15vh;
+  bottom: 10vh;
   left: 25px;
   padding: 10px;
   box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);

--- a/apps/frontend/src/app/layout.css
+++ b/apps/frontend/src/app/layout.css
@@ -1,0 +1,3 @@
+body{
+    margin:0;
+}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -9,7 +9,7 @@ import Sidebar from './components/Sidebar';
 import TopLeftButtons from './components/TopLeftButtons';
 import AvailableDatasets, { Dataset } from './components/AvailableDatasets';
 import MapMetaData from './components/MapMetaData';
-
+import "./layout.css";
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);


### PR DESCRIPTION
### Summary

Resolved the issue of an unexpected border or margin around the edges of the body element, ensuring that all elements extend to the full screen as intended.

### Changes Made

- Removed the default margin on the body element to prevent unintended spacing around the page.
- Changed the views component position and its color to the mockup one

### Testing Instructions

- Open the web app in any supported browser.
- Ensure that the content extends to the full screen without any visible margin or border around the body element.
- Inspect the body element to confirm that there is no default padding or margin applied.

### Screenshots
![Screenshot 2024-11-09 at 8 38 39 PM](https://github.com/user-attachments/assets/8f9a9161-ea8f-4493-b158-faf0750b714d)
