### PR TITLE
#82 - feature(frontend & backend): Add endpoint to reset collections and update frontend with reset button

### DIFF
--- a/apps/backend/src/main/java/com/example/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/com/example/backend/controller/DataController.java
@@ -90,4 +90,17 @@ public class DataController {
       return ResponseEntity.internalServerError().body(null);
     }
   }
+
+  @GetMapping("/api/reset-collections")
+  public ResponseEntity<String> resetCollections() {
+    logger.info("Received request to reset collections");
+    try {
+      dataService.deleteAllCollections();
+      dataService.fetchAndSaveCollections();
+      return ResponseEntity.ok("Collections deleted and fetched successfully");
+    } catch (Exception e) {
+      logger.error("Error resetting collections: {}", e.getMessage(), e);
+      return ResponseEntity.internalServerError().body("Error resetting collections: " + e.getMessage());
+    }
+  }
 }

--- a/apps/backend/src/main/java/com/example/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/com/example/backend/repository/StacRepository.java
@@ -70,4 +70,16 @@ public class StacRepository {
       throw new RuntimeException("Error fetching all collections: " + e.getMessage(), e);
     }
   }
+
+  public void deleteAllCollections() {
+    logger.info("Deleting all collections from pgstac.collections");
+    try {
+      String sql = "DELETE FROM pgstac.collections";
+      jdbcTemplate.update(sql);
+      logger.info("All collections deleted successfully");
+    } catch (DataAccessException e) {
+      logger.error("Error deleting collections: {}", e.getMessage(), e);
+      throw new RuntimeException("Error deleting collections: " + e.getMessage(), e);
+    }
+  }
 }

--- a/apps/backend/src/main/java/com/example/backend/service/DataService.java
+++ b/apps/backend/src/main/java/com/example/backend/service/DataService.java
@@ -112,4 +112,15 @@ public class DataService {
       throw new RuntimeException("Failed to fetch collections: " + e.getMessage(), e);
     }
   }
+
+  public void deleteAllCollections() {
+    logger.info("Deleting all collections");
+    try {
+      stacRepository.deleteAllCollections();
+      logger.info("All collections deleted successfully");
+    } catch (Exception e) {
+      logger.error("Error deleting collections: {}", e.getMessage(), e);
+      throw new RuntimeException("Failed to delete collections: " + e.getMessage(), e);
+    }
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/com/example/backend/controller/DataControllerTests.java
@@ -159,4 +159,31 @@ class DataControllerTests {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(response.getBody()).isNull();
   }
+
+  @Test
+  void resetCollections_Success() {
+    // Act
+    ResponseEntity<String> response = dataController.resetCollections();
+
+    // Assert
+    verify(dataService, times(1)).deleteAllCollections();
+    verify(dataService, times(1)).fetchAndSaveCollections();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("Collections deleted and fetched successfully");
+  }
+
+  @Test
+  void resetCollections_Failure() {
+    // Arrange
+    doThrow(new RuntimeException("Test error")).when(dataService).deleteAllCollections();
+
+    // Act
+    ResponseEntity<String> response = dataController.resetCollections();
+
+    // Assert
+    verify(dataService, times(1)).deleteAllCollections();
+    verify(dataService, times(0)).fetchAndSaveCollections();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody()).contains("Error resetting collections: Test error");
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
@@ -18,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StacRepositoryTests {
@@ -146,5 +145,14 @@ class StacRepositoryTests {
     assertThatThrownBy(() -> stacRepository.getAllCollections())
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Error fetching all collections");
+  }
+
+  @Test
+  void deleteAllCollections_Success() {
+    // Act
+    stacRepository.deleteAllCollections();
+
+    // Assert
+    verify(jdbcTemplate, times(1)).update("DELETE FROM pgstac.collections");
   }
 }

--- a/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
@@ -155,4 +155,26 @@ class StacRepositoryTests {
     // Assert
     verify(jdbcTemplate, times(1)).update("DELETE FROM pgstac.collections");
   }
+
+  @Test
+  void insertCollection_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    doThrow(new DataAccessException("Database error") {}).when(jdbcTemplate).queryForObject(anyString(), any(Class.class), anyString());
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.insertCollection(testCollectionJson))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Error inserting collection");
+  }
+
+  @Test
+  void deleteAllCollections_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    doThrow(new DataAccessException("Database error") {}).when(jdbcTemplate).update(anyString());
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.deleteAllCollections())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Error deleting collections");
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
@@ -216,4 +216,32 @@ class DataServiceTests {
     // Assert
     verify(stacRepository, times(1)).deleteAllCollections();
   }
+
+  @Test
+  void insertAndQueryCollection_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    when(stacRepository.checkCollectionExists(anyString())).thenThrow(new RuntimeException("Test exception"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.insertAndQueryCollection())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Failed to process collection: Test exception");
+
+    verify(stacRepository, times(1)).checkCollectionExists(anyString());
+    verify(stacRepository, times(0)).insertCollection(anyString());
+    verify(stacRepository, times(0)).queryCollection(anyString());
+  }
+
+  @Test
+  void deleteAllCollections_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    doThrow(new RuntimeException("Test exception")).when(stacRepository).deleteAllCollections();
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.deleteAllCollections())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Failed to delete collections: Test exception");
+
+    verify(stacRepository, times(1)).deleteAllCollections();
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
@@ -207,4 +207,13 @@ class DataServiceTests {
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Failed to fetch collections");
   }
+
+  @Test
+  void deleteAllCollections_Success() {
+    // Act
+    dataService.deleteAllCollections();
+
+    // Assert
+    verify(stacRepository, times(1)).deleteAllCollections();
+  }
 }

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SettingsPanel from '../src/app/components/SettingsPanel';
+import { resetCollections } from '../src/app/services/api';
+import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
+import { ToastContainer } from 'react-toastify';
+
+jest.mock('sweetalert2');
+jest.mock('../src/app/services/api');
+
+const MySwal = withReactContent(Swal);
 
 describe('Test SettingsPanel component', () => {
   // Mock alert function to avoid JSDOM error
@@ -16,11 +25,11 @@ describe('Test SettingsPanel component', () => {
   // 1) Prompt Test
   it('should open and close the settings dropdown', () => {
     render(<SettingsPanel />);
-    
+
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton); // Open settings dropdown
-    
+
     // Assert settings dropdown is active
     expect(settingsButton).toHaveClass('active');
 
@@ -37,16 +46,16 @@ describe('Test SettingsPanel component', () => {
 
   it('should render the correct initial API endpoint value and update the input field', () => {
     render(<SettingsPanel />);
-  
+
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton); // Open settings dropdown
-  
+
     const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
-  
+
     // Check initial value
     expect(inputField.value).toBe('https://default-api-endpoint.com');
-  
+
     // Update input field
     fireEvent.change(inputField, { target: { value: 'https://new-api-endpoint.com' } });
     expect(inputField.value).toBe('https://new-api-endpoint.com');
@@ -55,18 +64,18 @@ describe('Test SettingsPanel component', () => {
   // 6) Prompt Test
   it('should trigger save action for a valid API endpoint', () => {
     render(<SettingsPanel />);
-  
+
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton); // Open settings dropdown
-  
+
     const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
     const saveButton = screen.getByText('save');
-  
+
     // Update input field with a valid URL
     fireEvent.change(inputField, { target: { value: 'https://new-api-endpoint.com' } });
     fireEvent.click(saveButton);
-  
+
     // Verify alert for valid input
     expect(window.alert).toHaveBeenCalledWith('api_endpoint save: https://new-api-endpoint.com');
   });
@@ -75,38 +84,38 @@ describe('Test SettingsPanel component', () => {
   // 7) Prompt Test
   it('should trigger an error alert for an invalid API endpoint', () => {
     render(<SettingsPanel />);
-  
+
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton); // Open settings dropdown
-  
+
     const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
     const saveButton = screen.getByText('save');
-  
+
     // Update input field with an invalid URL
     fireEvent.change(inputField, { target: { value: 'invalid-url' } });
     fireEvent.click(saveButton);
-  
+
     // Verify alert for invalid input
     expect(window.alert).toHaveBeenCalledWith('invalid_url');
   });
 
   it('should close the settings dropdown when Cancel is clicked', () => {
     render(<SettingsPanel />);
-  
+
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton); // Open settings dropdown
-  
+
     const cancelButton = screen.getByText('cancel');
-  
+
     // Click the Cancel button
     fireEvent.click(cancelButton);
-  
+
     // Verify dropdown closes
     expect(settingsButton).not.toHaveClass('active');
-  }); 
-  
+  });
+
 
   // 2) Prompt Test
   it('should close settings dropdown when clicking outside', () => {
@@ -136,41 +145,41 @@ describe('Test SettingsPanel component', () => {
   it('should handle case where dropdownRef is null without errors', () => {
     // Mock React.useRef to return a ref with current as null
     jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
-  
+
     render(<SettingsPanel />);
-  
+
     // Open the settings dropdown
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton);
-  
+
     // Simulate clicking outside
     fireEvent.mouseDown(document.body);
-  
+
     // Verify no errors occur and dropdown state remains unaffected
     expect(settingsButton).not.toHaveClass('active');
-  });  
-  
+  });
+
   // 3) Prompt Test
   it('should not close settings dropdown if clicking inside dropdown', () => {
     render(<SettingsPanel />);
-  
+
     // Open the settings dropdown
     const buttons = document.querySelectorAll('.dropdown-button');
     const settingsButton = buttons[0].querySelector('button')!;
     fireEvent.click(settingsButton);
-  
+
     // Mock dropdownRef.current.contains to return true
     const dropdownContent = screen.getByLabelText('api_endpoint:').closest('.dropdown-content');
     jest.spyOn(dropdownContent!, 'contains').mockReturnValueOnce(true);
-  
+
     // Simulate clicking inside
     fireEvent.mouseDown(dropdownContent!);
-  
+
     // Dropdown should remain open
     expect(settingsButton).toHaveClass('active');
   });
-  
+
 
   it('should open and close the language dropdown', () => {
     render(<SettingsPanel />);
@@ -242,7 +251,7 @@ test('should select English and French in the language dropdown', () => {
 
   it('should close dropdowns when clicking outside', () => {
     render(<SettingsPanel />);
-    
+
     const buttons = document.querySelectorAll('.dropdown-button');
     const languageButton = buttons[1].querySelector('button')!;
     fireEvent.click(languageButton); // Open language dropdown
@@ -251,5 +260,47 @@ test('should select English and French in the language dropdown', () => {
 
     // Simulate clicking outside
     fireEvent.mouseDown(document.body);
+  });
+
+  it('should trigger reset data from endpoint confirmation and success', async () => {
+    (MySwal.fire as jest.Mock).mockResolvedValue({ isConfirmed: true });
+    (resetCollections as jest.Mock).mockResolvedValue('Collections deleted and fetched successfully');
+
+    render(<SettingsPanel />);
+    render(<ToastContainer />);
+
+    const buttons = document.querySelectorAll('.dropdown-button');
+    const resetButton = buttons[2].querySelector('button')!;
+    fireEvent.click(resetButton); // Open reset dropdown
+
+    const resetDataButton = screen.getByText((content, element) => {
+      return element?.textContent === 'reset_data_from_endpoint';
+    });
+    fireEvent.click(resetDataButton);
+
+    await waitFor(() => expect(MySwal.fire).toHaveBeenCalled());
+    await waitFor(() => expect(resetCollections).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('Collections deleted and fetched successfully')).toBeInTheDocument());
+  });
+
+  it('should trigger reset data from endpoint confirmation and handle error', async () => {
+    (MySwal.fire as jest.Mock).mockResolvedValue({ isConfirmed: true });
+    (resetCollections as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    render(<SettingsPanel />);
+    render(<ToastContainer />);
+
+    const buttons = document.querySelectorAll('.dropdown-button');
+    const resetButton = buttons[2].querySelector('button')!;
+    fireEvent.click(resetButton); // Open reset dropdown
+
+    const resetDataButton = screen.getByText((content, element) => {
+      return element?.textContent === 'reset_data_from_endpoint';
+    });
+    fireEvent.click(resetDataButton);
+
+    await waitFor(() => expect(MySwal.fire).toHaveBeenCalled());
+    await waitFor(() => expect(resetCollections).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByText('Test error')).toBeInTheDocument());
   });
 });

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,7 +18,10 @@
     "react-dom": "18.3.1",
     "react-i18next": "^15.1.3",
     "react-icons": "^5.3.0",
-    "styled-components": "^6.1.13"
+    "react-toastify": "^11.0.3",
+    "styled-components": "^6.1.13",
+    "sweetalert2": "^11.15.10",
+    "sweetalert2-react-content": "^5.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.25.9",

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -1,11 +1,18 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useTranslation } from 'react-i18next'; // Import useTranslation hook
-import '../styles/SettingsPanel.css'; // Import the CSS file
-import { IoSettingsOutline, IoLanguage, IoCheckmark, IoTrashOutline } from "react-icons/io5";
+import { useTranslation } from 'react-i18next';
+import '../styles/SettingsPanel.css';
+import { IoSettingsOutline, IoLanguage, IoCheckmark, IoTrashOutline, IoDownloadOutline } from 'react-icons/io5';
 import { PiArrowClockwiseFill } from "react-icons/pi";
+import { resetCollections } from '../services/api';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
+
+const MySwal = withReactContent(Swal);
 
 const SettingsPanel: React.FC = () => {
-  const { t, i18n } = useTranslation(); // Initialize useTranslation
+  const { t, i18n } = useTranslation();
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
     isOpen: boolean;
@@ -14,7 +21,6 @@ const SettingsPanel: React.FC = () => {
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>("https://default-api-endpoint.com");
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Toggles dropdown state
   const toggleDropdown = (buttonName: string) => {
     setDropdownState((prevState) => ({
       activeButton: prevState.activeButton === buttonName ? null : buttonName,
@@ -22,39 +28,55 @@ const SettingsPanel: React.FC = () => {
     }));
   };
 
-  // Handles settings selection
   const handleSaveEndpoint = () => {
     if (isValidUrl(newApiEndpoint)) {
-      alert(`${t('api_endpoint')} ${t('save')}: ${newApiEndpoint}`);
+      toast.success(`${t('api_endpoint')} ${t('save')}: ${newApiEndpoint}`);
       setDropdownState({ activeButton: null, isOpen: false });
     } else {
-      alert(t('invalid_url'));
+      toast.error(t('invalid_url'));
     }
   };
 
-  // Cancel button clicked
   const handleCancelEndpoint = () => {
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
-  // Handles language selection
   const handleLanguageSelect = (language: string) => {
-    i18n.changeLanguage(language); // Change the application language
+    i18n.changeLanguage(language);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
-  // Handles reset actions
   const handleReset = () => {
-    alert(t('reset_initiated'));
+    toast.info(t('reset_initiated'));
     setDropdownState({ activeButton: null, isOpen: false });
+  };
+
+  const handleResetDataFromEndpoint = async () => {
+    MySwal.fire({
+      title: t('reset_data_from_endpoint'),
+      text: t('confirm_reset_data_from_endpoint'),
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: "#3085d6",
+      cancelButtonColor: "#d33",
+      confirmButtonText: t('yes')
+    }).then(async (result: { isConfirmed: any }) => {
+      if (result.isConfirmed) {
+        try {
+          const message = await resetCollections();
+          toast.success(message);
+        } catch (error: any) {
+          toast.error(error.message);
+        }
+      }
+    });
   };
 
   const handleFactoryReset = () => {
-    alert(t('factory_reset_initiated'));
+    toast.warn(t('factory_reset_initiated'));
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
-  // Check if valid URL
   const isValidUrl = (url: string) => {
     try {
       new URL(url);
@@ -64,7 +86,6 @@ const SettingsPanel: React.FC = () => {
     }
   };
 
-  // Close dropdowns when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
@@ -82,9 +103,9 @@ const SettingsPanel: React.FC = () => {
 
   return (
     <div className="button-container" ref={dropdownRef}>
-      {/* Settings button */}
+      <ToastContainer />
       <div className="dropdown-button">
-        <button 
+        <button
           className={`button ${dropdownState.activeButton === 'settings' ? 'active' : ''}`}
           onClick={() => toggleDropdown('settings')}
           aria-expanded={dropdownState.activeButton === 'settings'}
@@ -113,7 +134,6 @@ const SettingsPanel: React.FC = () => {
         )}
       </div>
 
-      {/* Language Dropdown */}
       <div className="dropdown-button">
         <button
           className={`button ${dropdownState.activeButton === 'language' ? 'active' : ''}`}
@@ -136,7 +156,6 @@ const SettingsPanel: React.FC = () => {
         )}
       </div>
 
-      {/* Reset Dropdown */}
       <div className="dropdown-button">
         <button
           className={`button ${dropdownState.activeButton === 'reset' ? 'active' : ''}`}
@@ -150,6 +169,10 @@ const SettingsPanel: React.FC = () => {
             <button onClick={handleReset}>
               <PiArrowClockwiseFill size={24} />
               {t('reset')}
+            </button>
+            <button onClick={handleResetDataFromEndpoint} style={{ color: '#dc143c' }}>
+              <IoDownloadOutline size={24} />
+              {t('reset_data_from_endpoint')}
             </button>
             <button onClick={handleFactoryReset} style={{ color: '#dc143c' }}>
               <IoTrashOutline size={24} fill="red" />

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -8,11 +8,9 @@ import Sidebar from './components/Sidebar';
 import SettingsPanel from './components/SettingsPanel';
 import AvailableDatasets, { Dataset } from './components/AvailableDatasets';
 import MapMetaData from './components/MapMetaData';
-import TestStac from './testComponents/TestStac';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './resources/i18n';
 import './layout.css';
-
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [loading, setLoading] = useState(false);
@@ -32,7 +30,6 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       });
     }, 300); // Update every 300ms
   };
-
 
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: Dataset) => {
@@ -61,30 +58,28 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     <I18nextProvider i18n={i18n}>
       <MapProvider>
         <html lang="en">
-        <body>
-        <SettingsPanel />
-        <div className="layout-container relative">
-          <LoadingOverlay progress={progress} isVisible={loading} />
-          <TestStac />
-          <main className="app-main">{children}</main>
-          <AvailableDatasets onDatasetClick={handleDatasetClick} />
-          <MapView />
-          <Sidebar />
-          {selectedDataset && (
-              <MapMetaData
-                city={selectedDataset.city}
-                name={selectedDataset.name}
-                description={selectedDataset.description}
-                format={selectedDataset.format}
-                processes={selectedDataset.processes}
-                datasetSource={selectedDataset.datasetSource}
-                onLoadDataset={handleLoadDataset}
-              />
-            )
-          }
-          <footer className="app-footer"></footer>
-        </div>
-        </body>
+          <body>
+            <SettingsPanel />
+            <div className="layout-container relative">
+              <LoadingOverlay progress={progress} isVisible={loading} />
+              <main className="app-main">{children}</main>
+              <AvailableDatasets onDatasetClick={handleDatasetClick} />
+              <MapView />
+              <Sidebar />
+              {selectedDataset && (
+                <MapMetaData
+                  city={selectedDataset.city}
+                  name={selectedDataset.name}
+                  description={selectedDataset.description}
+                  format={selectedDataset.format}
+                  processes={selectedDataset.processes}
+                  datasetSource={selectedDataset.datasetSource}
+                  onLoadDataset={handleLoadDataset}
+                />
+              )}
+              <footer className="app-footer"></footer>
+            </div>
+          </body>
         </html>
       </MapProvider>
     </I18nextProvider>

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -15,6 +15,8 @@ const resources = {
         french: "French",
         //Reset
         reset: "Reset",
+        reset_data_from_endpoint: "Delete and Fetch Collections",
+        confirm_reset_data_from_endpoint: "Collections saved from Hirondelle's endpoint will first be deleted and then reinstalled. Do you want to proceed?",
         factory_reset: "Factory Reset",
         reset_initiated: "Reset initiated",
         factory_reset_initiated: "Factory Reset initiated",
@@ -42,7 +44,10 @@ const resources = {
         collapse: "Collapse",
         default_layer: "Default Layer",
         topographical_layer: "Topographical Layer",
-        satellite_layer: "Satellite Layer"
+        satellite_layer: "Satellite Layer",
+        //Decisions
+        yes: "Yes",
+        no: "No"
     },
   },
   fr: {
@@ -58,6 +63,8 @@ const resources = {
         french: "Français",
         //Reset
         reset: "Réinitialiser",
+        reset_data_from_endpoint: "Supprimer et récupérer les collections",
+        confirm_reset_data_from_endpoint: "Les collections enregistrées à partir du endpoint de Hirondelle seront d'abord supprimées, puis réinstallées. Voulez-vous continuer?",
         factory_reset: "Réinitialisation d'Usine",
         reset_initiated: "Réinitialisation démarrée",
         factory_reset_initiated: "Réinitialisation d'Usine démarrée",
@@ -85,7 +92,10 @@ const resources = {
         collapse: "Réduire",
         default_layer: "Calque par Défaut",
         topographical_layer: "Calque Topographique",
-        satellite_layer: "Calque Satellite"
+        satellite_layer: "Calque Satellite",
+        //Decisions
+        yes: "Oui",
+        no: "Non"
     },
   },
 };

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -30,3 +30,17 @@ export const fetchCollectionsFromEndpoint = async (): Promise<{
     return { error: 'Failed to fetch data' };
   }
 };
+
+export const resetCollections = async (): Promise<string> => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/reset-collections`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const message = await response.text();
+    return message;
+  } catch (error: any) {
+    console.error('Error resetting collections:', error);
+    throw new Error(`Error resetting collections: ${error.message}`);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,10 @@
         "react-i18next": "^15.4.0",
         "react-icons": "^5.3.0",
         "react-leaflet": "^4.2.1",
-        "styled-components": "^6.1.13"
+        "react-toastify": "^11.0.3",
+        "styled-components": "^6.1.13",
+        "sweetalert2": "^11.15.10",
+        "sweetalert2-react-content": "^5.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
@@ -11027,6 +11030,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -23026,6 +23037,18 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
+      "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -25032,6 +25055,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.15.10",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.15.10.tgz",
+      "integrity": "sha512-Sjiwcd5mWiz8X0JFkHsso2EPVQHrLCjVv+xR6Ry2LKf4KY6kSi4U5pM0Tgmn1c7SMfkyDqPal2NWqwj6vck8bw==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
+    "node_modules/sweetalert2-react-content": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sweetalert2-react-content/-/sweetalert2-react-content-5.1.0.tgz",
+      "integrity": "sha512-SBh41SdyHDY9NzwrIG6LACbClCMxIlEFP86tGVr/B4zGD4H2gGXB8o7UAJRc/RtBd/iQL9hIvuCAkrk0AgKEMA==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "sweetalert2": "^11.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "react-i18next": "^15.4.0",
     "react-icons": "^5.3.0",
     "react-leaflet": "^4.2.1",
-    "styled-components": "^6.1.13"
+    "react-toastify": "^11.0.3",
+    "styled-components": "^6.1.13",
+    "sweetalert2": "^11.15.10",
+    "sweetalert2-react-content": "^5.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",


### PR DESCRIPTION
### Summary
This PR introduces an endpoint `/api/reset-collections` to delete and reset the collections table in the database. It also adds a button in the reset options to call this endpoint, utilizing SweetAlert2 and Toast notifications for user feedback.

### Screenshots and Demo
https://github.com/user-attachments/assets/e7f55961-b680-4638-9951-a10bcebf7bf1

![image](https://github.com/user-attachments/assets/95820040-9243-4856-88ab-b53aef50f5ba)
![image](https://github.com/user-attachments/assets/3f2b7ceb-b440-4144-ae94-ef9bbd11337a)

### Changes Made
- Added `/api/reset-collections` endpoint to delete and fetch collections.
- Integrated SweetAlert2 for confirmation dialogs.
- Added Toast notifications for success and error messages.
- Updated `SettingsPanel` component to include the reset button.

### Testing Instructions
1. Open the application and navigate to the settings panel.
2. Click on the reset button.
3. Confirm the action in the SweetAlert2 dialog.
4. Verify that the collections are deleted and fetched again.
5. Check for success or error messages via Toast notifications.

### Additional Notes
Ensure the backend service is running and accessible for the endpoint to function correctly.