### PR TITLE
#227 - fix(deployment): Added dependency for health check for backend and fix deployment

### DIFF
--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -57,6 +57,12 @@
       <artifactId>spring-jdbc</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+
     <!-- Lombok -->
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -11,3 +11,5 @@ spring.datasource.hikari.maximum-pool-size=5
 spring.datasource.hikari.minimum-idle=1
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
+
+management.endpoints.web.exposure.include=health

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,10 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8080/health || exit 1" ]
+      test: [ "CMD-SHELL", "curl -f http://localhost:8080/actuator/health || exit 1" ]
       interval: 20s
       timeout: 10s
-      retries: 5
+      retries: 10
     deploy:
       resources:
         limits:


### PR DESCRIPTION
#### **Summary**  
This PR resolves an issue where the backend health check was incorrectly marking the service as unhealthy, preventing the frontend from starting. Additionally, a missing dependency has been added to ensure the health check endpoint is available.  

#### **Changes**  
 **Updated backend health check endpoint**  
- Changed from `curl -f http://localhost:8080/health` to `curl -f http://localhost:8080/actuator/health` (Spring Boot standard).  

 **Added missing dependency for health check**  
- Included **Spring Boot Actuator** in the backend to expose `/actuator/health`.  

 **Increased health check retries & interval**  
- Adjusted `retries` from `5` → `10` to allow more time for backend startup.  

 **Validated network resolution inside Docker**  
- Confirmed `curl` correctly reaches the backend within the container.  

#### **Testing**  
- **Ran `docker-compose up backend frontend` and verified:**  
  - Backend is correctly marked as healthy.  
  - Frontend starts successfully.  
- **Manually tested health check with:**  
  ```sh
  docker exec -it <backend-container-id> curl -f http://localhost:8080/actuator/health
  ```
  -  Returns HTTP 200 when backend is running.  
  -  Prevents unnecessary health check failures in CI/CD.  



Tested it and it works:
![image](https://github.com/user-attachments/assets/8f716031-7357-4c7a-b694-643016bce5c3)
