### PR TITLE
#172 - fix: [Bug] Loading bar / Load Dataset bug fix

### DIFF
--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -5,10 +5,10 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { insertDatalayerView } from '../src/app/services/api';
 import { changeLayer } from '../src/app/components/MapView';
 
-jest.mock('react', ()=>({
+jest.mock('react', () => ({
     ...jest.requireActual('react'),
     useState: jest.fn()
-  }));
+}));
 
 jest.mock('../src/app/services/api', () => ({
     insertDatalayerView: jest.fn(),
@@ -19,96 +19,87 @@ jest.mock('../src/app/components/MapView', () => ({
 }));
 
 describe(MapMetaData, () => {
-
-    beforeEach(()=>{
-        jest.spyOn(React, 'useState').mockImplementation(() => [false, jest.fn()])
-    })
+    let setStateMock: any;
+    beforeEach(() => {
+        setStateMock = jest.fn();
+        jest.spyOn(React, 'useState').mockImplementation(() => [false, setStateMock]);
+    });
 
     afterEach(() => {
-        jest.clearAllMocks()
-    })
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
 
     it("meta data displays dataset name prop", () => {
-        const {getByTestId} = render(<MapMetaData name='Dataset1' onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } }/>)
-        const displayedName = getByTestId("name-div").textContent;
-        expect(displayedName).toEqual("Dataset1")
-    })
-    it("meta data displays description prop", () => {
-        const {getByTestId} = render(<MapMetaData description='Desc' onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } }/>)
-        const displayedDesc = getByTestId("dataset-description").textContent;
-        expect(displayedDesc).toEqual("Desc")
-    })
-    it("meta data displays format prop", () => {
-        const {getByTestId} = render(<MapMetaData format='CSV' onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } }/>)
-        const displayedFormat = getByTestId("dataset-format").textContent;
-        expect(displayedFormat).toEqual("CSV")
-    })
-    it("meta data displays processes prop", () => {
-        const {getByTestId} = render(<MapMetaData processes='Process' onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } }/>)
-        const displayedProcesses = getByTestId("dataset-processes").textContent;
-        expect(displayedProcesses).toEqual("Process")
-    })
-    it("meta data displays datasetSource prop", () => {
-        const {getByTestId} = render(<MapMetaData datasetSource='Source' onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } }/>)
-        const displayedSource = getByTestId("dataset-datasource").textContent;
-        expect(displayedSource).toEqual("Source")
-    })
-    it("all data displays in the metadata box", () => {
-        const {getByTestId} = render(<MapMetaData name='Dataset1' description='Desc' format='CSV' processes='Process' datasetSource='Source' onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } }/>)
-
-        const displayedName = getByTestId("name-div").textContent;
-        expect(displayedName).toEqual("Dataset1")
-
-        const displayedDesc = getByTestId("dataset-description").textContent;
-        expect(displayedDesc).toEqual("Desc")
-
-        const displayedFormat = getByTestId("dataset-format").textContent;
-        expect(displayedFormat).toEqual("CSV")
-
-        const displayedProcesses = getByTestId("dataset-processes").textContent;
-        expect(displayedProcesses).toEqual("Process")
-
-        const displayedSource = getByTestId("dataset-datasource").textContent;
-        expect(displayedSource).toEqual("Source")
-    })
-    it("metadata box collapses when isCollapsed = false", () => {
-        jest.spyOn(React, 'useState').mockImplementation(() => [true, jest.fn()])
-
-        const {getByTestId} = render(<MapMetaData onLoadDataset={function (): void {
-            throw new Error('Function not implemented.');
-        } } />)
-        const collapsedBox = getByTestId("collapsedMetaData");
-        expect(collapsedBox).toBeInTheDocument();
+        const { getByTestId } = render(<MapMetaData name='Dataset1' />);
+        expect(getByTestId("name-div").textContent).toEqual("Dataset1");
     });
-    it('calls insertDatalayerView and changeLayer when load dataset button is clicked', async () => {
-        const mockOnLoadDataset = jest.fn();
+
+    it("meta data displays description prop", () => {
+        const { getByTestId } = render(<MapMetaData description='Desc' />);
+        expect(getByTestId("dataset-description").textContent).toEqual("Desc");
+    });
+
+    it("meta data displays format prop", () => {
+        const { getByTestId } = render(<MapMetaData format='CSV' />);
+        expect(getByTestId("dataset-format").textContent).toEqual("CSV");
+    });
+
+    it("meta data displays processes prop", () => {
+        const { getByTestId } = render(<MapMetaData processes='Process' />);
+        expect(getByTestId("dataset-processes").textContent).toEqual("Process");
+    });
+
+    it("meta data displays datasetSource prop", () => {
+        const { getByTestId } = render(<MapMetaData datasetSource='Source' />);
+        expect(getByTestId("dataset-datasource").textContent).toEqual("Source");
+    });
+
+    it("metadata box collapses when isCollapsed = false", () => {
+        setStateMock = jest.fn();
+        jest.spyOn(React, 'useState').mockImplementation(() => [false, setStateMock]);
+        jest.spyOn(React, 'useState').mockImplementation(() => [true, setStateMock]);
+        const { getByTestId } = render(<MapMetaData />);
+        expect(getByTestId("collapsedMetaData")).toBeInTheDocument();
+    });
+
+    // it("displays the loading module when dataset loading starts", async () => {
+    //     jest.useFakeTimers();
+    //     const { getByTestId, queryByTestId, rerender } = render(<MapMetaData id="123" />);
     
-        const { getByTestId } = render(
-            <MapMetaData 
-                id="123" 
-                onLoadDataset={mockOnLoadDataset} 
-            />
-        );
+    //     const loadButton = getByTestId("load-dataset-button");
     
-        const loadButton = getByTestId('load-dataset-button');
+    //     // Ensure loading module is NOT visible initially
+    //     expect(queryByTestId("loading-module")).not.toBeInTheDocument();
+    
+    //     await act(async () => {
+    //         fireEvent.click(loadButton);
+    //         jest.advanceTimersByTime(500); // Allow loading state to update
+    //         rerender(<MapMetaData id="123" />); // 🔹 Force re-render to reflect state change
+    //     });
+    
+    //     expect(getByTestId("loading-module")).toBeInTheDocument(); // ✅ Should be visible now
+    
+    //     // Simulate loading completion
+    //     jest.advanceTimersByTime(4000);
+    //     expect(setTimeout).toHaveBeenCalled();
+    //     jest.useRealTimers();
+    // });       
+
+    it("calls insertDatalayerView and changeLayer when load dataset button is clicked", async () => {
+        jest.useFakeTimers();
+        const { getByTestId } = render(<MapMetaData id="123" />);
+    
+        const loadButton = getByTestId("load-dataset-button");
     
         await act(async () => {
             fireEvent.click(loadButton);
+            jest.advanceTimersByTime(4000);
         });
     
         expect(insertDatalayerView).toHaveBeenCalledWith("123");
         expect(changeLayer).toHaveBeenCalled();
+    
+        jest.useRealTimers();
     });
-})
+});

--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import MapMetaData from '../src/app/components/MapMetaData';
 import { render, fireEvent, act } from '@testing-library/react';
-import { insertDatalayerView } from '../src/app/services/api';
-import { changeLayer } from '../src/app/components/MapView';
 
 jest.mock('react', () => ({
     ...jest.requireActual('react'),
@@ -57,49 +55,81 @@ describe(MapMetaData, () => {
 
     it("metadata box collapses when isCollapsed = false", () => {
         setStateMock = jest.fn();
-        jest.spyOn(React, 'useState').mockImplementation(() => [false, setStateMock]);
         jest.spyOn(React, 'useState').mockImplementation(() => [true, setStateMock]);
         const { getByTestId } = render(<MapMetaData />);
         expect(getByTestId("collapsedMetaData")).toBeInTheDocument();
-    });
+    });        
 
-    // it("displays the loading module when dataset loading starts", async () => {
-    //     jest.useFakeTimers();
-    //     const { getByTestId, queryByTestId, rerender } = render(<MapMetaData id="123" />);
-    
-    //     const loadButton = getByTestId("load-dataset-button");
-    
-    //     // Ensure loading module is NOT visible initially
-    //     expect(queryByTestId("loading-module")).not.toBeInTheDocument();
-    
-    //     await act(async () => {
-    //         fireEvent.click(loadButton);
-    //         jest.advanceTimersByTime(500); // Allow loading state to update
-    //         rerender(<MapMetaData id="123" />); // 🔹 Force re-render to reflect state change
-    //     });
-    
-    //     expect(getByTestId("loading-module")).toBeInTheDocument(); // ✅ Should be visible now
-    
-    //     // Simulate loading completion
-    //     jest.advanceTimersByTime(4000);
-    //     expect(setTimeout).toHaveBeenCalled();
-    //     jest.useRealTimers();
-    // });       
-
-    it("calls insertDatalayerView and changeLayer when load dataset button is clicked", async () => {
+    it("calls showLoadingBar and increments progress until it reaches 100", async () => {
         jest.useFakeTimers();
-        const { getByTestId } = render(<MapMetaData id="123" />);
     
+        let progressState = 0;
+        const setProgressMock = jest.fn((updateFn) => {
+            if (typeof updateFn === "function") {
+                progressState = updateFn(progressState);
+            } else {
+                progressState = updateFn;
+            }
+        });
+    
+        jest.spyOn(React, "useState")
+            .mockImplementationOnce(() => [false, jest.fn()])
+            .mockImplementationOnce(() => [false, jest.fn()])
+            .mockImplementationOnce(() => [progressState, setProgressMock]);
+    
+        const { getByTestId } = render(<MapMetaData id="123" />);
         const loadButton = getByTestId("load-dataset-button");
     
         await act(async () => {
             fireEvent.click(loadButton);
-            jest.advanceTimersByTime(4000);
         });
     
-        expect(insertDatalayerView).toHaveBeenCalledWith("123");
-        expect(changeLayer).toHaveBeenCalled();
+        // Simulate the progress updates over time
+        for (let i = 0; i < 10; i++) {
+            jest.advanceTimersByTime(300);
+            await act(async () => {});
+        }
+    
+        // Ensure `setProgress` was called multiple times (progress is updating)
+        expect(setProgressMock).toHaveBeenCalledTimes(11);
+        expect(progressState).toBe(100);
     
         jest.useRealTimers();
     });
+    
+    it("handles errors in onLoadDataset gracefully", async () => {
+        jest.useFakeTimers();
+        
+        // Mock error in insertDatalayerView
+        const errorMock = new Error("API failure");
+        const insertDatalayerViewMock = require("../src/app/services/api").insertDatalayerView;
+        insertDatalayerViewMock.mockRejectedValue(errorMock);
+    
+        let setLoadingMock = jest.fn();
+        let setProgressMock = jest.fn();
+    
+        jest.spyOn(React, "useState")
+            .mockImplementationOnce(() => [false, jest.fn()])
+            .mockImplementationOnce(() => [false, setLoadingMock])
+            .mockImplementationOnce(() => [0, setProgressMock]);
+    
+        const { getByTestId } = render(<MapMetaData id="123" />);
+        const loadButton = getByTestId("load-dataset-button");
+    
+        await act(async () => {
+            fireEvent.click(loadButton);
+        });
+    
+        // Advance time to trigger progress bar updates
+        jest.advanceTimersByTime(4000);
+        await act(async () => {});
+    
+        // Check if the error was logged and loading state was reset
+        expect(insertDatalayerViewMock).toHaveBeenCalledWith("123");
+        expect(setLoadingMock).toHaveBeenCalledWith(true);
+        expect(setLoadingMock).toHaveBeenCalledWith(false);
+        expect(setProgressMock).toHaveBeenCalled();
+    
+        jest.useRealTimers();
+    });    
 });

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -4,6 +4,7 @@ import { IoInformationCircle } from "react-icons/io5";
 import { useTranslation } from "react-i18next";
 import { insertDatalayerView } from "../services/api";
 import { changeLayer } from "./MapView";
+import LoadingModule from "./LoadingModule";
 
 interface MapMetaDataProps {
   id?: string;
@@ -12,7 +13,6 @@ interface MapMetaDataProps {
   format?: string;
   processes?: string;
   datasetSource?: string;
-  onLoadDataset: () => void;
 }
 
 const MapMetaData: React.FC<MapMetaDataProps> = ({
@@ -22,15 +22,45 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   format = "",
   processes = "",
   datasetSource = "",
-  onLoadDataset,
 }) => {
   const { t } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const toggleCollapse = () => setIsCollapsed((prev) => !prev);
+  const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
 
-  onLoadDataset = async () => {
-    await insertDatalayerView(id);
-    changeLayer();
+  // Function to show loading bar with progress
+  const showLoadingBar = () => {
+    setProgress(0); // Reset progress
+    const progressInterval = setInterval(() => {
+      setProgress((prevProgress) => {
+        if (prevProgress >= 100) {
+          clearInterval(progressInterval); // Stop auto-progress at 100%
+          return 100;
+        }
+        return prevProgress + 10; // Increment progress
+      });
+    }, 300); // Update every 300ms
+  };
+
+  const onLoadDataset = async () => {
+
+    // if (!selectedDataset) return;
+
+    try {
+      setLoading(true); // Show loading overlay
+      showLoadingBar(); // Start progress simulation
+      await insertDatalayerView(id);
+      changeLayer();
+
+      // Simulate a delay for loading (mocked)
+      await new Promise((resolve) => setTimeout(resolve, 4000)); // Simulate a 4-second loading delay
+      console.log('Dataset loaded successfully (mock)');
+    } catch (error) {
+      console.error('Error loading dataset:', error);
+    } finally {
+      setLoading(false); // Ensure loading overlay is hidden
+    }
     };
 
   const CollapsedMetaData = (
@@ -68,6 +98,12 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
           onClick={onLoadDataset}
           data-testid="load-dataset-button"
         >
+        <LoadingModule
+          progress={progress}
+          isVisible={loading}
+          datasetBeingLoaded={name}
+          data-testid="loading-module"
+        />
           {t("load_dataset")}
         </button>
       </div>

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -44,9 +44,6 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   };
 
   const onLoadDataset = async () => {
-
-    // if (!selectedDataset) return;
-
     try {
       setLoading(true); // Show loading overlay
       showLoadingBar(); // Start progress simulation

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -10,49 +10,13 @@ import MapMetaData from './components/MapMetaData';
 import { I18nextProvider } from 'react-i18next';
 import i18n from './resources/i18n';
 import './layout.css';
-import LoadingModule from './components/LoadingModule';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [loading, setLoading] = useState(false);
-  const [progress, setProgress] = useState(0);
   const [selectedDataset, setSelectedDataset] = useState<DatasetMetadata | null>(null);
-  const [errorMessage, setErrorMessage] = useState("");
-
-  // Function to show loading bar with progress
-  const showLoadingBar = () => {
-    setProgress(0); // Reset progress
-    const progressInterval = setInterval(() => {
-      setProgress((prevProgress) => {
-        if (prevProgress >= 100) {
-          clearInterval(progressInterval); // Stop auto-progress at 100%
-          return 100;
-        }
-        return prevProgress + 10; // Increment progress
-      });
-    }, 300); // Update every 300ms
-  };
 
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: DatasetMetadata) => {
     setSelectedDataset(dataset); // Just update the selected dataset
-  };
-
-  // Handle dataset loading from MapMetaData
-  const handleLoadDataset = async () => {
-    if (!selectedDataset) return;
-
-    try {
-      setLoading(true); // Show loading overlay
-      showLoadingBar(); // Start progress simulation
-
-      // Simulate a delay for loading (mocked)
-      await new Promise((resolve) => setTimeout(resolve, 4000)); // Simulate a 4-second loading delay
-      console.log('Dataset loaded successfully (mock)');
-    } catch (error) {
-      console.error('Error loading dataset:', error);
-    } finally {
-      setLoading(false); // Ensure loading overlay is hidden
-    }
   };
 
   return (
@@ -62,11 +26,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <body>
             <SettingsPanel />
             <div className="layout-container relative">
-              <LoadingModule
-                progress={progress}
-                isVisible={loading}
-                datasetBeingLoaded={selectedDataset?.name}
-              />
+              
               <main className="app-main">{children}</main>
               <AvailableDatasets onDatasetClick={handleDatasetClick} />
               <MapView />
@@ -79,7 +39,6 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
                   format={selectedDataset.format}
                   processes={selectedDataset.processes}
                   datasetSource={selectedDataset.datasetSource}
-                  onLoadDataset={handleLoadDataset}
                 />
               )}
               <footer className="app-footer"></footer>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+# version: '3.8'
 
 services:
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# version: '3.8'
+version: '3.8'
 
 services:
   backend:


### PR DESCRIPTION
Summary:

We had two separate implementations for the method handling the load dataset button click. This caused the dev and prod environments to behave differently.

Changes made:
- Moved the loading module to MapMetadata component from layout
- Implemented one single handle function for load dataset button click

Testing Instruction:
- Run the application in either prod of dev environments
- Ensure that behaviour is the same for both when clicking on load dataset button under metadata component.