### PR TITLE
#184 - feat(frontend): Added Tile Server as an offline map provider

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+apps/db/data/
+node_modules/
+dist/
+.git/
+.github
+.gitignore
+Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,8 +45,9 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/postgres
           SPRING_DATASOURCE_USERNAME: postgres
           SPRING_DATASOURCE_PASSWORD: password
+          NEXT_PUBLIC_GEOSERVER_URL: http://localhost:8090/geoserver/Default/wms
+          NEXT_PUBLIC_TILESERVER_URL: http://localhost:8081/data/OAM-World-1-8-min-J80
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
-          MAPTILER_API_KEY: ${{ secrets.MAPTILER_API_KEY }}
           CONFIG_FILE_PATH: /var/config/app-config.json
 
       # Push Docker images to Docker Hub

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,19 +23,21 @@ jobs:
           sudo apt-get install -y docker-compose
           docker-compose --version
 
-      # Start PostgreSQL, Backend, and Geoserver using Docker Compose
+      # Start All Required Services (DB, Backend, Geoserver, TileServer)
       - name: Start Services
-        run: docker-compose up -d db backend geoserver
+        run: docker-compose up -d db backend geoserver tileserver-init tileserver
+        env:
+          CONFIG_FILE_PATH: /var/config/app-config.json
 
       # Wait for Database to be Ready using Health Check
       - name: Wait for Database
         run: |
           for i in {1..30}; do
             if docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q -f name=db) | grep -q "healthy"; then
-              echo "Database is ready!";
+              echo "✅ Database is ready!";
               break;
             fi;
-            echo "Waiting for the database...";
+            echo "⏳ Waiting for the database...";
             sleep 5;
           done
 
@@ -44,10 +46,38 @@ jobs:
         run: |
           for i in {1..30}; do
             if docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q -f name=geoserver) | grep -q "healthy"; then
-              echo "Geoserver is ready!";
+              echo "✅ Geoserver is ready!";
               break;
             fi;
-            echo "Waiting for Geoserver...";
+            echo "⏳ Waiting for Geoserver...";
+            sleep 5;
+          done
+
+      # Wait for TileServer Initialization (MBTiles Download)
+      - name: Wait for TileServer Init to Complete
+        run: |
+          for i in {1..30}; do
+            if docker inspect --format='{{json .State.Status}}' $(docker ps -q -f name=tileserver-init) | grep -q "exited"; then
+              echo "✅ TileServer Init completed!";
+              break;
+            fi;
+            echo "⏳ Waiting for TileServer to download MBTiles...";
+            sleep 5;
+          done
+
+      # Start the Frontend Application
+      - name: Start Frontend
+        run: docker-compose up -d frontend
+
+      # Wait for Frontend to be Ready
+      - name: Wait for Frontend
+        run: |
+          for i in {1..30}; do
+            if curl -s http://localhost:3000 | grep -q "<title>"; then
+              echo "✅ Frontend is ready!";
+              break;
+            fi;
+            echo "⏳ Waiting for the frontend to start...";
             sleep 5;
           done
 
@@ -66,14 +96,24 @@ jobs:
         run: npx nx build frontend
         env:
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
+          NEXT_PUBLIC_GEOSERVER_URL: http://localhost:8090/geoserver/Default/wms
+          NEXT_PUBLIC_TILESERVER_URL: http://localhost:8081/data/OAM-World-1-8-min-J80
 
       # Run Cypress for E2E Testing
       - name: Run Cypress E2E Tests
         run: npx nx e2e frontend-e2e
         env:
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
-          CYPRESS_BASE_URL: http://localhost:3000
-          CONFIG_FILE_PATH: /var/config/app-config.json
+          NEXT_PUBLIC_GEOSERVER_URL: http://localhost:8090/geoserver/Default/wms
+          NEXT_PUBLIC_TILESERVER_URL: http://localhost:8081/data/OAM-World-1-8-min-J80
+
+      # Collect logs if tests fail (for debugging)
+      - name: Collect Logs on Failure
+        if: failure()
+        run: |
+          echo "🔍 Collecting logs..."
+          docker-compose logs > docker-logs.txt
+          cat docker-logs.txt
 
       # Post-Test Cleanup
       - name: Cleanup

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,12 @@ jobs:
           sudo apt-get install -y docker-compose
           docker-compose --version
 
+      - name: Fix Permissions for Tileserver on GitHub Runner
+        run: |
+          sudo mkdir -p ./apps/tileserver/layers
+          sudo chmod -R 777 ./apps/tileserver/layers
+          ls -lah ./apps/tileserver/layers
+
       # Start All Required Services (DB, Backend, Geoserver, TileServer)
       - name: Start Services
         run: docker-compose up -d db backend geoserver tileserver-init tileserver

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,22 +71,6 @@ jobs:
             sleep 5;
           done
 
-      # Start the Frontend Application
-      - name: Start Frontend
-        run: docker-compose up -d frontend
-
-      # Wait for Frontend to be Ready
-      - name: Wait for Frontend
-        run: |
-          for i in {1..30}; do
-            if curl -s http://localhost:3000 | grep -q "<title>"; then
-              echo "✅ Frontend is ready!";
-              break;
-            fi;
-            echo "⏳ Waiting for the frontend to start...";
-            sleep 5;
-          done
-
       # Set up Node.js
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,11 +60,11 @@ jobs:
           done
 
       # Wait for TileServer Initialization (MBTiles Download)
-      - name: Wait for TileServer Init to Complete
+      - name: Wait for TileServer
         run: |
           for i in {1..30}; do
-            if docker inspect --format='{{json .State.Status}}' $(docker ps -q -f name=tileserver-init) | grep -q "exited"; then
-              echo "✅ TileServer Init completed!";
+            if docker inspect --format='{{json .State.Health.Status}}' $(docker ps -q -f name=tileserver) | grep -q "healthy"; then
+              echo "✅ TileServer is ready!";
               break;
             fi;
             echo "⏳ Waiting for TileServer to download MBTiles...";

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -24,7 +24,7 @@ RUN npm install --ignore-scripts
 COPY . .
 
 # Remove unnecessary folders to keep only the backend app
-RUN rm -rf apps/frontend apps/frontend-e2e
+RUN rm -rf apps/frontend apps/frontend-e2e apps/geoserver_data apps/tileserver
 
 # Install Nx globally to ensure it's available
 RUN npm install -g nx

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install --ignore-scripts
 COPY . .
 
 # Remove unnecessary folders to keep only the frontend app
-RUN rm -rf apps/backend apps/frontend-e2e
+RUN rm -rf apps/backend apps/frontend-e2e apps/geoserver_data apps/tileserver
 
 # Install Nx globally to ensure it's available
 RUN npm install -g nx

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -3,10 +3,9 @@ import '@testing-library/jest-dom';
 import { act, render } from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 import MapView from '../src/app/components/MapView';
-import { MapProvider, useMapLayerContext } from '../src/app/components/MapContext';
+import { MapProvider } from '../src/app/components/MapContext';
 import Polygon from 'ol/geom/Polygon';
 import ol from 'ol/dist/ol';
-import layer = ol.layer;
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 import MapView from '../src/app/components/MapView';
-import { MapProvider } from '../src/app/components/MapContext';
+import { MapProvider, useMapLayerContext } from '../src/app/components/MapContext';
 import Polygon from 'ol/geom/Polygon';
+import ol from 'ol/dist/ol';
+import layer = ol.layer;
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
@@ -20,12 +22,22 @@ jest.mock('ol/source/XYZ', () => {
 });
 
 jest.mock('ol/layer/Tile', () => {
-  return jest.fn().mockImplementation(() => ({
-    set: jest.fn(), // Ensure `set()` exists
-    get: jest.fn(), // Mock `get()`
-    getSource: jest.fn(), // Mock `getSource()`
-  }));
+  return jest.fn().mockImplementation(() => {
+    const properties: Record<string, any> = {}; // Store layer properties
+
+    return {
+      set: jest.fn((key: string, value: any) => {
+        properties[key] = value; // Store key-value pairs
+      }),
+      get: jest.fn((key: string) => properties[key]), // Retrieve stored values
+      getSource: jest.fn(), // Mock `getSource()`
+      on: jest.fn(), // Mock event handling (e.g., 'tileloaderror')
+      once: jest.fn(), // Mock one-time event handling
+      un: jest.fn(), // Mock event unbinding
+    }
+  });
 });
+
 
 
 jest.mock('ol/View', () => {
@@ -91,6 +103,7 @@ jest.mock('../src/app/components/MapContext', () => ({
     mapRef: { current: null },
     resetView: jest.fn(),
     setIsOnline: jest.fn(),
+    isOnline: true,
   }),
 }));
 
@@ -178,5 +191,45 @@ describe(MapView, () => {
     const { Feature } = require('ol');
     const feature = new Feature();
     expect(feature).toBeInstanceOf(Feature);
+  });
+
+  it('renders the offline layer when isOnline is false', () => {
+    let mockLayersArray: any[] = []; // Simulate an array of layers
+    const mockLayers = {
+      getArray: () => mockLayersArray, // Retrieve layers
+      clear: () => { mockLayersArray.length = 0; }, // Clear layers
+    };
+
+    const mockMap = {
+      getLayers: () => mockLayers,
+      addLayer: jest.fn((layer) => {
+        mockLayersArray.push(layer); // Track added layers
+      }),
+      removeLayer: jest.fn((layer) => {
+        mockLayersArray = mockLayersArray.filter(l => l !== layer);
+      }),
+    };
+
+    // Mock `useRef` to return our mock map
+    jest.spyOn(React, 'useRef').mockReturnValue({ current: mockMap });
+
+    const { useMapLayerContext } = require('../src/app/components/MapContext');
+
+    useMapLayerContext.mockReturnValue({
+      layer: 'default',
+      mapRef: { current: mockMap },
+      setIsOnline: jest.fn(),
+      isOnline: false, // Simulating offline mode
+    });
+
+    // Render inside `act()` to ensure updates are applied
+    act(() => {
+      render(<MapView />);
+    });
+
+    // Ensure `offlineLayer` is added and has `id: 'baseLayer'`
+    const offlineLayer = mockMap.getLayers().getArray().find(layer => layer.get && layer.get('offline') === true);
+    expect(offlineLayer).toBeTruthy(); // ✅ Ensure offline layer is added
+    expect(offlineLayer.get('id')).toBe('baseLayer'); // ✅ Ensure it is set as base layer
   });
 });

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -49,9 +49,7 @@ const topographicLayer = new TileLayer({
 
 // Dynamic Data Layer (STAC Item)
 const createDataLayer = () => {
-  console.log("Creating data layer");
   const geoserverUrl = process.env.NEXT_PUBLIC_GEOSERVER_URL;
-  console.log(geoserverUrl)
   const newLayer = new TileLayer({
     source: new TileWMS({
       url: geoserverUrl,

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -16,6 +16,15 @@ import { verifyInternetConnection } from '../services/api';
 
 const attributions = '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
 
+const tileserverUrl = process.env.NEXT_PUBLIC_TILESERVER_URL;
+
+const offlineLayer = new TileLayer({
+  source: new XYZ({
+    url: `${tileserverUrl}/{z}/{x}/{y}.jpg`,
+    attributions: attributions
+  })
+});
+
 // Base layers
 const defaultLayer = new TileLayer({
   source: new XYZ({
@@ -40,7 +49,9 @@ const topographicLayer = new TileLayer({
 
 // Dynamic Data Layer (STAC Item)
 const createDataLayer = () => {
-  const geoserverUrl = process.env.REACT_APP_GEOSERVER_URL;
+  console.log("Creating data layer");
+  const geoserverUrl = process.env.NEXT_PUBLIC_GEOSERVER_URL;
+  console.log(geoserverUrl)
   const newLayer = new TileLayer({
     source: new TileWMS({
       url: geoserverUrl,
@@ -75,7 +86,7 @@ export const refreshLayer = (map: Map) => {
 const MapView = () => {
   useGeographic();
   const mapElement = useRef(null);
-  const { layer, mapRef, setIsOnline } = useMapLayerContext();
+  const { layer, mapRef, setIsOnline, isOnline } = useMapLayerContext();
 
   const getLayer = (): TileLayer => {
     const layerMap: Record<string, TileLayer> = {
@@ -84,20 +95,22 @@ const MapView = () => {
       default: defaultLayer,
     };
 
+    offlineLayer.set("offline", true);
+
     // Ensure `layer` is always a valid string before accessing the object
-    const selectedLayer = layerMap[layer ?? "default"];
+    const selectedLayer = isOnline ? layerMap[layer ?? "default"] : offlineLayer;
     if (!selectedLayer.get('id')) {
       selectedLayer.set('id', 'baseLayer');
     }
 
     return selectedLayer;
   };
-  
+
   const setOnlineStatus = async () => {
     try {
         const response = await verifyInternetConnection("https://hirondelle.crim.ca/stac/collections");
         setIsOnline(response === "Internet connection established")
-    } 
+    }
     catch (error) {
       setIsOnline(false);
       console.log('No connection to the URL:', error);

--- a/apps/tileserver/layers/download_tiles.sh
+++ b/apps/tileserver/layers/download_tiles.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -e
+
+TILE_DIR="/tileserver"
+MBTILES_FILE="OAM-World-1-8-min-J80.mbtiles"
+DOWNLOAD_URL="https://ftp.gwdg.de/pub/misc/openstreetmap/openandromaps/world/OAM-World-1-8-min-J80.mbtiles"
+
+# Ensure the directory exists
+mkdir -p "$TILE_DIR"
+
+# Check if the MBTiles file already exists
+if [ ! -f "$TILE_DIR/$MBTILES_FILE" ]; then
+    echo "⬇️ Downloading MBTiles file..."
+    curl -o "$TILE_DIR/$MBTILES_FILE" "$DOWNLOAD_URL"
+    echo "✅ Download complete!"
+else
+    echo "✅ MBTiles file already exists, skipping download."
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
   tileserver-init:
     image: curlimages/curl
     container_name: tileserver-init
+    user: root
     volumes:
       - ./apps/tileserver/layers:/tileserver
     entrypoint: [ "/bin/sh", "-c", "sh /tileserver/download_tiles.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,16 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:8080/health || exit 1" ]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: "512M"
+          cpus: "0.5"
 
   frontend:
     build:
@@ -29,15 +39,26 @@ services:
         NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
     environment:
       - NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
-      - MAPTILER_API_KEY=${MAPTILER_API_KEY}
-      - REACT_APP_GEOSERVER_URL=http://localhost:8090/geoserver/Default/wms
+      - NEXT_PUBLIC_GEOSERVER_URL=http://localhost:8090/geoserver/Default/wms
+      - NEXT_PUBLIC_TILESERVER_URL=http://localhost:8081/data/OAM-World-1-8-min-J80
     image: xavierguertin/wildfirevisualization-frontend:latest
     ports:
       - "3000:3000"
     networks:
       - app-network
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:3000 || exit 1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: "256M"
+          cpus: "0.25"
 
   db:
     image: ghcr.io/stac-utils/pgstac:v0.9.2
@@ -59,6 +80,42 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: "1G"
+          cpus: "1"
+
+  tileserver-init:
+    image: curlimages/curl
+    container_name: tileserver-init
+    volumes:
+      - ./apps/tileserver/layers:/tileserver
+    entrypoint: [ "/bin/sh", "-c", "sh /tileserver/download_tiles.sh" ]
+    networks:
+      - app-network
+
+  tileserver:
+    image: maptiler/tileserver-gl
+    container_name: tileserver
+    restart: always
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./apps/tileserver/layers:/data
+    depends_on:
+      tileserver-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: curl --fail http://localhost:8080 || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: "512M"
+          cpus: "0.5"
 
   geoserver:
     image: kartoza/geoserver:latest
@@ -81,6 +138,11 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: "1G"
+          cpus: "1"
 
 networks:
   app-network:


### PR DESCRIPTION
Summary:
This update proposes an alternative approach to handling offline layers by leveraging TileServer GL instead of storing and converting WMS layers. The goal is to enable a lightweight offline map with low storage requirements (~300MB) and a zoom scale of 1-8, ensuring seamless offline functionality.

Changes:
Backend:
Create a script to download a .mbtiles map in the user's local machine.
Load pre-generated map in TileServer GL.
Modify the database configuration to point to the locally stored tile files on startup.
Frontend:
Update map rendering logic to pull layers from TileServer GL instead of online map provider.
Modify UI components to recognize and display offline layers seamlessly.
Ensure that dataset selections and overlays remain functional with the new setup.
Testing:
Verify that maps load correctly from offline storage without an internet connection. (Using docker compose up tileserver-init tilesever)
Once offline (no internet), refresh page and application will go offline mode (Look at work from #193)
Ensure smooth interaction across all zoom levels (1-8).
Test fallback behavior in case of missing or corrupted map tiles.

This approach could reduce storage complexity while maintaining essential offline capabilities.
Also, updated CI/CD to reflect changes with new services.