### PR TITLE
#189 - fix: [Bug]: Metadata container stays open after factory reset with previous dataset information

### DIFF
--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import MapMetaData from '../src/app/components/MapMetaData';
 import { render, fireEvent, act } from '@testing-library/react';
-
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useState: jest.fn()
-}));
+import { insertDatalayerView, fetchItems } from '../src/app/services/api';
+import { changeLayer } from '../src/app/components/MapView';
+import { useMapLayerContext } from '../src/app/components/MapContext';
 
 jest.mock('../src/app/services/api', () => ({
   insertDatalayerView: jest.fn(),
+  fetchItems: jest.fn(),
 }));
 
 jest.mock('../src/app/components/MapView', () => ({
@@ -18,131 +17,69 @@ jest.mock('../src/app/components/MapView', () => ({
 
 jest.mock('../src/app/components/MapContext', () => ({
   useMapLayerContext: jest.fn(() => ({
-    layer: "default",
-    mapRef: { current: null },
+    mapRef: { current: {} },
+    setDataItems: jest.fn(),
+    dataItems: [],
   })),
 }));
 
-describe(MapMetaData, () => {
-  let setStateMock: any;
-  const mockOnLoadDataset = jest.fn();
-
+describe('MapMetaDataCompleteCoverage', () => {
   beforeEach(() => {
-    setStateMock = jest.fn();
-    jest.spyOn(React, 'useState').mockImplementation(() => [false, setStateMock]);
+    jest.clearAllMocks();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
-  it("meta data displays dataset name prop", () => {
-    const { getByTestId } = render(<MapMetaData name='Dataset1' onLoadDataset={mockOnLoadDataset} />);
-    expect(getByTestId("name-div").textContent).toEqual("Dataset1");
+  it('does not render if visible is false', () => {
+    const { container } = render(<MapMetaData onLoadDataset={jest.fn()} onClose={jest.fn()} visible={false} />);
+    expect(container.firstChild).toBeNull();
   });
 
-  it("meta data displays description prop", () => {
-    const { getByTestId } = render(<MapMetaData description='Desc' onLoadDataset={mockOnLoadDataset} />);
-    expect(getByTestId("dataset-description").textContent).toEqual("Desc");
+  it('renders and toggles collapse', () => {
+    const { getByTestId, queryByTestId } = render(
+      <MapMetaData name='TestName' description='TestDesc' format='CSV' processes='Proc'
+                   datasetSource='DataSrc' visible={true} onLoadDataset={jest.fn()} onClose={jest.fn()} />
+    );
+    expect(getByTestId('name-div').textContent).toBe('TestName');
+    fireEvent.click(getByTestId('name-div'));
+    expect(getByTestId('collapsedMetaData')).toBeInTheDocument();
+    fireEvent.click(getByTestId('collapsedMetaData'));
+    expect(queryByTestId('collapsedMetaData')).toBeNull();
   });
 
-  it("meta data displays format prop", () => {
-    const { getByTestId } = render(<MapMetaData format='CSV' onLoadDataset={mockOnLoadDataset} />);
-    expect(getByTestId("dataset-format").textContent).toEqual("CSV");
-  });
-
-  it("meta data displays processes prop", () => {
-    const { getByTestId } = render(<MapMetaData processes='Process' onLoadDataset={mockOnLoadDataset} />);
-    expect(getByTestId("dataset-processes").textContent).toEqual("Process");
-  });
-
-  it("meta data displays datasetSource prop", () => {
-    const { getByTestId } = render(<MapMetaData datasetSource='Source' onLoadDataset={mockOnLoadDataset} />);
-    expect(getByTestId("dataset-datasource").textContent).toEqual("Source");
-  });
-
-  it("metadata box collapses when isCollapsed = false", () => {
-    setStateMock = jest.fn();
-    jest.spyOn(React, 'useState').mockImplementation(() => [true, setStateMock]);
-    const { getByTestId } = render(<MapMetaData onLoadDataset={mockOnLoadDataset} />);
-    expect(getByTestId("collapsedMetaData")).toBeInTheDocument();
-  });
-
-  it("calls showLoadingBar and increments progress until it reaches 100", async () => {
-    jest.useFakeTimers();
-
-    let progressState = 0;
-    const setProgressMock = jest.fn((updateFn) => {
-      if (typeof updateFn === "function") {
-        progressState = updateFn(progressState);
-      } else {
-        progressState = updateFn;
-      }
+  it('calls onLoadDataset successfully and covers loading bar', async () => {
+    (insertDatalayerView as jest.Mock).mockResolvedValue({});
+    (fetchItems as jest.Mock).mockResolvedValue([{ id: '1' }]);
+    const setDataItemsMock = jest.fn();
+    (useMapLayerContext as jest.Mock).mockReturnValue({
+      mapRef: { current: {} },
+      setDataItems: setDataItemsMock,
+      dataItems: [],
     });
-
-    jest.spyOn(React, "useState")
-      .mockImplementationOnce(() => [false, jest.fn()])
-      .mockImplementationOnce(() => [false, jest.fn()])
-      .mockImplementationOnce(() => [progressState, setProgressMock]);
-
-    const { getByTestId } = render(<MapMetaData id="123" onLoadDataset={mockOnLoadDataset} />);
-    const loadButton = getByTestId("load-dataset-button");
-
-    await act(async () => {
-      fireEvent.click(loadButton);
-    });
-
-    // Simulate the progress updates over time
-    for (let i = 0; i < 10; i++) {
+    const { getByTestId } = render(<MapMetaData id='123' visible={true} onLoadDataset={jest.fn()} onClose={jest.fn()} />);
+    fireEvent.click(getByTestId('load-dataset-button'));
+    for (let i = 0; i < 15; i++) {
       jest.advanceTimersByTime(300);
-      await act(async () => {
-        // Empty function to satisfy ESLint
-      });
+      await act(async () => {});
     }
-
-    // Ensure `setProgress` was called multiple times (progress is updating)
-    expect(setProgressMock).toHaveBeenCalledTimes(11);
-    expect(progressState).toBe(100);
-
-    jest.useRealTimers();
+    expect(insertDatalayerView).toHaveBeenCalledWith('123');
+    expect(changeLayer).toHaveBeenCalled();
+    expect(fetchItems).toHaveBeenCalledWith('123');
+    expect(setDataItemsMock).toHaveBeenCalledWith([{ id: '1' }]);
   });
 
-  it("handles errors in onLoadDataset gracefully", async () => {
-    jest.useFakeTimers();
-
-    // Mock error in insertDatalayerView
-    const errorMock = new Error("API failure");
-    const insertDatalayerViewMock = require("../src/app/services/api").insertDatalayerView;
-    insertDatalayerViewMock.mockRejectedValue(errorMock);
-
-    const setLoadingMock = jest.fn();
-    const setProgressMock = jest.fn();
-
-    jest.spyOn(React, "useState")
-      .mockImplementationOnce(() => [false, jest.fn()])
-      .mockImplementationOnce(() => [false, setLoadingMock])
-      .mockImplementationOnce(() => [0, setProgressMock]);
-
-    const { getByTestId } = render(<MapMetaData id="123" onLoadDataset={mockOnLoadDataset} />);
-    const loadButton = getByTestId("load-dataset-button");
-
-    await act(async () => {
-      fireEvent.click(loadButton);
-    });
-
-    // Advance time to trigger progress bar updates
+  it('handles onLoadDataset error path fully', async () => {
+    const errorMock = new Error('API failure');
+    (insertDatalayerView as jest.Mock).mockRejectedValue(errorMock);
+    const { getByTestId } = render(
+      <MapMetaData id='123' visible={true} onLoadDataset={jest.fn()} onClose={jest.fn()} />
+    );
+    fireEvent.click(getByTestId('load-dataset-button'));
     jest.advanceTimersByTime(4000);
-    await act(async () => {
-      // Empty function to satisfy ESLint
-    });
-
-    // Check if the error was logged and loading state was reset
-    expect(insertDatalayerViewMock).toHaveBeenCalledWith("123");
-    expect(setLoadingMock).toHaveBeenCalledWith(true);
-    expect(setLoadingMock).toHaveBeenCalledWith(false);
-    expect(setProgressMock).toHaveBeenCalled();
-
-    jest.useRealTimers();
+    await act(async () => {});
+    expect(insertDatalayerView).toHaveBeenCalledWith('123');
   });
 });

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -18,7 +18,7 @@ interface MapMetaDataProps {
   datasetSource?: string;
   onLoadDataset: () => Promise<void>;
   onClose: () => void;
-  visible: boolean; // Add visible prop
+  visible: boolean;
 }
 
 const MapMetaData: React.FC<MapMetaDataProps> = ({

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from "react";
-import "../styles/MapMetaData.css";
-import { IoInformationCircle } from "react-icons/io5";
-import { useTranslation } from "react-i18next";
-import { fetchItems, insertDatalayerView } from "../services/api";
+import React, { useState } from 'react';
+import '../styles/MapMetaData.css';
+import { IoInformationCircle } from 'react-icons/io5';
+import { RiCollapseDiagonalFill } from 'react-icons/ri';
+import { useTranslation } from 'react-i18next';
+import { fetchItems, insertDatalayerView } from '../services/api';
 import { changeLayer } from './MapView';
 import { useMapLayerContext } from './MapContext';
-import LoadingModule from "./LoadingModule";
+import LoadingModule from './LoadingModule';
 import { Map } from 'ol';
 
 interface MapMetaDataProps {
@@ -16,15 +17,18 @@ interface MapMetaDataProps {
   processes?: string;
   datasetSource?: string;
   onLoadDataset: () => Promise<void>;
+  onClose: () => void;
+  visible: boolean; // Add visible prop
 }
 
 const MapMetaData: React.FC<MapMetaDataProps> = ({
-  id="",
-  name = "",
-  description = "",
-  format = "",
-  processes = "",
-  datasetSource = "",
+  id = '',
+  name = '',
+  description = '',
+  format = '',
+  processes = '',
+  datasetSource = '',
+  visible,
 }) => {
   const { t } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -57,8 +61,8 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       changeLayer(map);
 
       //Adding the items retrieved from the collection to the context (this is the endpoint that the loading bar will be waiting for)
-      const items = await fetchItems(id)
-      setDataItems(items)
+      const items = await fetchItems(id);
+      setDataItems(items);
 
       // Simulate a delay for loading (mocked)
       await new Promise((resolve) => setTimeout(resolve, 4000)); // Simulate a 4-second loading delay
@@ -68,7 +72,9 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
     } finally {
       setLoading(false); // Ensure loading overlay is hidden
     }
-    };
+  };
+
+  if (!visible) return null; // Return null if not visible
 
   const CollapsedMetaData = (
     <div
@@ -77,26 +83,39 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       onClick={toggleCollapse}
     >
       <IoInformationCircle size={36} fill="white" />
-      <span className="collapsed-name">{t("metadata")}</span>
+      <span className="collapsed-name">{t('metadata')}</span>
     </div>
   );
 
   const NonCollapsedMetaData = (
     <div className="metadata-container">
       <div className="header" onClick={toggleCollapse} data-testid="name-div">
-        {name || t("unknown_name")}
+        {name || t('unknown_name')}
+        <RiCollapseDiagonalFill size={20} />
       </div>
       <div className="content">
         {[
-          { label: t("description"), value: description, testId: "dataset-description" },
-          { label: t("format"), value: format, testId: "dataset-format" },
-          { label: t("processes"), value: processes, testId: "dataset-processes" },
-          { label: t("dataset_source"), value: datasetSource, testId: "dataset-datasource" },
+          {
+            label: t('description'),
+            value: description,
+            testId: 'dataset-description',
+          },
+          { label: t('format'), value: format, testId: 'dataset-format' },
+          {
+            label: t('processes'),
+            value: processes,
+            testId: 'dataset-processes',
+          },
+          {
+            label: t('dataset_source'),
+            value: datasetSource,
+            testId: 'dataset-datasource',
+          },
         ].map(({ label, value, testId }) => (
           <div className="data-row" key={label}>
             <div className="label">{label}:</div>
             <div className="value" data-testid={testId}>
-              {value || t("n_a")}
+              {value || t('n_a')}
             </div>
           </div>
         ))}
@@ -105,13 +124,13 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
           onClick={onLoadDataset}
           data-testid="load-dataset-button"
         >
-        <LoadingModule
-          progress={progress}
-          isVisible={loading}
-          datasetBeingLoaded={name}
-          data-testid="loading-module"
-        />
-          {t("load_dataset")}
+          <LoadingModule
+            progress={progress}
+            isVisible={loading}
+            datasetBeingLoaded={name}
+            data-testid="loading-module"
+          />
+          {t('load_dataset')}
         </button>
       </div>
     </div>

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -23,9 +23,10 @@ import { getConfig, saveConfig } from '../services/configApi';
 
 const MySwal = withReactContent(Swal);
 
-const SettingsPanel: React.FC<{ refreshDatasets: () => void }> = ({
-  refreshDatasets,
-}) => {
+const SettingsPanel: React.FC<{
+  refreshDatasets: () => void;
+  setMetadataVisible: (visible: boolean) => void;
+}> = ({ refreshDatasets, setMetadataVisible }) => {
   const { t, i18n } = useTranslation();
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
@@ -74,7 +75,10 @@ const SettingsPanel: React.FC<{ refreshDatasets: () => void }> = ({
       setLanguageInitialized(true);
 
       // Check if endpoint is "No endpoint saved" and prompt user to enter a new one
-      if (config.endpoint === 'No endpoint saved' || config.endpoint === undefined) {
+      if (
+        config.endpoint === 'No endpoint saved' ||
+        config.endpoint === undefined
+      ) {
         await promptForEndpoint(
           refreshDatasets,
           t,
@@ -198,6 +202,7 @@ const SettingsPanel: React.FC<{ refreshDatasets: () => void }> = ({
             getConfig,
             saveConfig,
           );
+          setMetadataVisible(false); // Hide metadata container
         } catch (error: any) {
           toast.error(error.message);
         }
@@ -239,7 +244,7 @@ const SettingsPanel: React.FC<{ refreshDatasets: () => void }> = ({
         cancelButtonColor: '#d33',
         showCancelButton: true,
         confirmButtonText: t('save'),
-        cancelButtonText: t('cancel')
+        cancelButtonText: t('cancel'),
       });
 
       if (inputResult.isConfirmed) {
@@ -377,7 +382,11 @@ const SettingsPanel: React.FC<{ refreshDatasets: () => void }> = ({
               <PiArrowClockwiseFill size={24} />
               {t('reset')}
             </button>
-            <button onClick={handleFactoryReset} data-testid="factory-reset-button" style={{ color: '#dc143c' }}>
+            <button
+              onClick={handleFactoryReset}
+              data-testid="factory-reset-button"
+              style={{ color: '#dc143c' }}
+            >
               <IoTrashOutline size={24} fill="red" />
               {t('factory_reset')}
             </button>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import React, { useState } from 'react';
 import MapView from './components/MapView';
 import Sidebar from './components/Sidebar';
@@ -17,6 +15,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [progress, setProgress] = useState(0);
   const [selectedDataset, setSelectedDataset] = useState<DatasetMetadata | null>(null);
   const [refreshKey, setRefreshKey] = useState(0); // Add state for refresh key
+  const [isMetadataVisible, setMetadataVisible] = useState(false); // Add state for metadata visibility
 
   // Function to show loading bar with progress
   const showLoadingBar = () => {
@@ -35,6 +34,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: DatasetMetadata) => {
     setSelectedDataset(dataset); // Just update the selected dataset
+    setMetadataVisible(true); // Show metadata container
   };
 
   // Handle dataset loading from MapMetaData
@@ -64,7 +64,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <MapProvider>
         <html lang="en">
         <body>
-        <SettingsPanel refreshDatasets={refreshDatasets} />
+        <SettingsPanel refreshDatasets={refreshDatasets} setMetadataVisible={setMetadataVisible} />
         <div className="layout-container relative">
           <LoadingModule
             progress={progress}
@@ -84,6 +84,8 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
               processes={selectedDataset.processes}
               datasetSource={selectedDataset.datasetSource}
               onLoadDataset={handleLoadDataset}
+              onClose={() => setMetadataVisible(false)}
+              visible={isMetadataVisible} // Pass visibility state
             />
           )}
           <footer className="app-footer"></footer>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 import MapView from './components/MapView';
 import Sidebar from './components/Sidebar';

--- a/apps/frontend/src/app/styles/MapMetaData.css
+++ b/apps/frontend/src/app/styles/MapMetaData.css
@@ -46,6 +46,9 @@
 }
 
 .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   cursor: pointer;
   background-color: #00447E;
   color: #ffffff;


### PR DESCRIPTION
## [Bug] Metadata container stays open after factory reset with previous dataset information

### Demo of fix:
https://github.com/user-attachments/assets/2702f498-9b85-4b0a-8111-ac983a0f29a2

### Addition: 
- added a collapse icon to the metadata container to make it clearer that we can collapse

### Steps to Reproduce:
**1.** Connect to endpoint
**2.** Select a dataset
**3.** Factory reset

**Expected Behavior:** Metadata container should not be visible and shouldn't contain previous dataset. The info should be reset
**Actual Behavior:** Metadata container stays open after factory reset with previous dataset information. 

### Screenshot of defect: 

![Image](https://github.com/user-attachments/assets/c43f2981-2aed-4d2b-abc2-5f871302644d)

