### PR TITLE
#222 - fix(tileserver-init): Adding gitattributes 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,6 @@ node_modules/
 yarn.lock
 
 # Git specific files
-.gitattributes
 .gitmodules
 .gitconfig
 


### PR DESCRIPTION
#### **Summary**  
This PR resolves an issue where the `tileserver-init` script (`download_tiles.sh`) was being converted to Windows-style line endings (`CRLF`) when pulled on Windows machines. This caused execution failures inside the Docker container due to incorrect line formatting.  

#### **Changes**  
- **Added `.gitattributes`** to enforce LF (`\n`) line endings for all `.sh` scripts.  
- **Forced Git to reapply correct line endings** by removing and re-adding the script.  
- **Verified the fix by deleting and restoring the script** after applying `.gitattributes`.  
- **Confirmed `tileserver-init` now runs successfully** inside Docker without errors.  

#### **Testing**  
- Deleted the script locally and restored it with `git checkout -- apps/tileserver/layers/download_tiles.sh`.  
- Checked the file type using `file apps/tileserver/layers/download_tiles.sh` to confirm LF line endings.  
- Ran `docker-compose up tileserver-init`, which executed correctly and detected that the MBTiles file already existed.  
