### PR TITLE
#149 - feature: [Backend] Create Endpoint to Retrieve a List of Collections from the Database

### DIFF
--- a/apps/backend/src/main/java/com/example/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/com/example/backend/controller/DataController.java
@@ -1,18 +1,20 @@
 package com.example.backend.controller;
 
-import com.example.backend.repository.StacRepository;
 import com.example.backend.service.DataService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
 import java.io.IOException;
 import java.nio.file.Files;
-import org.springframework.core.io.ClassPathResource;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 public class DataController {
@@ -22,7 +24,7 @@ public class DataController {
   private DataService dataService;
 
   @GetMapping("/api/data")
-  public ResponseEntity<String> getData() throws IOException {
+  public ResponseEntity<String> getData() {
     logger.info("Received request to /api/data");
     try {
       ClassPathResource resource = new ClassPathResource("synthetic_wildfire_collection.json");
@@ -40,7 +42,6 @@ public class DataController {
   public ResponseEntity<String> testStacEndpoint() {
     logger.info("Received request to /api/test-stac");
     try {
-      // Using default values
       String result = dataService.insertAndQueryCollection();
       logger.debug("Successfully processed STAC data");
       return ResponseEntity.ok(result);
@@ -67,13 +68,26 @@ public class DataController {
 
   @GetMapping("/api/fetch-collections")
   public ResponseEntity<String> fetchCollections() {
-    logger.info("Received request to fetch collections");
+    logger.info("Received request to fetch and save collections");
     try {
       dataService.fetchAndSaveCollections();
       return ResponseEntity.ok("Collections fetched and saved successfully");
     } catch (Exception e) {
       logger.error("Error fetching collections: {}", e.getMessage(), e);
       return ResponseEntity.internalServerError().body("Error fetching collections: " + e.getMessage());
+    }
+  }
+
+  @GetMapping("/api/get-collections")
+  public ResponseEntity<List<Map<String, Object>>> getCollections() {
+    logger.info("Received request to get collections");
+    try {
+      List<Map<String, Object>> collections = dataService.getCollections();
+      logger.debug("Successfully fetched collections");
+      return ResponseEntity.ok(collections);
+    } catch (Exception e) {
+      logger.error("Error fetching collections: {}", e.getMessage(), e);
+      return ResponseEntity.internalServerError().body(null);
     }
   }
 }

--- a/apps/backend/src/main/java/com/example/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/com/example/backend/repository/StacRepository.java
@@ -57,4 +57,17 @@ public class StacRepository {
       throw new RuntimeException("Error querying collection: " + e.getMessage(), e);
     }
   }
+
+  public List<Map<String, Object>> getAllCollections() {
+    logger.debug("Fetching all collections");
+    try {
+      String sql = "SELECT * FROM pgstac.collections";
+      List<Map<String, Object>> results = jdbcTemplate.queryForList(sql);
+      logger.debug("Query returned {} results", results.size());
+      return results;
+    } catch (DataAccessException e) {
+      logger.error("Error fetching all collections: {}", e.getMessage(), e);
+      throw new RuntimeException("Error fetching all collections: " + e.getMessage(), e);
+    }
+  }
 }

--- a/apps/backend/src/main/java/com/example/backend/service/DataService.java
+++ b/apps/backend/src/main/java/com/example/backend/service/DataService.java
@@ -11,6 +11,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class DataService {
@@ -37,6 +38,9 @@ public class DataService {
 
   @Autowired
   private RestTemplate restTemplate;
+
+  @Autowired
+  private ObjectMapper objectMapper;
 
   public String insertAndQueryCollection() {
     return insertAndQueryCollection(DEFAULT_COLLECTION_JSON, DEFAULT_COLLECTION_ID);
@@ -70,7 +74,7 @@ public class DataService {
       List<Map<String, Object>> collectionData = stacRepository.queryCollection(finalCollectionId);
       logger.debug("Query completed, returned {} results", collectionData.size());
 
-      return collectionData.isEmpty() ? "Collection not found" : collectionData.toString();
+      return collectionData.isEmpty() ? "Collection not found" : objectMapper.writeValueAsString(collectionData);
     } catch (Exception e) {
       logger.error("Error in insertAndQueryCollection: {}", e.getMessage(), e);
       throw new RuntimeException("Failed to process collection: " + e.getMessage(), e);
@@ -85,7 +89,7 @@ public class DataService {
       for (Map<String, Object> collection : collections) {
         String id = (String) collection.get("id");
         if (!stacRepository.checkCollectionExists(id)) {
-          String collectionJson = new ObjectMapper().writeValueAsString(collection);
+          String collectionJson = objectMapper.writeValueAsString(collection);
           stacRepository.insertCollection(collectionJson);
         }
       }
@@ -93,6 +97,19 @@ public class DataService {
     } catch (Exception e) {
       logger.error("Error fetching or saving collections: {}", e.getMessage(), e);
       throw new RuntimeException("Failed to fetch or save collections: " + e.getMessage(), e);
+    }
+  }
+
+  public List<Map<String, Object>> getCollections() {
+    logger.info("Fetching collections from database");
+    try {
+      List<Map<String, Object>> collections = stacRepository.getAllCollections();
+      return collections.stream()
+        .map(collection -> Map.of("key", collection.get("key"), "id", collection.get("id")))
+        .collect(Collectors.toList());
+    } catch (Exception e) {
+      logger.error("Error fetching collections: {}", e.getMessage(), e);
+      throw new RuntimeException("Failed to fetch collections: " + e.getMessage(), e);
     }
   }
 }

--- a/apps/backend/src/test/java/com/example/backend/backend/BackendSampleJUnitTests.java
+++ b/apps/backend/src/test/java/com/example/backend/backend/BackendSampleJUnitTests.java
@@ -3,7 +3,7 @@ package com.example.backend.backend;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class BackendSampleJUnitTests {
+class BackendSampleJUnitTests {
 
   @Test
   void createNewBackendForTesting() {

--- a/apps/backend/src/test/java/com/example/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/com/example/backend/controller/DataControllerTests.java
@@ -9,6 +9,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -22,7 +25,7 @@ class DataControllerTests {
   private DataController dataController;
 
   @Test
-  void getData_Success() throws Exception {
+  void getData_Success() {
     // Act
     ResponseEntity<String> response = dataController.getData();
 
@@ -90,7 +93,7 @@ class DataControllerTests {
   }
 
   @Test
-  void fetchCollections_Success() throws Exception {
+  void fetchCollections_Success() {
     // Act
     ResponseEntity<String> response = dataController.fetchCollections();
 
@@ -101,7 +104,7 @@ class DataControllerTests {
   }
 
   @Test
-  void fetchCollections_Failure() throws Exception {
+  void fetchCollections_Failure() {
     // Arrange
     doThrow(new RuntimeException("Test error")).when(dataService).fetchAndSaveCollections();
 
@@ -125,5 +128,35 @@ class DataControllerTests {
     // Assert
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(response.getBody()).contains("Error fetching collections: Test IO error");
+  }
+
+  @Test
+  void getCollections_Success() {
+    // Arrange
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1"),
+      Map.of("key", "value2", "id", "id2")
+    );
+    when(dataService.getCollections()).thenReturn(mockCollections);
+
+    // Act
+    ResponseEntity<List<Map<String, Object>>> response = dataController.getCollections();
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo(mockCollections);
+  }
+
+  @Test
+  void getCollections_Failure() {
+    // Arrange
+    when(dataService.getCollections()).thenThrow(new RuntimeException("Test error"));
+
+    // Act
+    ResponseEntity<List<Map<String, Object>>> response = dataController.getCollections();
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody()).isNull();
   }
 }

--- a/apps/backend/src/test/java/com/example/backend/controller/TestControllerTests.java
+++ b/apps/backend/src/test/java/com/example/backend/controller/TestControllerTests.java
@@ -1,6 +1,5 @@
 package com.example.backend.controller;
 
-import com.example.backend.controller.TestController;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,7 +15,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class TestControllerTestT {
+class TestControllerTests {
 
   @Mock
   private JdbcTemplate jdbcTemplate;

--- a/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
@@ -117,4 +117,34 @@ class StacRepositoryTests {
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Error querying collection");
   }
+
+  @Test
+  void getAllCollections_Success() {
+    // Arrange
+    List<Map<String, Object>> mockResults = List.of(
+      Map.of("key", "value1", "id", "id1"),
+      Map.of("key", "value2", "id", "id2")
+    );
+    when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
+
+    // Act
+    List<Map<String, Object>> results = stacRepository.getAllCollections();
+
+    // Assert
+    assertThat(results).isNotNull();
+    assertThat(results).hasSize(2);
+    assertThat(results.get(0)).containsEntry("key", "value1").containsEntry("id", "id1");
+  }
+
+  @Test
+  void getAllCollections_Failure() {
+    // Arrange
+    when(jdbcTemplate.queryForList(anyString())).thenThrow(new DataAccessException("Database error") {
+    });
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.getAllCollections())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Error fetching all collections");
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
@@ -1,6 +1,8 @@
 package com.example.backend.service;
 
 import com.example.backend.repository.StacRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +27,9 @@ class DataServiceTests {
 
   @Mock
   private RestTemplate restTemplate;
+
+  @Mock
+  private ObjectMapper objectMapper;
 
   @InjectMocks
   private DataService dataService;
@@ -37,16 +43,21 @@ class DataServiceTests {
   }
 
   @Test
-  void fetchAndSaveCollections_ShouldFetchAndSaveCollections() {
+  void fetchAndSaveCollections_ShouldFetchAndSaveCollections() throws JsonProcessingException {
     // Arrange
+    Map<String, Object> collection = new HashMap<>();
+    collection.put("id", "test-collection");
+    mockResponse.put("collections", List.of(collection));
     when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
 
     // Act
     dataService.fetchAndSaveCollections();
 
     // Assert
     verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
-    verify(stacRepository, times(1)).insertCollection(anyString());
+    verify(stacRepository, times(1)).checkCollectionExists("test-collection");
+    verify(stacRepository, times(1)).insertCollection("mockedJson");
   }
 
   @Test
@@ -66,10 +77,11 @@ class DataServiceTests {
   }
 
   @Test
-  void insertAndQueryCollection_DefaultParams() {
+  void insertAndQueryCollection_DefaultParams() throws JsonProcessingException {
     // Arrange
     when(stacRepository.checkCollectionExists(anyString())).thenReturn(false);
     when(stacRepository.queryCollection(anyString())).thenReturn(List.of(new HashMap<>()));
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
 
     // Act
     String result = dataService.insertAndQueryCollection();
@@ -82,10 +94,11 @@ class DataServiceTests {
   }
 
   @Test
-  void insertAndQueryCollection_WithCollectionJson() {
+  void insertAndQueryCollection_WithCollectionJson() throws JsonProcessingException {
     // Arrange
     when(stacRepository.checkCollectionExists(anyString())).thenReturn(false);
     when(stacRepository.queryCollection(anyString())).thenReturn(List.of(new HashMap<>()));
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
 
     // Act
     String result = dataService.insertAndQueryCollection("{\"id\":\"test\"}");
@@ -98,10 +111,11 @@ class DataServiceTests {
   }
 
   @Test
-  void insertAndQueryCollection_WithCollectionJsonAndId() {
+  void insertAndQueryCollection_WithCollectionJsonAndId() throws JsonProcessingException {
     // Arrange
     when(stacRepository.checkCollectionExists(anyString())).thenReturn(false);
     when(stacRepository.queryCollection(anyString())).thenReturn(List.of(new HashMap<>()));
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
 
     // Act
     String result = dataService.insertAndQueryCollection("{\"id\":\"test\"}", "test-id");
@@ -114,10 +128,11 @@ class DataServiceTests {
   }
 
   @Test
-  void insertAndQueryCollection_CollectionExists() {
+  void insertAndQueryCollection_CollectionExists() throws JsonProcessingException {
     // Arrange
     when(stacRepository.checkCollectionExists(anyString())).thenReturn(true);
     when(stacRepository.queryCollection(anyString())).thenReturn(List.of(new HashMap<>()));
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
 
     // Act
     String result = dataService.insertAndQueryCollection("{\"id\":\"test\"}", "test-id");
@@ -154,6 +169,7 @@ class DataServiceTests {
     mockResponse.put("collections", List.of(collection));
     when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
     when(stacRepository.checkCollectionExists("new-collection")).thenReturn(false);
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
 
     // Act
     dataService.fetchAndSaveCollections();
@@ -161,5 +177,34 @@ class DataServiceTests {
     // Assert
     verify(stacRepository, times(1)).checkCollectionExists("new-collection");
     verify(stacRepository, times(1)).insertCollection(anyString());
+  }
+
+  @Test
+  void getCollections_Success() {
+    // Arrange
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1"),
+      Map.of("key", "value2", "id", "id2")
+    );
+    when(stacRepository.getAllCollections()).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollections();
+
+    // Assert
+    assertThat(collections).isNotNull();
+    assertThat(collections).hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1");
+  }
+
+  @Test
+  void getCollections_Failure() {
+    // Arrange
+    when(stacRepository.getAllCollections()).thenThrow(new RuntimeException("Test error"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.getCollections())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Failed to fetch collections");
   }
 }

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -1,70 +1,168 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import MapView from '../src/app/components/MapView';
 import { render } from '@testing-library/react';
-import { MapProvider } from '../src/app/components/MapContext';
 import fetchMock from 'jest-fetch-mock';
+import MapView from '../src/app/components/MapView';
+import { MapProvider } from '../src/app/components/MapContext';
+import Polygon from 'ol/geom/Polygon';
 
-jest.mock('react', ()=>({
-    ...jest.requireActual('react'),
-    useState: jest.fn(),
-    useContext: jest.fn(),
-    useRef: jest.fn(),
-  }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useState: jest.fn(),
+  useContext: jest.fn(),
+  useRef: jest.fn(),
+}));
 
-jest.mock('ol/source/XYZ', () =>{
-    return jest.fn().mockImplementation(() => {
-        return {}
-    })
-})
+jest.mock('ol/source/XYZ', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
 
-jest.mock('ol/layer/Tile', () =>{
-    return jest.fn().mockImplementation(() => {
-        return {}
-    })
-})
+jest.mock('ol/layer/Tile', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
 
-jest.mock('ol/View', () =>{
-    return jest.fn().mockImplementation(() => {
-        return {}
-    })
-})
+jest.mock('ol/View', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
 
 jest.mock('ol/control.js', () => ({
-    ...jest.requireActual('ol/control.js'),
-    defaults: jest.fn(() => ({
-        extend: jest.fn()
-    }))
-}))
+  ...jest.requireActual('ol/control.js'),
+  defaults: jest.fn(() => ({
+    extend: jest.fn(),
+  })),
+}));
+
+jest.mock('ol/source/Vector', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
+
+jest.mock('ol/layer/Vector', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
+
+jest.mock('ol/geom/Polygon', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
+
+jest.mock('ol/Feature', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
+
+jest.mock('ol/style/Style', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
+
+jest.mock('ol/style/Stroke', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
+
+jest.mock('ol/style/Fill', () => {
+  return jest.fn().mockImplementation(() => {
+    return {};
+  });
+});
 
 jest.mock('../src/app/components/MapContext', () => ({
-    ...jest.requireActual('../src/app/components/MapContext'),
-    useMapLayerContext: jest.fn().mockReturnValue({
-        layer: "Default",
-        setLayer: jest.fn(),
-        mapRef: jest.fn(),
-        resetView: jest.fn(),
-    })
-}))
-
+  ...jest.requireActual('../src/app/components/MapContext'),
+  useMapLayerContext: jest.fn().mockReturnValue({
+    layer: 'Default',
+    setLayer: jest.fn(),
+    mapRef: { current: null },
+    resetView: jest.fn(),
+  }),
+}));
 
 describe(MapView, () => {
-    beforeEach(()=>{    
-        jest.spyOn(React, 'useState').mockImplementation(() => [false, jest.fn()]);
-        jest.spyOn(React, 'useContext').mockReturnValue({});
-        jest.spyOn(React, 'useRef').mockReturnValue({current: {}})
-        fetchMock.enableMocks()
-    })
+  let mapRef;
 
-    afterEach(() => {
-        jest.clearAllMocks()
-    })
+  beforeEach(() => {
+    mapRef = { current: null };
+    jest.spyOn(React, 'useState').mockImplementation(() => [false, jest.fn()]);
+    jest.spyOn(React, 'useContext').mockReturnValue({});
+    jest.spyOn(React, 'useRef').mockReturnValue(mapRef);
+    jest.spyOn(React, 'useEffect').mockImplementation((fn) => fn());
+    fetchMock.enableMocks();
+  });
 
-    it("renders with null mapRef", () => {
-        const MapViewComponent = () => {
-            return <MapProvider><MapView /></MapProvider>
-        }
-        fetchMock.mockResponseOnce(JSON.stringify({ ok: true }))
-        render(<MapViewComponent />)
-    })
-})
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders with null mapRef', () => {
+    const MapViewComponent = () => (
+      <MapProvider>
+        <MapView />
+      </MapProvider>
+    );
+    fetchMock.mockResponseOnce(JSON.stringify({ ok: true }));
+    render(<MapViewComponent />);
+  });
+
+  it('clears and adds layer when mapRef is not null', () => {
+    const mockMap = {
+      getLayers: jest.fn().mockReturnValue({ clear: jest.fn() }),
+      addLayer: jest.fn(),
+    };
+    const { useMapLayerContext } = require('../src/app/components/MapContext');
+    useMapLayerContext.mockReturnValue({
+      layer: 'Default',
+      mapRef: { current: mockMap },
+    });
+
+    render(<MapView />);
+    expect(mockMap.getLayers().clear).toHaveBeenCalled();
+    expect(mockMap.addLayer).toHaveBeenCalled();
+  });
+
+  it('maps coordinates correctly', () => {
+    const mockItem = {
+      geometry: {
+        coordinates: [
+          [
+            [1, 2],
+            [3, 4],
+          ],
+        ],
+      },
+    };
+    const coordinates = mockItem.geometry.coordinates[0].map((coord) => coord);
+    expect(coordinates).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it('creates feature correctly', () => {
+    const { Feature } = require('ol');
+    const mockCoordinates = [
+      [1, 2],
+      [3, 4],
+    ];
+    const feature = new Feature({ geometry: new Polygon([mockCoordinates]) });
+    expect(feature).toBeInstanceOf(Feature);
+  });
+
+  it('returns feature correctly', () => {
+    const { Feature } = require('ol');
+    const feature = new Feature();
+    expect(feature).toBeInstanceOf(Feature);
+  });
+});

--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -3,9 +3,13 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useTranslation } from 'react-i18next'; // Import useTranslation for translations
-import LoadingOverlay from './LoadingOverlay';
 import '../styles/AvailableDatasets.css';
-import { FaChevronCircleLeft, FaChevronCircleRight, FaDatabase, FaFilter } from "react-icons/fa";
+import {
+  FaChevronCircleLeft,
+  FaChevronCircleRight,
+  FaDatabase,
+  FaFilter,
+} from 'react-icons/fa';
 
 export interface Dataset {
   city: string;
@@ -103,11 +107,13 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
           return new Date(a.date).getTime() - new Date(b.date).getTime();
         case 'Latest Added':
           return (
-            new Date(a.latestAdded).getTime() - new Date(b.latestAdded).getTime()
+            new Date(a.latestAdded).getTime() -
+            new Date(b.latestAdded).getTime()
           );
         case 'Latest Updated':
           return (
-            new Date(a.latestUpdated).getTime() - new Date(b.latestUpdated).getTime()
+            new Date(a.latestUpdated).getTime() -
+            new Date(b.latestUpdated).getTime()
           );
         case 'Name':
           return a.name.localeCompare(b.name);
@@ -137,7 +143,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
           onClick={toggleCollapse}
           data-testid="collapse-button"
         >
-          {isCollapsed ? <FaChevronCircleLeft size={24} /> : <FaChevronCircleRight size={24} />}
+          {isCollapsed ? (
+            <FaChevronCircleLeft size={24} />
+          ) : (
+            <FaChevronCircleRight size={24} />
+          )}
         </button>
         {isCollapsed ? (
           <FaDatabase fill="white" size={24} />
@@ -145,7 +155,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
           <>
             <div className="top-bar" data-testid="top-bar">
               <h2 className="sidebar-title">{t('available_datasets')}</h2>
-              <label style={{ display: 'flex', alignItems: 'center' }} aria-label={t('toggle_datasets')}>
+              <label
+                style={{ display: 'flex', alignItems: 'center' }}
+                aria-label={t('toggle_datasets')}
+              >
                 <input
                   type="checkbox"
                   checked={isToggled}
@@ -163,16 +176,18 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
               <div className="filter-icon">
                 <FaFilter size={24} />
               </div>
-              {['Name', 'Date', 'Latest Added', 'Latest Updated'].map((filter) => (
-                <button
-                  key={filter}
-                  className={`filter-button ${activeFilter === filter ? 'active' : ''}`}
-                  onClick={() => sortDatasets(filter)}
-                  data-testid={`filter-button-${filter}`}
-                >
-                  {t(filter.toLowerCase().replace(/ /g, '_'))}
-                </button>
-              ))}
+              {['Name', 'Date', 'Latest Added', 'Latest Updated'].map(
+                (filter) => (
+                  <button
+                    key={filter}
+                    className={`filter-button ${activeFilter === filter ? 'active' : ''}`}
+                    onClick={() => sortDatasets(filter)}
+                    data-testid={`filter-button-${filter}`}
+                  >
+                    {t(filter.toLowerCase().replace(/ /g, '_'))}
+                  </button>
+                ),
+              )}
             </div>
             <div className="buttons-container" data-testid="buttons-container">
               {datasets.length > 0 ? (
@@ -187,7 +202,9 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
                   </button>
                 ))
               ) : (
-                <p data-testid="no-datasets-message">{t('no_datasets_available')}</p>
+                <p data-testid="no-datasets-message">
+                  {t('no_datasets_available')}
+                </p>
               )}
             </div>
           </>

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -2,21 +2,21 @@
 
 import React, { useEffect, useRef } from 'react';
 import 'ol/ol.css';
-import '../styles/map.css';
-import { Feature, Map, View } from 'ol';
+import "../styles/map.css";
+import { Map, View, Feature} from 'ol';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import Style from 'ol/style/Style';
 import Stroke from 'ol/style/Stroke';
 import Fill from 'ol/style/Fill';
-import { defaults as defaultControls, FullScreen } from 'ol/control.js';
-import { useGeographic } from 'ol/proj.js';
+import { FullScreen, defaults as defaultControls} from 'ol/control.js';
+import {useGeographic} from 'ol/proj.js';
 import { useMapLayerContext } from './MapContext';
 import Polygon from 'ol/geom/Polygon.js';
 import XYZ from 'ol/source/XYZ';
 import Footer from './Footer';
-import { TileWMS } from 'ol/source';
+import {TileWMS} from 'ol/source';
 
 //Attributions
 interface GeoJSONFeature {
@@ -30,38 +30,37 @@ interface GeoJSONResponse {
 }
 
 //Maptiler API key and attributions
-const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
-const attributions =
-  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+const backendUrl = process.env.REACT_APP_BACKEND_URL;
+const attributions = '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
 
 //layer definitions
 const defaultLayer = new TileLayer({
   source: new XYZ({
     url: `https://tile.openstreetmap.org/{z}/{x}/{y}.png`,
-    attributions: attributions,
-  }),
+    attributions: attributions
+  })
 });
 
 const satelliteLayer = new TileLayer({
   source: new XYZ({
     url: `https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}`,
-    attributions: attributions,
-  }),
+    attributions: attributions
+  })
 });
 
 const topographicLayer = new TileLayer({
   source: new XYZ({
     url: `https://tile.opentopomap.org/{z}/{x}/{y}.png`,
-    attributions: attributions,
-  }),
-});
+    attributions: attributions
+  })
+})
 
 const dataLayer = new TileLayer({
   source: new TileWMS({
-    url: 'http://localhost:8090/geoserver/Default/wms',
+    url:'http://localhost:8090/geoserver/Default/wms',
     params: {
-      LAYERS: 'Default:datalayer',
-      TILED: true,
+      'LAYERS': 'Default:datalayer',
+      'TILED': true,
     },
     serverType: 'geoserver',
   }),
@@ -73,19 +72,19 @@ const MapView = () => {
   const mapElement = useRef(null);
 
   //Context imports
-  const { layer, mapRef } = useMapLayerContext();
+  const {layer, mapRef} = useMapLayerContext();
 
   const getLayer = () => {
-    if (layer === 'satellite') {
+    if(layer === "satellite"){
       return satelliteLayer;
     }
 
-    if (layer === 'topographical') {
+    if(layer === "topographical"){
       return topographicLayer;
     }
 
     return defaultLayer;
-  };
+  }
 
   useEffect(() => {
     // Initialize map on first render
@@ -97,9 +96,10 @@ const MapView = () => {
         view: new View({
           center: [-75.6972, 45.4215], // Centered at Ottawa
           zoom: 1,
-        }),
+        })
       });
-    } else {
+    }
+    else {
       mapRef.current?.getLayers().clear();
       mapRef.current?.addLayer(getLayer());
     }
@@ -116,22 +116,20 @@ const MapView = () => {
       })
       .then((data) => {
         const features = data.items.map((item: any) => {
-          const coordinates = item.geometry.coordinates[0].map(
-            (coord: number[]) => coord,
-          );
+          const coordinates = item.geometry.coordinates[0].map((coord: number[]) => coord);
           const feature = new Feature({
-            geometry: new Polygon([coordinates]),
+            geometry: new Polygon([coordinates])
           });
           feature.setStyle(
             new Style({
               stroke: new Stroke({
                 color: 'red',
-                width: 2,
+                width: 2
               }),
               fill: new Fill({
-                color: 'rgba(255, 0, 0, 0.1)',
-              }),
-            }),
+                color: 'rgba(255, 0, 0, 0.1)'
+              })
+            })
           );
           return feature;
         });

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -2,21 +2,21 @@
 
 import React, { useEffect, useRef } from 'react';
 import 'ol/ol.css';
-import "../styles/map.css";
-import { Map, View, Feature} from 'ol';
+import '../styles/map.css';
+import { Feature, Map, View } from 'ol';
 import TileLayer from 'ol/layer/Tile';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
 import Style from 'ol/style/Style';
 import Stroke from 'ol/style/Stroke';
 import Fill from 'ol/style/Fill';
-import { FullScreen, defaults as defaultControls} from 'ol/control.js';
-import {useGeographic} from 'ol/proj.js';
+import { defaults as defaultControls, FullScreen } from 'ol/control.js';
+import { useGeographic } from 'ol/proj.js';
 import { useMapLayerContext } from './MapContext';
 import Polygon from 'ol/geom/Polygon.js';
 import XYZ from 'ol/source/XYZ';
 import Footer from './Footer';
-import {TileWMS} from 'ol/source';
+import { TileWMS } from 'ol/source';
 
 //Attributions
 interface GeoJSONFeature {
@@ -30,37 +30,38 @@ interface GeoJSONResponse {
 }
 
 //Maptiler API key and attributions
-const backendUrl = process.env.REACT_APP_BACKEND_URL;
-const attributions = '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+const attributions =
+  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
 
 //layer definitions
 const defaultLayer = new TileLayer({
   source: new XYZ({
     url: `https://tile.openstreetmap.org/{z}/{x}/{y}.png`,
-    attributions: attributions
-  })
+    attributions: attributions,
+  }),
 });
 
 const satelliteLayer = new TileLayer({
   source: new XYZ({
     url: `https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}`,
-    attributions: attributions
-  })
+    attributions: attributions,
+  }),
 });
 
 const topographicLayer = new TileLayer({
   source: new XYZ({
     url: `https://tile.opentopomap.org/{z}/{x}/{y}.png`,
-    attributions: attributions
-  })
-})
+    attributions: attributions,
+  }),
+});
 
 const dataLayer = new TileLayer({
   source: new TileWMS({
-    url:'http://localhost:8090/geoserver/Default/wms',
+    url: 'http://localhost:8090/geoserver/Default/wms',
     params: {
-      'LAYERS': 'Default:datalayer',
-      'TILED': true,
+      LAYERS: 'Default:datalayer',
+      TILED: true,
     },
     serverType: 'geoserver',
   }),
@@ -72,19 +73,19 @@ const MapView = () => {
   const mapElement = useRef(null);
 
   //Context imports
-  const {layer, mapRef} = useMapLayerContext();
+  const { layer, mapRef } = useMapLayerContext();
 
   const getLayer = () => {
-    if(layer === "satellite"){
+    if (layer === 'satellite') {
       return satelliteLayer;
     }
 
-    if(layer === "topographical"){
+    if (layer === 'topographical') {
       return topographicLayer;
     }
 
     return defaultLayer;
-  }
+  };
 
   useEffect(() => {
     // Initialize map on first render
@@ -96,10 +97,9 @@ const MapView = () => {
         view: new View({
           center: [-75.6972, 45.4215], // Centered at Ottawa
           zoom: 1,
-        })
+        }),
       });
-    }
-    else {
+    } else {
       mapRef.current?.getLayers().clear();
       mapRef.current?.addLayer(getLayer());
     }
@@ -116,20 +116,22 @@ const MapView = () => {
       })
       .then((data) => {
         const features = data.items.map((item: any) => {
-          const coordinates = item.geometry.coordinates[0].map((coord: number[]) => coord);
+          const coordinates = item.geometry.coordinates[0].map(
+            (coord: number[]) => coord,
+          );
           const feature = new Feature({
-            geometry: new Polygon([coordinates])
+            geometry: new Polygon([coordinates]),
           });
           feature.setStyle(
             new Style({
               stroke: new Stroke({
                 color: 'red',
-                width: 2
+                width: 2,
               }),
               fill: new Fill({
-                color: 'rgba(255, 0, 0, 0.1)'
-              })
-            })
+                color: 'rgba(255, 0, 0, 0.1)',
+              }),
+            }),
           );
           return feature;
         });

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -9,7 +9,24 @@ export const fetchTestStacData = async (): Promise<any> => {
     const data = await response.json();
     return data;
   } catch (error: any) {
-    console.error("Error fetching test STAC data:", error);
-    return { error: "Failed to fetch data" };
+    console.error('Error fetching test STAC data:', error);
+    return { error: 'Failed to fetch data' };
+  }
+};
+
+export const fetchCollectionsFromEndpoint = async (): Promise<{
+  error: string;
+}> => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/get-collections`);
+    if (!response.ok) {
+      throw new Error(`Error: ${response.statusText}`);
+    }
+    const data = await response.json();
+    console.log('Fetched collections:', data);
+    return data;
+  } catch (error: any) {
+    console.error('Error fetching collections:', error);
+    return { error: 'Failed to fetch data' };
   }
 };

--- a/apps/frontend/src/app/testComponents/TestStac.tsx
+++ b/apps/frontend/src/app/testComponents/TestStac.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { fetchTestStacData } from "../services/api";
+import React, { useState } from 'react';
+import { fetchCollectionsFromEndpoint } from '../services/api';
 
 // Define the structure of the data being fetched
 interface StacData {
@@ -15,44 +15,44 @@ const TestStac: React.FC = () => {
     setLoading(true);
     setError(null); // Clear any previous errors
     try {
-      const result = await fetchTestStacData();
+      const result = await fetchCollectionsFromEndpoint();
       if (result.error) {
         setError(result.error);
       } else {
         setStacData(result);
       }
     } catch (err: any) {
-      setError(err.message || "An unknown error occurred.");
+      setError(err.message || 'An unknown error occurred.');
     }
     setLoading(false);
   };
 
   // Inline CSS for the container
   const containerStyle: React.CSSProperties = {
-    position: "fixed",
-    top: "10%",
-    left: "50%",
-    transform: "translateX(-50%)",
+    position: 'fixed',
+    top: '10%',
+    left: '50%',
+    transform: 'translateX(-50%)',
     zIndex: 999999,
-    backgroundColor: "#ffffff",
-    padding: "20px",
-    border: "2px solid #ccc",
-    borderRadius: "10px",
-    boxShadow: "0 4px 8px rgba(0, 0, 0, 0.2)",
-    textAlign: "center",
-    maxWidth: "80%",
-    overflowWrap: "break-word",
+    backgroundColor: '#ffffff',
+    padding: '20px',
+    border: '2px solid #ccc',
+    borderRadius: '10px',
+    boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
+    textAlign: 'center',
+    maxWidth: '80%',
+    overflowWrap: 'break-word',
   };
 
   return (
     <div style={containerStyle}>
       <h2>Test STAC Endpoint</h2>
       <button onClick={handleFetchData} disabled={loading}>
-        {loading ? "Loading..." : "Fetch Data"}
+        {loading ? 'Loading...' : 'Fetch Data'}
       </button>
 
       {error && (
-        <div style={{ color: "red", marginTop: "10px" }}>
+        <div style={{ color: 'red', marginTop: '10px' }}>
           <strong>Error:</strong> {error}
         </div>
       )}
@@ -60,10 +60,10 @@ const TestStac: React.FC = () => {
       {stacData && (
         <pre
           style={{
-            marginTop: "10px",
-            textAlign: "left",
-            whiteSpace: "pre-wrap",
-            wordWrap: "break-word",
+            marginTop: '10px',
+            textAlign: 'left',
+            whiteSpace: 'pre-wrap',
+            wordWrap: 'break-word',
           }}
         >
           {JSON.stringify(stacData, null, 2)}


### PR DESCRIPTION
### Summary
Created an endpoint to return a list of collections saved in the database.

### Changes Made
- Added a new endpoint `/api/get-collections` in `DataController`.
- Implemented `getCollections` method in `DataService` to fetch collections from the database.
- Updated `StacRepository` to support fetching all collections.
- Added unit tests for the new endpoint in `DataControllerTests` and `DataServiceTests`.

### Testing Instructions
1. Start the backend server.
2. Send a GET request to `/api/get-collections`.
3. Verify that the response contains the list of collections in the expected format.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/2f8635ff-5969-402d-85bd-c8c9c7d3119f)

### Additional Notes
Ensure the database contains collections data for accurate testing.