### PR TITLE
#0 - chore(db): Default 5432 port conflicting with other local DBs. Update to 5433.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,9 @@ jobs:
         run: docker-compose up -d db backend geoserver tileserver-init tileserver
         env:
           CONFIG_FILE_PATH: /var/config/app-config.json
+          SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/postgres
+          SPRING_DATASOURCE_USERNAME: postgres
+          SPRING_DATASOURCE_PASSWORD: password
 
       # Wait for Database to be Ready using Health Check
       - name: Wait for Database

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=backend
 logging.config=classpath:log4j2-spring.xml
 
-spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/postgres}
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5433/postgres}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME:postgres}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:password}
 spring.datasource.driver-class-name=org.postgresql.Driver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       PGPASSWORD: password
       PGDATABASE: postgres
     ports:
-      - "5432:5432"
+      - "5433:5432"
     networks:
       - app-network
     volumes:


### PR DESCRIPTION
MAINTENANCE

#### **Summary:**  
This update changes the default PostgreSQL port from **5432 to 5433** to prevent conflicts with other local database instances running on the same machine. This ensures seamless **development** without requiring users to manually stop existing PostgreSQL services.  

#### **Changes:**  
🔹 **Backend:**  
- Updated `docker-compose.yml` to set PostgreSQL service to use port **5433** instead of **5432**.  ONLY EXTERNAL PORT
- Modified any database connection settings that referenced the old port.  

🔹 **Frontend & CI/CD:**  
- Updated `.env` or configuration files where necessary to ensure compatibility.  
- Ensured the pipeline correctly connects to the new database port during tests.  

#### **Testing:**  
 Verify that the database starts up correctly on port **5433** with `docker compose up db`.  
 Ensure existing database connections are updated to reflect the new port.  
 Check that the application successfully connects to the database after the change.  
