### PR TITLE
#0 - chore(ci): Separating e2e tests into a different pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,15 @@ jobs:
   frontend_ci:
     runs-on: ubuntu-latest
     steps:
-      # Checkout the code
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # Set up Node.js
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
 
-      # Cache node_modules
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
@@ -35,46 +32,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      # Cache Cypress binary to avoid re-downloading
-      - name: Cache Cypress
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/Cypress
-          key: ${{ runner.os }}-cypress-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
-
-      # Install Node.js dependencies
       - run: npm install --legacy-peer-deps
 
-      # Install Cypress binary explicitly to ensure it's available
-      - name: Install Cypress Binary
-        run: npx cypress install
-
-      # Lint Frontend Projects
       - name: Lint Frontend Projects
         run: npx nx lint frontend
 
-      # Build Frontend
       - name: Build Frontend
         run: npx nx build frontend
 
-      # Test Frontend
       - name: Test Frontend
         run: npx nx test frontend
 
-      # End-to-End Tests
-      - name: End-to-End Tests
-        run: npx nx e2e frontend-e2e
-
-      # Set up Java 17 for SonarCloud compatibility
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
 
-      # SonarCloud Analysis for Frontend
       - name: SonarCloud Scan Frontend
         env:
           SONAR_TOKEN_FRONTEND: ${{ secrets.SONAR_TOKEN_FRONTEND }}
@@ -93,45 +67,35 @@ jobs:
   backend_ci:
     runs-on: ubuntu-latest
     steps:
-      # Checkout the code
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # Set up Java
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '22'
 
-      # Install Node.js and dependencies
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
 
-      # Install Node.js dependencies (including Nx) for backend
-      - name: Install Node.js Dependencies
-        run: npm install --legacy-peer-deps
+      - run: npm install --legacy-peer-deps
 
-      # Lint Backend Projects
       - name: Lint Backend Projects
         run: npx nx lint backend
 
-      # Build Backend
       - name: Build Backend
         run: npx nx build backend
 
-      # Test Backend
       - name: Test Backend
         run: npx nx test backend
 
-      # Verify Backend Coverage Files
-      - name: List Backend Coverage Files
+      - name: Verify Backend Coverage Files
         run: ls -R apps/backend/target/site/jacoco/
 
-      # SonarCloud Analysis for Backend
       - name: SonarCloud Scan Backend
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,21 +4,24 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - dev  # Triggers on merging PRs to main branch
+      - dev  # Triggers on pushes to the dev branch
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
     steps:
+      # Checkout code
       - uses: actions/checkout@v4
 
+      # Java Setup
       - name: Java Setup
         uses: actions/setup-java@v2
         with:
           java-version: '22'
           distribution: 'adopt'
 
+      # Build Backend
       - name: Build Backend
         run: mvn clean package -f apps/backend
 
@@ -36,17 +39,20 @@ jobs:
           sudo apt-get install -y docker-compose
 
       # Build and start the services in detached mode
-      - name: Build and start services
+      - name: Build and Start Services
         run: docker-compose up --build -d
         env:
-          REACT_APP_BACKEND_URL: http://backend:8080
+          SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/postgres
+          SPRING_DATASOURCE_USERNAME: postgres
+          SPRING_DATASOURCE_PASSWORD: password
+          NEXT_PUBLIC_BACKEND_URL: http://backend:8080
           MAPTILER_API_KEY: ${{ secrets.MAPTILER_API_KEY }}
 
-      # Push images to Docker Hub
-      - name: Push Docker images
+      # Push Docker images to Docker Hub
+      - name: Push Docker Images
         run: docker-compose push
 
       # Tear down the services
-      - name: Tear Down the Docker-Compose
+      - name: Tear Down Services
         if: always()
         run: docker-compose down

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,12 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install Docker and Docker Compose using apt
-      - name: Install Docker and Docker Compose
+      # Install Docker Compose using apt
+      - name: Install Docker Compose
         run: |
           sudo apt-get update
-          sudo apt-get install -y docker.io docker-compose
-          docker --version
+          sudo apt-get install -y docker-compose
           docker-compose --version
 
       # Start PostgreSQL, Backend, and Geoserver using Docker Compose

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,20 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install Docker and Docker Compose Manually
+      # Install Docker and Docker Compose using apt
       - name: Install Docker and Docker Compose
         run: |
           sudo apt-get update
-          sudo apt-get install -y ca-certificates curl gnupg lsb-release
-          sudo mkdir -p /etc/apt/keyrings
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-          echo \
-            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-          sudo curl -L "https://github.com/docker/compose/releases/download/2.22.0/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
+          sudo apt-get install -y docker.io docker-compose
           docker --version
           docker-compose --version
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,8 @@ jobs:
       # Build Frontend Application
       - name: Build Frontend
         run: npx nx build frontend
+        env:
+          NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
 
       # Run Cypress for E2E Testing
       - name: Run Cypress E2E Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,11 +39,11 @@ jobs:
             sleep 5;
           done
 
-      # Wait for Geoserver to be Ready
+      # Wait for Geoserver to be Ready using Health Check
       - name: Wait for Geoserver
         run: |
-          for i in {1..180}; do
-            if curl -s http://localhost:8090/geoserver/web/ | grep -q "GeoServer"; then
+          for i in {1..30}; do
+            if docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q -f name=geoserver) | grep -q "healthy"; then
               echo "Geoserver is ready!";
               break;
             fi;

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,7 +42,7 @@ jobs:
       # Wait for Geoserver to be Ready
       - name: Wait for Geoserver
         run: |
-          for i in {1..30}; do
+          for i in {1..180}; do
             if curl -s http://localhost:8090/geoserver/web/ | grep -q "GeoServer"; then
               echo "Geoserver is ready!";
               break;
@@ -60,6 +60,10 @@ jobs:
       # Install Node.js dependencies
       - name: Install Node.js Dependencies
         run: npm install --legacy-peer-deps
+
+      # Build Frontend Application
+      - name: Build Frontend
+        run: npx nx build frontend
 
       # Run Cypress for E2E Testing
       - name: Run Cypress E2E Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,13 +16,21 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install Docker and Docker Compose
-      - name: Set up Docker and Docker Compose
+      # Install Docker and Docker Compose Manually
+      - name: Install Docker and Docker Compose
         run: |
           sudo apt-get update
-          sudo apt-get install -y docker.io
-          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo apt-get install -y ca-certificates curl gnupg lsb-release
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+            $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+          sudo curl -L "https://github.com/docker/compose/releases/download/2.22.0/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
+          docker --version
           docker-compose --version
 
       # Start PostgreSQL, Backend, and Geoserver using Docker Compose

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Install Docker and Docker Compose
+      - name: Set up Docker and Docker Compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker.io
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker-compose --version
+
       # Start PostgreSQL, Backend, and Geoserver using Docker Compose
       - name: Start Services
         run: docker-compose up -d db backend geoserver
@@ -54,16 +63,14 @@ jobs:
       - name: Install Node.js Dependencies
         run: npm install --legacy-peer-deps
 
-      # Wait for Backend to Start
-      - name: Wait for Backend
-        run: sleep 20
-
       # Run Cypress for E2E Testing
       - name: Run Cypress E2E Tests
         run: npx nx e2e frontend-e2e
         env:
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
+          CYPRESS_BASE_URL: http://localhost:3000
 
       # Post-Test Cleanup
       - name: Cleanup
+        if: always()
         run: docker-compose down

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,69 @@
+name: E2E Pipeline
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  e2e_tests:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Start PostgreSQL, Backend, and Geoserver using Docker Compose
+      - name: Start Services
+        run: docker-compose up -d db backend geoserver
+
+      # Wait for Database to be Ready using Health Check
+      - name: Wait for Database
+        run: |
+          for i in {1..30}; do
+            if docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q -f name=db) | grep -q "healthy"; then
+              echo "Database is ready!";
+              break;
+            fi;
+            echo "Waiting for the database...";
+            sleep 5;
+          done
+
+      # Wait for Geoserver to be Ready
+      - name: Wait for Geoserver
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:8090/geoserver/web/ | grep -q "GeoServer"; then
+              echo "Geoserver is ready!";
+              break;
+            fi;
+            echo "Waiting for Geoserver...";
+            sleep 5;
+          done
+
+      # Set up Node.js
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      # Install Node.js dependencies
+      - name: Install Node.js Dependencies
+        run: npm install --legacy-peer-deps
+
+      # Wait for Backend to Start
+      - name: Wait for Backend
+        run: sleep 20
+
+      # Run Cypress for E2E Testing
+      - name: Run Cypress E2E Tests
+        run: npx nx e2e frontend-e2e
+        env:
+          NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
+
+      # Post-Test Cleanup
+      - name: Cleanup
+        run: docker-compose down

--- a/apps/geoserver_data/security/usergroup/default/users.xml
+++ b/apps/geoserver_data/security/usergroup/default/users.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <userRegistry version="1.0" xmlns="http://www.geoserver.org/security/users">
     <users>
-        <user enabled="true" name="geoserver" password="digest1:TGZg2wQePKLtc5Rob0S1nFj0eRSUFI4lBzePoItRzaPMJJ0MO5oDuak2X0yUqn7a"/>
+        <user enabled="true" name="geoserver" password="digest1:0zUSCnHXKwYQMUekPiRPCipaWB+MgVgro9BipsuomQ7BBWmYWG5a6O3o+0ohMscb"/>
     </users>
     <groups/>
 </userRegistry>

--- a/apps/geoserver_data/security/usergroup/default/users.xml.orig
+++ b/apps/geoserver_data/security/usergroup/default/users.xml.orig
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <userRegistry version="1.0" xmlns="http://www.geoserver.org/security/users">
     <users>
-        <user enabled="true" name="geoserver" password="digest1:q+Cll8QZUVDFLQpMrQmdIuF3IKRpG5jzjVqfAhr2KSvs+OvhhUZM62b+0BomJZpy"/>
+        <user enabled="true" name="geoserver" password="digest1:TGZg2wQePKLtc5Rob0S1nFj0eRSUFI4lBzePoItRzaPMJJ0MO5oDuak2X0yUqn7a"/>
     </users>
     <groups/>
 </userRegistry>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,6 @@ services:
     environment:
       - GEOSERVER_ADMIN_USER=geoserver
       - GEOSERVER_ADMIN_PASSWORD=password
-      - GEOSERVER_DATA_DIR=/var/geoserver/data_dir
-      - RUN_AS_ROOT=TRUE
     networks:
       - app-network
     volumes:
@@ -72,6 +70,11 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: curl -s http://localhost:8080/geoserver/web/ || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
 networks:
   app-network:


### PR DESCRIPTION
## Summary
This pull request separates the End-to-End (E2E) testing workflow into a distinct pipeline to streamline the CI/CD process and reduce redundancy. The new pipeline ensures that E2E tests are isolated from other jobs and executed only when required.

### Changes Made
- Created a **dedicated E2E pipeline** (`E2E Pipeline`) that:
  - Sets up the PostgreSQL database using `pgstac`.
  - Starts the backend service in development mode.
  - Relies on Cypress to handle the frontend launch and run tests.
  - Includes `geoserver` as part of the test environment for completeness.
  - Cleans up all services after tests are completed.
- Updated the original CI/CD workflow:
  - Removed E2E steps from the frontend pipeline.
  - Ensured the E2E pipeline runs independently for `push`, `pull_request`, and `workflow_dispatch` events.

### Testing Instructions
1. Trigger the `E2E Pipeline`:
   - Push changes to the `dev` branch.
   - Open a pull request targeting the `dev` branch.
   - Manually trigger the pipeline using `workflow_dispatch`.
2. Validate the following:
   - The `db`, `backend`, and `geoserver` services start successfully within the Docker Compose app network.
   - Cypress launches the frontend and executes the E2E tests correctly.
   - All services are cleaned up after the tests complete.

