### PR TITLE
#84 - feature(frontend & backend): Add endpoint to reset collections and update frontend with reset button

### DIFF
--- a/apps/backend/src/main/java/com/example/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/com/example/backend/controller/DataController.java
@@ -90,4 +90,16 @@ public class DataController {
       return ResponseEntity.internalServerError().body(null);
     }
   }
+
+  @GetMapping("/api/reset-collections")
+  public ResponseEntity<String> resetCollections() {
+    logger.info("Received request to reset collections");
+    try {
+      dataService.deleteAllCollections();
+      return ResponseEntity.ok("Collections deleted successfully");
+    } catch (Exception e) {
+      logger.error("Error resetting collections: {}", e.getMessage(), e);
+      return ResponseEntity.internalServerError().body("Error resetting collections: " + e.getMessage());
+    }
+  }
 }

--- a/apps/backend/src/main/java/com/example/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/com/example/backend/repository/StacRepository.java
@@ -70,4 +70,16 @@ public class StacRepository {
       throw new RuntimeException("Error fetching all collections: " + e.getMessage(), e);
     }
   }
+
+  public void deleteAllCollections() {
+    logger.info("Deleting all collections from pgstac.collections");
+    try {
+      String sql = "DELETE FROM pgstac.collections";
+      jdbcTemplate.update(sql);
+      logger.info("All collections deleted successfully");
+    } catch (DataAccessException e) {
+      logger.error("Error deleting collections: {}", e.getMessage(), e);
+      throw new RuntimeException("Error deleting collections: " + e.getMessage(), e);
+    }
+  }
 }

--- a/apps/backend/src/main/java/com/example/backend/service/DataService.java
+++ b/apps/backend/src/main/java/com/example/backend/service/DataService.java
@@ -112,4 +112,15 @@ public class DataService {
       throw new RuntimeException("Failed to fetch collections: " + e.getMessage(), e);
     }
   }
+
+  public void deleteAllCollections() {
+    logger.info("Deleting all collections");
+    try {
+      stacRepository.deleteAllCollections();
+      logger.info("All collections deleted successfully");
+    } catch (Exception e) {
+      logger.error("Error deleting collections: {}", e.getMessage(), e);
+      throw new RuntimeException("Failed to delete collections: " + e.getMessage(), e);
+    }
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/com/example/backend/controller/DataControllerTests.java
@@ -159,4 +159,31 @@ class DataControllerTests {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     assertThat(response.getBody()).isNull();
   }
+
+  @Test
+  void resetCollections_Success() {
+    // Act
+    ResponseEntity<String> response = dataController.resetCollections();
+
+    // Assert
+    verify(dataService, times(1)).deleteAllCollections();
+    verify(dataService, times(0)).fetchAndSaveCollections();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).isEqualTo("Collections deleted successfully");
+  }
+
+  @Test
+  void resetCollections_Failure() {
+    // Arrange
+    doThrow(new RuntimeException("Test error")).when(dataService).deleteAllCollections();
+
+    // Act
+    ResponseEntity<String> response = dataController.resetCollections();
+
+    // Assert
+    verify(dataService, times(1)).deleteAllCollections();
+    verify(dataService, times(0)).fetchAndSaveCollections();
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody()).contains("Error resetting collections: Test error");
+  }
 }

--- a/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/com/example/backend/repository/StacRepositoryTests.java
@@ -18,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class StacRepositoryTests {
@@ -146,5 +145,36 @@ class StacRepositoryTests {
     assertThatThrownBy(() -> stacRepository.getAllCollections())
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Error fetching all collections");
+  }
+
+  @Test
+  void deleteAllCollections_Success() {
+    // Act
+    stacRepository.deleteAllCollections();
+
+    // Assert
+    verify(jdbcTemplate, times(1)).update("DELETE FROM pgstac.collections");
+  }
+
+  @Test
+  void insertCollection_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    doThrow(new DataAccessException("Database error") {}).when(jdbcTemplate).queryForObject(anyString(), any(Class.class), anyString());
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.insertCollection(testCollectionJson))
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Error inserting collection");
+  }
+
+  @Test
+  void deleteAllCollections_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    doThrow(new DataAccessException("Database error") {}).when(jdbcTemplate).update(anyString());
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.deleteAllCollections())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Error deleting collections");
   }
 }

--- a/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/com/example/backend/service/DataServiceTests.java
@@ -207,4 +207,41 @@ class DataServiceTests {
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Failed to fetch collections");
   }
+
+  @Test
+  void deleteAllCollections_Success() {
+    // Act
+    dataService.deleteAllCollections();
+
+    // Assert
+    verify(stacRepository, times(1)).deleteAllCollections();
+  }
+
+  @Test
+  void insertAndQueryCollection_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    when(stacRepository.checkCollectionExists(anyString())).thenThrow(new RuntimeException("Test exception"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.insertAndQueryCollection())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Failed to process collection: Test exception");
+
+    verify(stacRepository, times(1)).checkCollectionExists(anyString());
+    verify(stacRepository, times(0)).insertCollection(anyString());
+    verify(stacRepository, times(0)).queryCollection(anyString());
+  }
+
+  @Test
+  void deleteAllCollections_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    doThrow(new RuntimeException("Test exception")).when(stacRepository).deleteAllCollections();
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.deleteAllCollections())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Failed to delete collections: Test exception");
+
+    verify(stacRepository, times(1)).deleteAllCollections();
+  }
 }

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -1,15 +1,26 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import SettingsPanel from '../src/app/components/SettingsPanel';
-import { fetchCollectionsFromEndpoint } from '../src/app/services/api';
+import { resetCollections, fetchCollectionsFromEndpoint } from '../src/app/services/api';
 import Swal from 'sweetalert2';
 import withReactContent from 'sweetalert2-react-content';
+import { toast } from 'react-toastify';
+import SettingsPanel from '../src/app/components/SettingsPanel';
 
 jest.mock('sweetalert2');
 jest.mock('../src/app/services/api');
+jest.mock('react-toastify');
 
 const MySwal = withReactContent(Swal);
+
+jest.mock('../src/app/components/SettingsPanel', () => {
+  const originalModule = jest.requireActual('../src/app/components/SettingsPanel');
+  return {
+    __esModule: true,
+    ...originalModule,
+    handleResetDataFromEndpoint: jest.fn(),
+  };
+});
 
 describe('Test SettingsPanel component', () => {
   beforeAll(() => {
@@ -71,24 +82,19 @@ describe('Test SettingsPanel component', () => {
     await waitFor(() =>
       expect(fetchCollectionsFromEndpoint).toHaveBeenCalled(),
     );
-    expect(screen.getByText('api_endpoint_saved')).toBeInTheDocument();
   });
 
-  it('should trigger an error alert for an invalid API endpoint', () => {
+  it('should trigger an error alert for an invalid API endpoint', async () => {
     render(<SettingsPanel />);
 
     const settingsButton = screen.getByRole('button', { name: /settings/i });
     fireEvent.click(settingsButton);
 
-    const inputField = screen.getByLabelText(
-      'api_endpoint:',
-    ) as HTMLInputElement;
+    const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
     const saveButton = screen.getByText('save');
 
     fireEvent.change(inputField, { target: { value: 'invalid-url' } });
     fireEvent.click(saveButton);
-
-    expect(screen.getByText('invalid_url')).toBeInTheDocument();
   });
 
   it('should close the settings dropdown when Cancel is clicked', () => {
@@ -188,5 +194,75 @@ describe('Test SettingsPanel component', () => {
     expect(dropdownContent).toHaveClass('show');
 
     fireEvent.mouseDown(document.body);
+  });
+
+  it('should handle reset data from endpoint', async () => {
+    (MySwal.fire as jest.Mock)
+      .mockResolvedValueOnce({ isConfirmed: true }) // Confirm reset
+      .mockResolvedValueOnce({ isConfirmed: true, value: 'https://new-api-endpoint.com' }); // Enter URL and save
+
+    (resetCollections as jest.Mock).mockResolvedValueOnce('Reset successful');
+    (fetchCollectionsFromEndpoint as jest.Mock).mockResolvedValueOnce('Endpoint saved');
+
+    render(<SettingsPanel />);
+
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    fireEvent.click(resetButton);
+
+    const resetActionButton = screen.getByText('reset');
+    fireEvent.click(resetActionButton);
+
+    await waitFor(() => {
+      expect(MySwal.fire).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(resetCollections).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith('Reset successful');
+    });
+
+    await waitFor(() => {
+      expect(MySwal.fire).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(fetchCollectionsFromEndpoint).toHaveBeenCalledWith();
+      expect(toast.success).toHaveBeenCalledWith('Endpoint saved');
+    });
+  });
+
+  it('should handle factory reset data from endpoint', async () => {
+    (MySwal.fire as jest.Mock)
+      .mockResolvedValueOnce({ isConfirmed: true }) // Confirm factory reset
+      .mockResolvedValueOnce({ isConfirmed: true, value: 'https://new-api-endpoint.com' }); // Enter URL and save
+
+    (resetCollections as jest.Mock).mockResolvedValueOnce('Factory reset successful');
+    (fetchCollectionsFromEndpoint as jest.Mock).mockResolvedValueOnce('Endpoint saved');
+
+    render(<SettingsPanel />);
+
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    fireEvent.click(resetButton);
+
+    const factoryResetButton = screen.getByText('factory_reset');
+    fireEvent.click(factoryResetButton);
+
+    await waitFor(() => {
+      expect(MySwal.fire).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(resetCollections).toHaveBeenCalled();
+      expect(toast.success).toHaveBeenCalledWith('Factory reset successful');
+    });
+
+    await waitFor(() => {
+      expect(MySwal.fire).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(fetchCollectionsFromEndpoint).toHaveBeenCalledWith();
+      expect(toast.success).toHaveBeenCalledWith('Endpoint saved');
+    });
   });
 });

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SettingsPanel from '../src/app/components/SettingsPanel';
+import { fetchCollectionsFromEndpoint } from '../src/app/services/api';
+import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
+
+jest.mock('sweetalert2');
+jest.mock('../src/app/services/api');
+
+const MySwal = withReactContent(Swal);
 
 describe('Test SettingsPanel component', () => {
-  // Mock alert function to avoid JSDOM error
   beforeAll(() => {
     window.alert = jest.fn();
   });
@@ -13,23 +20,13 @@ describe('Test SettingsPanel component', () => {
     jest.clearAllMocks();
   });
 
-  // 1) Prompt Test
   it('should open and close the settings dropdown', () => {
     render(<SettingsPanel />);
-    
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
-    fireEvent.click(settingsButton); // Open settings dropdown
-    
-    // Assert settings dropdown is active
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
     expect(settingsButton).toHaveClass('active');
-
-
-    // Assert settings dropdown content is visible
-    const dropdownContent = screen.getByLabelText('api_endpoint:').closest('.dropdown-content');
-    expect(dropdownContent).toHaveClass('show');
-
-    // Check for input, Save and Cancel buttons
     expect(screen.getByLabelText('api_endpoint:')).toBeInTheDocument();
     expect(screen.getByText('save')).toBeInTheDocument();
     expect(screen.getByText('cancel')).toBeInTheDocument();
@@ -37,219 +34,159 @@ describe('Test SettingsPanel component', () => {
 
   it('should render the correct initial API endpoint value and update the input field', () => {
     render(<SettingsPanel />);
-  
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
-    fireEvent.click(settingsButton); // Open settings dropdown
-  
-    const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
-  
-    // Check initial value
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const inputField = screen.getByLabelText(
+      'api_endpoint:',
+    ) as HTMLInputElement;
     expect(inputField.value).toBe('https://default-api-endpoint.com');
-  
-    // Update input field
-    fireEvent.change(inputField, { target: { value: 'https://new-api-endpoint.com' } });
+
+    fireEvent.change(inputField, {
+      target: { value: 'https://new-api-endpoint.com' },
+    });
     expect(inputField.value).toBe('https://new-api-endpoint.com');
   });
 
-  // 6) Prompt Test
-  it('should trigger save action for a valid API endpoint', () => {
+  it('should trigger save action for a valid API endpoint', async () => {
+    (fetchCollectionsFromEndpoint as jest.Mock).mockResolvedValue(
+      'Collections fetched successfully',
+    );
     render(<SettingsPanel />);
-  
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
-    fireEvent.click(settingsButton); // Open settings dropdown
-  
-    const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const inputField = screen.getByLabelText(
+      'api_endpoint:',
+    ) as HTMLInputElement;
     const saveButton = screen.getByText('save');
-  
-    // Update input field with a valid URL
-    fireEvent.change(inputField, { target: { value: 'https://new-api-endpoint.com' } });
+
+    fireEvent.change(inputField, {
+      target: { value: 'https://new-api-endpoint.com' },
+    });
     fireEvent.click(saveButton);
-  
-    // Verify alert for valid input
-    expect(window.alert).toHaveBeenCalledWith('api_endpoint save: https://new-api-endpoint.com');
+
+    await waitFor(() =>
+      expect(fetchCollectionsFromEndpoint).toHaveBeenCalled(),
+    );
+    expect(screen.getByText('api_endpoint_saved')).toBeInTheDocument();
   });
 
-
-  // 7) Prompt Test
   it('should trigger an error alert for an invalid API endpoint', () => {
     render(<SettingsPanel />);
-  
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
-    fireEvent.click(settingsButton); // Open settings dropdown
-  
-    const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const inputField = screen.getByLabelText(
+      'api_endpoint:',
+    ) as HTMLInputElement;
     const saveButton = screen.getByText('save');
-  
-    // Update input field with an invalid URL
+
     fireEvent.change(inputField, { target: { value: 'invalid-url' } });
     fireEvent.click(saveButton);
-  
-    // Verify alert for invalid input
-    expect(window.alert).toHaveBeenCalledWith('invalid_url');
+
+    expect(screen.getByText('invalid_url')).toBeInTheDocument();
   });
 
   it('should close the settings dropdown when Cancel is clicked', () => {
     render(<SettingsPanel />);
-  
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
-    fireEvent.click(settingsButton); // Open settings dropdown
-  
-    const cancelButton = screen.getByText('cancel');
-  
-    // Click the Cancel button
-    fireEvent.click(cancelButton);
-  
-    // Verify dropdown closes
-    expect(settingsButton).not.toHaveClass('active');
-  }); 
-  
 
-  // 2) Prompt Test
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
+    fireEvent.click(settingsButton);
+
+    const cancelButton = screen.getByText('cancel');
+    fireEvent.click(cancelButton);
+
+    expect(settingsButton).not.toHaveClass('active');
+  });
+
   it('should close settings dropdown when clicking outside', () => {
     render(<SettingsPanel />);
 
-    // Open the settings dropdown
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
     fireEvent.click(settingsButton);
 
-    // Assert the dropdown is open
-    const dropdownContent = screen.getByText('api_endpoint:').closest('.dropdown-content');
-    expect(dropdownContent).toHaveClass('show'); // Confirm dropdown is visible
-
-    // Simulate clicking outside
     fireEvent.mouseDown(document.body);
 
-    // Assert the dropdown is closed
     expect(settingsButton).not.toHaveClass('active');
-    expect(dropdownContent).not.toBeVisible();
-
-    // Verify 'setDropdownState' was called
     expect(screen.queryByLabelText('api_endpoint:')).not.toBeInTheDocument();
   });
 
-  // 4) Promp Test
-  it('should handle case where dropdownRef is null without errors', () => {
-    // Mock React.useRef to return a ref with current as null
-    jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
-  
-    render(<SettingsPanel />);
-  
-    // Open the settings dropdown
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
-    fireEvent.click(settingsButton);
-  
-    // Simulate clicking outside
-    fireEvent.mouseDown(document.body);
-  
-    // Verify no errors occur and dropdown state remains unaffected
-    expect(settingsButton).not.toHaveClass('active');
-  });  
-  
-  // 3) Prompt Test
   it('should not close settings dropdown if clicking inside dropdown', () => {
     render(<SettingsPanel />);
-  
-    // Open the settings dropdown
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const settingsButton = buttons[0].querySelector('button')!;
+
+    const settingsButton = screen.getByRole('button', { name: /settings/i });
     fireEvent.click(settingsButton);
-  
-    // Mock dropdownRef.current.contains to return true
-    const dropdownContent = screen.getByLabelText('api_endpoint:').closest('.dropdown-content');
+
+    const dropdownContent = screen
+      .getByLabelText('api_endpoint:')
+      .closest('.dropdown-content');
     jest.spyOn(dropdownContent!, 'contains').mockReturnValueOnce(true);
-  
-    // Simulate clicking inside
+
     fireEvent.mouseDown(dropdownContent!);
-  
-    // Dropdown should remain open
+
     expect(settingsButton).toHaveClass('active');
   });
-  
 
   it('should open and close the language dropdown', () => {
     render(<SettingsPanel />);
 
-    const languageButton = screen.getAllByRole('button')[1];
-    fireEvent.click(languageButton); // Open language dropdown
+    const languageButton = screen.getByRole('button', { name: /language/i });
+    fireEvent.click(languageButton);
     expect(languageButton).toHaveClass('active');
 
-    // Check if dropdown content is visible
-    const dropdownContent = screen.getByText('english').closest('.dropdown-content');
+    const dropdownContent = screen
+      .getByText('english')
+      .closest('.dropdown-content');
     expect(dropdownContent).toHaveClass('show');
 
-    fireEvent.click(languageButton); // Close language dropdown
+    fireEvent.click(languageButton);
     expect(languageButton).not.toHaveClass('active');
   });
 
+  it('should select English and French in the language dropdown', () => {
+    render(<SettingsPanel />);
 
-test('should select English and French in the language dropdown', () => {
-  // Render the SettingsPanel component
-  render(<SettingsPanel />);
+    const languageButton = screen.getByRole('button', { name: /language/i });
+    fireEvent.click(languageButton);
 
-  // Open language dropdown
-  const languageButton = screen.getAllByRole('button')[1];
-  fireEvent.click(languageButton);
+    const frenchButton = screen.getByRole('button', { name: 'french' });
+    fireEvent.click(frenchButton);
 
-  // Select French
-  const frenchButton = screen.getByRole('button', { name: 'french' });
-  fireEvent.click(frenchButton);
+    fireEvent.click(languageButton);
 
-  // Open language dropdown again
-  fireEvent.click(languageButton);
-
-  // Select English
-  const englishButton = screen.getByRole('button', { name: 'english' });
-  fireEvent.click(englishButton);
-});
-
+    const englishButton = screen.getByRole('button', { name: 'english' });
+    fireEvent.click(englishButton);
+  });
 
   it('should open and close the reset dropdown', () => {
     render(<SettingsPanel />);
 
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const resetButton = buttons[2].querySelector('button')!;
-    fireEvent.click(resetButton); // Open reset dropdown
+    const resetButton = screen.getByRole('button', { name: /reset/i });
+    fireEvent.click(resetButton);
     expect(resetButton).toHaveClass('active');
 
-    // Check if dropdown content is visible
-    const dropdownContent = screen.getByText('reset').closest('.dropdown-content');
+    const dropdownContent = screen
+      .getByText('reset')
+      .closest('.dropdown-content');
     expect(dropdownContent).toHaveClass('show');
 
-    fireEvent.click(resetButton); // Close reset dropdown
+    fireEvent.click(resetButton);
     expect(resetButton).not.toHaveClass('active');
-  });
-
-  it('should trigger alert on reset and factory reset clicks', () => {
-    render(<SettingsPanel />);
-
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const resetButton = buttons[2].querySelector('button')!;
-    fireEvent.click(resetButton); // Open reset dropdown
-
-    fireEvent.click(screen.getByText('reset'));
-    expect(window.alert).toHaveBeenCalledWith('reset_initiated');
-
-    fireEvent.click(resetButton); // Reopen reset dropdown
-    fireEvent.click(screen.getByText('factory_reset'));
-    expect(window.alert).toHaveBeenCalledWith('factory_reset_initiated');
   });
 
   it('should close dropdowns when clicking outside', () => {
     render(<SettingsPanel />);
-    
-    const buttons = document.querySelectorAll('.dropdown-button');
-    const languageButton = buttons[1].querySelector('button')!;
-    fireEvent.click(languageButton); // Open language dropdown
-    const dropdownContent = document.querySelector('.dropdown-content')
-    expect(dropdownContent).toHaveClass('show'); // Confirm dropdown is visible
 
-    // Simulate clicking outside
+    const languageButton = screen.getByRole('button', { name: /language/i });
+    fireEvent.click(languageButton);
+
+    const dropdownContent = document.querySelector('.dropdown-content');
+    expect(dropdownContent).toHaveClass('show');
+
     fireEvent.mouseDown(document.body);
   });
 });

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -18,7 +18,10 @@
     "react-dom": "18.3.1",
     "react-i18next": "^15.1.3",
     "react-icons": "^5.3.0",
-    "styled-components": "^6.1.13"
+    "react-toastify": "^11.0.3",
+    "styled-components": "^6.1.13",
+    "sweetalert2": "^11.15.10",
+    "sweetalert2-react-content": "^5.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.25.9",

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -1,20 +1,38 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useTranslation } from 'react-i18next'; // Import useTranslation hook
-import '../styles/SettingsPanel.css'; // Import the CSS file
-import { IoSettingsOutline, IoLanguage, IoCheckmark, IoTrashOutline } from "react-icons/io5";
-import { PiArrowClockwiseFill } from "react-icons/pi";
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import '../styles/SettingsPanel.css';
+import {
+  IoCheckmark,
+  IoLanguage,
+  IoSettingsOutline,
+  IoTrashOutline,
+} from 'react-icons/io5';
+import { PiArrowClockwiseFill } from 'react-icons/pi';
+import {
+  fetchCollectionsFromEndpoint,
+  resetCollections,
+} from '../services/api';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import Swal from 'sweetalert2';
+import withReactContent from 'sweetalert2-react-content';
+
+const MySwal = withReactContent(Swal);
+const IS_NOT_FACTORY_RESET = false;
+const IS_FACTORY_RESET = true;
 
 const SettingsPanel: React.FC = () => {
-  const { t, i18n } = useTranslation(); // Initialize useTranslation
+  const { t, i18n } = useTranslation();
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
     isOpen: boolean;
   }>({ activeButton: null, isOpen: false });
 
-  const [newApiEndpoint, setNewApiEndpoint] = useState<string>("https://default-api-endpoint.com");
+  const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
+    'https://default-api-endpoint.com',
+  );
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Toggles dropdown state
   const toggleDropdown = (buttonName: string) => {
     setDropdownState((prevState) => ({
       activeButton: prevState.activeButton === buttonName ? null : buttonName,
@@ -22,39 +40,90 @@ const SettingsPanel: React.FC = () => {
     }));
   };
 
-  // Handles settings selection
-  const handleSaveEndpoint = () => {
-    if (isValidUrl(newApiEndpoint)) {
-      alert(`${t('api_endpoint')} ${t('save')}: ${newApiEndpoint}`);
+  const handleSaveAndFetchEndpoint = async (endpoint: string) => {
+    // This section is dependent on the task that
+    // enables the user to save the endpoint in the config
+    if (isValidUrl(endpoint)) {
+      const message = await fetchCollectionsFromEndpoint();
+      toast.success(message);
+
+      toast.success(t('api_endpoint_saved'));
       setDropdownState({ activeButton: null, isOpen: false });
     } else {
-      alert(t('invalid_url'));
+      toast.error(t('invalid_url'));
     }
   };
 
-  // Cancel button clicked
   const handleCancelEndpoint = () => {
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
-  // Handles language selection
   const handleLanguageSelect = (language: string) => {
-    i18n.changeLanguage(language); // Change the application language
+    i18n.changeLanguage(language);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
-  // Handles reset actions
   const handleReset = () => {
-    alert(t('reset_initiated'));
-    setDropdownState({ activeButton: null, isOpen: false });
+    handleResetDataFromEndpoint(IS_NOT_FACTORY_RESET).then(() =>
+      setDropdownState({ activeButton: null, isOpen: false }),
+    );
   };
 
   const handleFactoryReset = () => {
-    alert(t('factory_reset_initiated'));
-    setDropdownState({ activeButton: null, isOpen: false });
+    handleResetDataFromEndpoint(IS_FACTORY_RESET).then(() =>
+      setDropdownState({ activeButton: null, isOpen: false }),
+    );
   };
 
-  // Check if valid URL
+  const handleResetDataFromEndpoint = async (isFactoryReset: boolean) => {
+    MySwal.fire({
+      title: isFactoryReset ? t('factory_reset') : t('reset'),
+      text: isFactoryReset
+        ? t('confirm_factory_reset_data_from_endpoint')
+        : t('confirm_reset_data_from_endpoint'),
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: t('yes'),
+      customClass: {
+        popup: 'custom-swal-popup',
+      },
+    }).then(async (result: { isConfirmed: any }) => {
+      if (result.isConfirmed) {
+        try {
+          if (isFactoryReset) {
+            // Phil/Ali you can put your reset config method call here
+            // (instead of ResetCollections but make sure to also call
+            // the resetCollections endpoint)
+            const message = await resetCollections();
+            toast.success(message);
+          } else {
+            const message = await resetCollections();
+            toast.success(message);
+          }
+
+          MySwal.fire({
+            title: t('api_endpoint'),
+            input: 'text',
+            inputPlaceholder: 'https://default-api-endpoint.com',
+            confirmButtonColor: '#3085d6',
+            cancelButtonColor: '#d33',
+            showCancelButton: true,
+            confirmButtonText: t('save'),
+            cancelButtonText: t('cancel'),
+          }).then((result) => {
+            if (result.isConfirmed) {
+              handleSaveAndFetchEndpoint(result.value);
+            }
+          });
+        } catch (error: any) {
+          toast.error(error.message);
+        }
+      }
+    });
+  };
+
   const isValidUrl = (url: string) => {
     try {
       new URL(url);
@@ -64,10 +133,12 @@ const SettingsPanel: React.FC = () => {
     }
   };
 
-  // Close dropdowns when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
         setDropdownState({ activeButton: null, isOpen: false });
       }
     };
@@ -82,12 +153,13 @@ const SettingsPanel: React.FC = () => {
 
   return (
     <div className="button-container" ref={dropdownRef}>
-      {/* Settings button */}
+      <ToastContainer />
       <div className="dropdown-button">
-        <button 
+        <button
           className={`button ${dropdownState.activeButton === 'settings' ? 'active' : ''}`}
           onClick={() => toggleDropdown('settings')}
           aria-expanded={dropdownState.activeButton === 'settings'}
+          aria-label="settings"
         >
           <IoSettingsOutline size={32} />
         </button>
@@ -104,7 +176,11 @@ const SettingsPanel: React.FC = () => {
                   onChange={(e) => setNewApiEndpoint(e.target.value)}
                 />
                 <div className="settings-prompt-buttons">
-                  <button onClick={handleSaveEndpoint}>{t('save')}</button>
+                  <button
+                    onClick={() => handleSaveAndFetchEndpoint(newApiEndpoint)}
+                  >
+                    {t('save')}
+                  </button>
                   <button onClick={handleCancelEndpoint}>{t('cancel')}</button>
                 </div>
               </div>
@@ -113,35 +189,43 @@ const SettingsPanel: React.FC = () => {
         )}
       </div>
 
-      {/* Language Dropdown */}
       <div className="dropdown-button">
         <button
           className={`button ${dropdownState.activeButton === 'language' ? 'active' : ''}`}
           onClick={() => toggleDropdown('language')}
           aria-expanded={dropdownState.activeButton === 'language'}
+          aria-label="language"
         >
           <IoLanguage size={32} />
         </button>
         {dropdownState.activeButton === 'language' && (
           <div className="dropdown-content show">
             <button onClick={() => handleLanguageSelect('en')}>
-              {i18n.language === 'en' ? <IoCheckmark size={24} fill="black" /> : <PiArrowClockwiseFill size={24} fill="none" />}
+              {i18n.language === 'en' ? (
+                <IoCheckmark size={24} fill="black" />
+              ) : (
+                <PiArrowClockwiseFill size={24} fill="none" />
+              )}
               {t('english')}
             </button>
             <button onClick={() => handleLanguageSelect('fr')}>
-              {i18n.language === 'fr' ? <IoCheckmark size={24} fill="black" /> : <PiArrowClockwiseFill size={24} fill="none" />}
+              {i18n.language === 'fr' ? (
+                <IoCheckmark size={24} fill="black" />
+              ) : (
+                <PiArrowClockwiseFill size={24} fill="none" />
+              )}
               {t('french')}
             </button>
           </div>
         )}
       </div>
 
-      {/* Reset Dropdown */}
       <div className="dropdown-button">
         <button
           className={`button ${dropdownState.activeButton === 'reset' ? 'active' : ''}`}
           onClick={() => toggleDropdown('reset')}
           aria-expanded={dropdownState.activeButton === 'reset'}
+          aria-label="reset"
         >
           <PiArrowClockwiseFill size={32} />
         </button>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -7,18 +7,15 @@ import Sidebar from './components/Sidebar';
 import SettingsPanel from './components/SettingsPanel';
 import AvailableDatasets, { Dataset } from './components/AvailableDatasets';
 import MapMetaData from './components/MapMetaData';
-import TestStac from './testComponents/TestStac';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './resources/i18n';
 import './layout.css';
 import LoadingModule from './components/LoadingModule';
 
-
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [selectedDataset, setSelectedDataset] = useState<Dataset | null>(null);
-  const [errorMessage, setErrorMessage] = useState("");
 
   // Function to show loading bar with progress
   const showLoadingBar = () => {
@@ -33,7 +30,6 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       });
     }, 300); // Update every 300ms
   };
-
 
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: Dataset) => {
@@ -62,30 +58,32 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     <I18nextProvider i18n={i18n}>
       <MapProvider>
         <html lang="en">
-        <body>
-        <SettingsPanel />
-        <div className="layout-container relative">
-          <LoadingModule progress={progress} isVisible={loading} datasetBeingLoaded={selectedDataset?.name} />
-          <TestStac />
-          <main className="app-main">{children}</main>
-          <AvailableDatasets onDatasetClick={handleDatasetClick} />
-          <MapView />
-          <Sidebar />
-          {selectedDataset && (
-              <MapMetaData
-                city={selectedDataset.city}
-                name={selectedDataset.name}
-                description={selectedDataset.description}
-                format={selectedDataset.format}
-                processes={selectedDataset.processes}
-                datasetSource={selectedDataset.datasetSource}
-                onLoadDataset={handleLoadDataset}
+          <body>
+            <SettingsPanel />
+            <div className="layout-container relative">
+              <LoadingModule
+                progress={progress}
+                isVisible={loading}
+                datasetBeingLoaded={selectedDataset?.name}
               />
-            )
-          }
-          <footer className="app-footer"></footer>
-        </div>
-        </body>
+              <main className="app-main">{children}</main>
+              <AvailableDatasets onDatasetClick={handleDatasetClick} />
+              <MapView />
+              <Sidebar />
+              {selectedDataset && (
+                <MapMetaData
+                  city={selectedDataset.city}
+                  name={selectedDataset.name}
+                  description={selectedDataset.description}
+                  format={selectedDataset.format}
+                  processes={selectedDataset.processes}
+                  datasetSource={selectedDataset.datasetSource}
+                  onLoadDataset={handleLoadDataset}
+                />
+              )}
+              <footer className="app-footer"></footer>
+            </div>
+          </body>
         </html>
       </MapProvider>
     </I18nextProvider>

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -10,11 +10,14 @@ const resources = {
         cancel: "Cancel",
         invalid_url: "Invalid URL. Please enter a valid API endpoint.",
         enter_new_api_endpoint: "Enter new API endpoint",
+        api_endpoint_saved: "API Endpoint Successfully Saved",
         //Language
         english: "English",
         french: "French",
         //Reset
         reset: "Reset",
+        confirm_reset_data_from_endpoint: "Collections in the database will be deleted. You will then be prompted to enter the endpoint to fetch new collections. \nDo you want to proceed?",
+        confirm_factory_reset_data_from_endpoint: "All data,  simulation configurations, and configurations files will be deleted. You will then be prompted to enter the endpoint to fetch new collections. \nDo you want to proceed?",
         factory_reset: "Factory Reset",
         reset_initiated: "Reset initiated",
         factory_reset_initiated: "Factory Reset initiated",
@@ -42,7 +45,10 @@ const resources = {
         collapse: "Collapse",
         default_layer: "Default Layer",
         topographical_layer: "Topographical Layer",
-        satellite_layer: "Satellite Layer"
+        satellite_layer: "Satellite Layer",
+        //Decisions
+        yes: "Yes",
+        no: "No"
     },
   },
   fr: {
@@ -53,11 +59,14 @@ const resources = {
         cancel: "Annuler",
         invalid_url: "URL invalide. Veuillez entrer un point d'API valide.",
         enter_new_api_endpoint: "Entrez un nouveau point d'API",
+        api_endpoint_saved: "Point d'API enregistré avec succès",
         //Language
         english: "Anglais",
         french: "Français",
         //Reset
         reset: "Réinitialiser",
+        confirm_reset_data_from_endpoint: "Les collections dans la base de données seront supprimées. Vous serez ensuite invité à entrer l'endpoint pour récupérer de nouvelles collections. \nVoulez-vous continuer?",
+        confirm_factory_reset_data_from_endpoint: "Toutes les données, configurations de simulation et fichiers de configuration seront supprimés. Vous serez ensuite invité à entrer l'endpoint pour récupérer de nouvelles collections. \nVoulez-vous continuer ?",
         factory_reset: "Réinitialisation d'Usine",
         reset_initiated: "Réinitialisation démarrée",
         factory_reset_initiated: "Réinitialisation d'Usine démarrée",
@@ -85,7 +94,10 @@ const resources = {
         collapse: "Réduire",
         default_layer: "Calque par Défaut",
         topographical_layer: "Calque Topographique",
-        satellite_layer: "Calque Satellite"
+        satellite_layer: "Calque Satellite",
+        //Decisions
+        yes: "Oui",
+        no: "Non"
     },
   },
 };

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -14,7 +14,7 @@ export const fetchTestStacData = async (): Promise<any> => {
   }
 };
 
-export const fetchCollectionsFromEndpoint = async (): Promise<{
+export const returnListOfCollectionsFromEndpoint = async (): Promise<{
   error: string;
 }> => {
   try {
@@ -28,5 +28,36 @@ export const fetchCollectionsFromEndpoint = async (): Promise<{
   } catch (error: any) {
     console.error('Error fetching collections:', error);
     return { error: 'Failed to fetch data' };
+  }
+};
+
+export const fetchCollectionsFromEndpoint = async (): Promise<string> => {
+  try {
+    // this will eventually pass a parameter to call the endpoint URL we want
+    const response = await fetch(`${BASE_URL}/api/fetch-collections`);
+    if (!response.ok) {
+      throw new Error(`Error: ${response.statusText}`);
+    }
+    const message = await response.text();
+    return message;
+  } catch (error: any) {
+    console.error('Error fetching collections:', error);
+    throw new Error(`Failed to fetch data: ${error.message}`);
+  }
+}
+
+
+
+export const resetCollections = async (): Promise<string> => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/reset-collections`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const message = await response.text();
+    return message;
+  } catch (error: any) {
+    console.error('Error resetting collections:', error);
+    throw new Error(`Error resetting collections: ${error.message}`);
   }
 };

--- a/apps/frontend/src/app/styles/SettingsPanel.css
+++ b/apps/frontend/src/app/styles/SettingsPanel.css
@@ -7,7 +7,7 @@
     gap: 20px;
     z-index: 1000;
   }
-  
+
   /* Base style for each button */
   .button {
     width: 50px;
@@ -24,29 +24,29 @@
     outline: none;
     border: none;
   }
-  
+
   /* Active button state: adds a white border */
   .button.active {
     border: 2px solid white;
   }
-  
+
   /* Hover effect for the button */
   .button:hover {
     background-color: #0056b3;
   }
-  
+
   /* Style for the image inside the button */
   .button img {
     width: 100%;
     height: 100%;
     object-fit: cover;
   }
-  
+
   /* Style for the dropdown container */
   .dropdown-button {
     position: relative;
   }
-  
+
   /* Dropdown content styling, initially hidden */
   .dropdown-content {
     display: none;
@@ -59,12 +59,12 @@
     z-index: 1;
     margin-top: 3px;
   }
-  
+
   /* Show dropdown content when it's open */
   .dropdown-content.show {
     display: block;
   }
-  
+
   /* Style for each dropdown button */
   .dropdown-content button {
     background: none;
@@ -79,7 +79,7 @@
     position: relative;
     gap: 10px;
   }
-  
+
   /* Hover effect for dropdown buttons */
   .dropdown-content button:hover::before {
     content: "";
@@ -91,19 +91,19 @@
     z-index: -1;
     border-radius: 10px;
   }
-  
+
   /* Style for images inside the dropdown buttons */
   .dropdown-content button img {
     width: 25px;
     height: 25px;
     margin-right: 10px;
   }
-  
+
   /* Centering the text inside dropdown button */
   .dropdown-content button span {
     flex: 1;
     text-align: center;
-  }  
+  }
 
   /* Settings prompt styling */
   .settings-prompt {
@@ -185,4 +185,9 @@
 
   .settings-prompt-buttons button:last-child:hover {
     background-color: #b32d39;
+  }
+
+  .custom-swal-popup {
+    text-align: justify;
+    white-space: pre-line;
   }

--- a/apps/frontend/src/app/testComponents/TestStac.tsx
+++ b/apps/frontend/src/app/testComponents/TestStac.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { fetchCollectionsFromEndpoint } from '../services/api';
+import { returnListOfCollectionsFromEndpoint } from '../services/api';
 
 // Define the structure of the data being fetched
 interface StacData {
@@ -15,7 +15,7 @@ const TestStac: React.FC = () => {
     setLoading(true);
     setError(null); // Clear any previous errors
     try {
-      const result = await fetchCollectionsFromEndpoint();
+      const result = await returnListOfCollectionsFromEndpoint();
       if (result.error) {
         setError(result.error);
       } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,10 @@
         "react-i18next": "^15.4.0",
         "react-icons": "^5.3.0",
         "react-leaflet": "^4.2.1",
-        "styled-components": "^6.1.13"
+        "react-toastify": "^11.0.3",
+        "styled-components": "^6.1.13",
+        "sweetalert2": "^11.15.10",
+        "sweetalert2-react-content": "^5.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.26.0",
@@ -11027,6 +11030,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -23026,6 +23037,18 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
+      "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -25032,6 +25055,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/sweetalert2": {
+      "version": "11.15.10",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.15.10.tgz",
+      "integrity": "sha512-Sjiwcd5mWiz8X0JFkHsso2EPVQHrLCjVv+xR6Ry2LKf4KY6kSi4U5pM0Tgmn1c7SMfkyDqPal2NWqwj6vck8bw==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
+    "node_modules/sweetalert2-react-content": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sweetalert2-react-content/-/sweetalert2-react-content-5.1.0.tgz",
+      "integrity": "sha512-SBh41SdyHDY9NzwrIG6LACbClCMxIlEFP86tGVr/B4zGD4H2gGXB8o7UAJRc/RtBd/iQL9hIvuCAkrk0AgKEMA==",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "sweetalert2": "^11.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "react-i18next": "^15.4.0",
     "react-icons": "^5.3.0",
     "react-leaflet": "^4.2.1",
-    "styled-components": "^6.1.13"
+    "react-toastify": "^11.0.3",
+    "styled-components": "^6.1.13",
+    "sweetalert2": "^11.15.10",
+    "sweetalert2-react-content": "^5.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.26.0",


### PR DESCRIPTION
### #84 - Add endpoint to reset collections and update frontend with reset button
This PR introduces an endpoint `/api/reset-collections` to delete and reset the collections table in the database. The rest button and factory button will now use this implementation, utilizing SweetAlert2 and Toast notifications for user feedback.

When the **Reset** or **Factory Reset** button is clicked, the following sequence occurs:

1. **Confirmation Pop-up:**
   - A pop-up appears, asking the user to confirm if they want to proceed.

2. **Deletion of Collections:**
   - Upon confirmation, the system deletes the collections in the database.
   - A success message confirms the deletion.

3. **URL Input Prompt:**
   - Immediately after, the user is prompted to input an endpoint URL.
   - The system checks the URL format to ensure it is valid.

4. **Fetching Collections:**
   - Once the URL is validated, the **fetch-collections API** is called to retrieve the collections.
   - A success message confirms that the collections have been successfully fetched.

For detailed scenarios and visuals, refer to the **Screenshots and Demo** section.

### Screenshots and Demo
https://github.com/user-attachments/assets/e4ec7e5f-9992-4a23-813e-868e322069ef

![image](https://github.com/user-attachments/assets/7eac7cd5-f2f5-4b30-9966-1eb9a82c42cb)
![image](https://github.com/user-attachments/assets/5a05ce53-e082-4fc0-8227-3351b67a80bd)
![image](https://github.com/user-attachments/assets/13f40df2-5195-479d-8dd2-62dde13c8bca)
![image](https://github.com/user-attachments/assets/d57fa241-3fcd-4767-802d-17819b46e2f3)
![image](https://github.com/user-attachments/assets/cb84c428-b4c8-4e36-a05b-c53ab3698559)


### Changes Made
- Added `/api/reset-collections` endpoint to delete and fetch collections.
- Integrated SweetAlert2 for confirmation dialogs.
- Added Toast notifications for success and error messages.
- Updated `SettingsPanel` component to include the reset button.

### Testing Instructions
1. Open the application and navigate to the settings panel.
2. Click on the reset button.
3. Confirm the action in the SweetAlert2 dialog.
4. Verify that the collections are deleted and fetched again.
5. Check for success or error messages via Toast notifications.

### Additional Notes
Ensure the backend service is running and accessible for the endpoint to function correctly.