### PR TITLE
#233 - refactor(offline): Refactor Offline Mode

### DIFF
--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -295,25 +295,6 @@ describe(MapView, () => {
     expect(mockView.on).toHaveBeenCalled();
   });
 
-  it('calls verifyInternetConnection on mount', async () => {
-    const mockOnBboxChange = jest.fn();
-    const verifyInternetConnectionMock = jest.spyOn(
-      require('../src/app/services/api'),
-      'verifyInternetConnection',
-    );
-
-    render(
-      <MapProvider>
-        <MapView onBboxChange={mockOnBboxChange} />
-      </MapProvider>,
-    );
-
-    // Ensure `verifyInternetConnection` was called
-    expect(verifyInternetConnectionMock).toHaveBeenCalledWith(
-      'https://hirondelle.crim.ca/stac/collections',
-    );
-  });
-
   it('initializes the map with the correct layers', () => {
     const mockOnBboxChange = jest.fn();
 
@@ -376,7 +357,7 @@ describe(MapView, () => {
 
     useMapLayerContext.mockReturnValue(contextMock);
 
-    const { rerender } = render(
+    render(
       <MapProvider>
         <MapView onBboxChange={mockOnBboxChange} />
       </MapProvider>,
@@ -387,11 +368,6 @@ describe(MapView, () => {
 
     // Simulate offline mode
     contextMock.isOnline = false;
-    rerender(
-      <MapProvider>
-        <MapView onBboxChange={mockOnBboxChange} />
-      </MapProvider>,
-    );
 
     expect(mapMock.addLayer).toHaveBeenCalledTimes(1);
     expect(contextMock.isOnline).toBe(false);
@@ -442,80 +418,5 @@ describe(MapView, () => {
 
     // Expect `onBboxChange` to have been triggered zero times since toggle is off
     expect(mockOnBboxChange).toHaveBeenCalledTimes(0);
-  });
-
-  describe('MapView Extended Coverage', () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      global.console.debug = jest.fn();
-      global.console.warn = jest.fn();
-
-      // Create a proper Map mock with getView implemented
-      const mockMap = {
-        getView: jest.fn().mockReturnValue({
-          calculateExtent: jest.fn().mockReturnValue([0, 0, 100, 100]),
-          on: jest.fn()
-        }),
-        getSize: jest.fn().mockReturnValue([800, 600]),
-        getLayers: jest.fn().mockReturnValue({
-          getArray: jest.fn().mockReturnValue([])
-        }),
-        addLayer: jest.fn(),
-        removeLayer: jest.fn()
-      };
-
-      // Update the Map constructor mock
-      const Map = require('ol/Map');
-      Map.mockImplementation(() => mockMap);
-    });
-
-
-    it('handles internet connection failure', async () => {
-      const mockOnBboxChange = jest.fn();
-      const { verifyInternetConnection } = require('../src/app/services/api');
-
-      // Mock connection failure
-      verifyInternetConnection.mockRejectedValueOnce(new Error('Connection failed'));
-
-      const mockSetIsOnline = jest.fn();
-      const { useMapLayerContext } = require('../src/app/context/MapContext');
-      useMapLayerContext.mockReturnValue({
-        layer: 'default',
-        setLayer: jest.fn(),
-        mapRef: {
-          current: {
-            getView: jest.fn().mockReturnValue({
-              calculateExtent: jest.fn().mockReturnValue([0, 0, 0, 0]),
-              on: jest.fn()
-            }),
-            getSize: jest.fn().mockReturnValue([800, 600]),
-            getLayers: jest.fn().mockReturnValue({
-              getArray: jest.fn().mockReturnValue([])
-            }),
-            addLayer: jest.fn(),
-            removeLayer: jest.fn()
-          }
-        },
-        resetView: jest.fn(),
-        setIsOnline: mockSetIsOnline,
-        isOnline: true,
-        sliderValue: 0,
-        setSliderValue: jest.fn(),
-        timeStamps: [],
-        setTimeStamps: jest.fn(),
-      });
-
-      render(
-        <MapProvider>
-          <MapView onBboxChange={mockOnBboxChange} />
-        </MapProvider>
-      );
-
-      // Wait for the async function to complete
-      await waitFor(() => {
-        expect(mockSetIsOnline).toHaveBeenCalledWith(false);
-        expect(console.warn).toHaveBeenCalledWith('No internet connection detected.');
-      });
-    });
   });
 });

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -1,5 +1,5 @@
 // SettingsPanel.test.tsx
-import React, {useEffect} from 'react';
+import React from 'react';
 import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SettingsPanel from '../src/app/components/SettingsPanel';
@@ -87,10 +87,11 @@ describe('SettingsPanel Component', () => {
     localStorage.clear();
   });
 
-  it('renders the three dropdown buttons (settings, language, reset)', async () => {
+  it('renders the four dropdown buttons (settings, language, internet reset)', async () => {
     await renderSettingsPanel();
     expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /language/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /internet/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
   });
 
@@ -294,47 +295,38 @@ describe('SettingsPanel Component', () => {
     });
   });
 
-  describe('Offline Behavior', () => {
-    it('Internet button is not visible when online', () => {
-      const OnlineComponent = () => {
-        const { setIsOnline } = useMapLayerContext();
-        useEffect(() => {
-          setIsOnline(true);
-      }, [setIsOnline]);
-        return <></>;
-      };
+  describe('Offline Mode Dropdown', () => {
+    it('opens the offline mode dropdown and allows the user to select a mode', async () => {      
+      await renderSettingsPanel();
 
-      const TestComponent = () => (
-        <MapProvider>
-          <SettingsPanel refreshDatasets={jest.fn} setMetadataVisible={jest.fn} />
-          <OnlineComponent />
-        </MapProvider>
-      );
+      const internetButton = screen.getByRole('button', { name: /internet/i });
+      await act(async () => {
+        fireEvent.click(internetButton);
+      });
+      expect(internetButton).toHaveClass('active');
 
-      render(<TestComponent />);
-      expect(screen.queryByRole('button', { name: /internet/i })).not.toBeInTheDocument();
+      // Verify modes
+      const onlineOption = screen.getByText('online');
+      const offlineOption = screen.getByText('offline');
+      expect(onlineOption).toBeInTheDocument();
+      expect(offlineOption).toBeInTheDocument();
+
+      // Select offline
+      await act(async () => {
+        fireEvent.click(offlineOption);
+      });
+      expect(screen.getByTestId('offline-icon')).toBeInTheDocument();
+
+      // Re-open dropdown and select online.
+      await act(async () => {
+        fireEvent.click(internetButton);
+      });
+      const newOnlineOption = screen.getByText('online');
+      await act(async () => {
+        fireEvent.click(newOnlineOption);
+      });
+      expect(screen.getByTestId('online-icon')).toBeInTheDocument();
     });
-
-    it('Internet button is visible when offline', () => {
-      const OnlineComponent = () => {
-        const { setIsOnline } = useMapLayerContext();
-        useEffect(() => {
-          setIsOnline(false);
-        }, [setIsOnline])
-        return <></>;
-      };
-
-      const TestComponent = () => (
-        <MapProvider>
-          <SettingsPanel refreshDatasets={jest.fn} setMetadataVisible={jest.fn} />
-          <OnlineComponent />
-        </MapProvider>
-      );
-
-      render(<TestComponent />);
-      expect(screen.queryByRole('button', { name: /internet/i })).toBeInTheDocument();
-    });
-
   });
 
   describe('Language Configuration', () => {
@@ -468,34 +460,6 @@ describe('SettingsPanel Component', () => {
       expect(resetItems).toHaveBeenCalled();
     });
   });
-
-  describe('Internet Connection Display', () => {
-    it('shows internet status when internet dropdown is clicked', async () => {
-      const OfflineComponent = () => {
-        const { setIsOnline } = useMapLayerContext();
-        useEffect(() => {
-          setIsOnline(false);
-        }, [setIsOnline])
-        return <></>;
-      };
-
-      render(
-        <MapProvider>
-          <SettingsPanel refreshDatasets={jest.fn()} setMetadataVisible={jest.fn()} />
-          <OfflineComponent />
-        </MapProvider>
-      );
-
-      const internetButton = await screen.findByTestId('internet-dropdown-button');
-      await act(async () => {
-        fireEvent.click(internetButton);
-      });
-
-      const noInternetMessage = await screen.findByTestId('internet-button');
-      expect(noInternetMessage).toHaveTextContent('no_internet_access');
-    });
-  });
-
 
   describe('Endpoint Prompt Flow', () => {
     it('handles confirmed input in promptForEndpoint', async () => {

--- a/apps/frontend/__tests__/TestSidebarComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSidebarComponent.spec.tsx
@@ -102,10 +102,10 @@ describe('Test Sidebar component', () => {
 
       fireEvent.click(screen.getByAltText('topographical_layer'));
       expect(screen.getByTestId('current-layer')).toHaveTextContent('default');
-      expect(toast.error).toHaveBeenCalledWith('view_disabled - no_internet_access', {"toastId": "view-disabled"});
+      expect(toast.error).toHaveBeenCalledWith('disabled - no_internet_access', {"toastId": "online-disabled"});
 
       fireEvent.click(screen.getByAltText('satellite_layer'));
       expect(screen.getByTestId('current-layer')).toHaveTextContent('default');
-      expect(toast.error).toHaveBeenCalledWith('view_disabled - no_internet_access', {"toastId": "view-disabled"});
+      expect(toast.error).toHaveBeenCalledWith('disabled - no_internet_access', {"toastId": "online-disabled"});
   });
 });

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -52,9 +52,16 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   };
 
   const MySwal = withReactContent(Swal);
-  const { setTimeStamps } = useMapLayerContext();
+  const { setTimeStamps, isOnline } = useMapLayerContext();
 
   const onLoadDataset = async () => {
+    if(!isOnline){
+      toast.error(`${t('disabled')} - ${t('no_internet_access')}`, {
+        toastId: 'online-disabled',
+      });
+      return;
+    }
+    
     try {
       MySwal.fire({
         title: t('reset'),

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -31,6 +31,7 @@ const offlineLayer = new TileLayer({
     url: OFFLINE_LAYER_URL,
     attributions: attributions,
   }),
+  zIndex: -10,
 });
 
 // Default base layers
@@ -39,6 +40,7 @@ const defaultLayer = new TileLayer({
     url: DEFAULT_LAYER_URL,
     attributions: attributions,
   }),
+  zIndex: -10,
 });
 
 const satelliteLayer = new TileLayer({
@@ -46,6 +48,7 @@ const satelliteLayer = new TileLayer({
     url: SATELLITE_LAYER_URL,
     attributions: attributions,
   }),
+  zIndex: -10,
 });
 
 const topographicLayer = new TileLayer({
@@ -53,6 +56,7 @@ const topographicLayer = new TileLayer({
     url: TOPOGRAPHIC_LAYER_URL,
     attributions: attributions,
   }),
+  zIndex: -10,
 });
 
 /**

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -10,7 +10,6 @@ import { useGeographic } from 'ol/proj.js';
 import { useMapLayerContext } from '../context/MapContext';
 import XYZ from 'ol/source/XYZ';
 import Footer from './Footer';
-import { verifyInternetConnection } from '../services/api';
 import debounce from 'lodash/debounce';
 import VectorLayer from 'ol/layer/Vector';
 import VectorSource from 'ol/source/Vector';
@@ -148,7 +147,7 @@ interface MapViewProps {
 const MapView = ({ onBboxChange }: MapViewProps) => {
   useGeographic();
   const mapElement = useRef(null);
-  const { layer, mapRef, setIsOnline, isOnline } = useMapLayerContext();
+  const { layer, mapRef, isOnline } = useMapLayerContext();
 
   /**
    * Determines which base layer to use based on network connectivity.
@@ -174,23 +173,8 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
 
     return selectedLayer;
   };
-
-  /**
-   * Checks internet connectivity by verifying a connection to a remote STAC server.
-   */
-  const setOnlineStatus = async () => {
-    try {
-      const response = await verifyInternetConnection(DEFAULT_ENDPOINT_URL);
-      setIsOnline(response === 'Internet connection established');
-    } catch (error) {
-      setIsOnline(false);
-      console.warn('No internet connection detected.');
-    }
-  };
-
+  
   useEffect(() => {
-    setOnlineStatus();
-
     if (!mapRef.current) {
       // Initialize the map if it hasn't been created yet
       mapRef.current = new Map({
@@ -217,7 +201,7 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
       }
       map.addLayer(getLayer());
     }
-  }, [layer]);
+  }, [layer, isOnline]);
 
   useEffect(() => {
     const debouncedBboxChange = debounce((extent: number[]) => {

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -19,7 +19,6 @@ import { Style, Stroke, Fill } from 'ol/style';
 const attributions =
   '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
 const tileserverUrl = process.env.NEXT_PUBLIC_TILESERVER_URL;
-const DEFAULT_ENDPOINT_URL = 'https://hirondelle.crim.ca/stac/collections';
 const DEFAULT_LAYER_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 const OFFLINE_LAYER_URL = `${tileserverUrl}/{z}/{x}/{y}.jpg`;
 const SATELLITE_LAYER_URL = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -8,7 +8,7 @@ import {
   IoSettingsOutline,
   IoTrashOutline,
 } from 'react-icons/io5';
-import { PiArrowClockwiseFill, PiGlobeXLight, PiX } from 'react-icons/pi';
+import { PiArrowClockwiseFill, PiGlobeXLight, PiGlobeLight } from 'react-icons/pi';
 import {
   fetchCollectionsFromEndpoint,
   resetCollections, resetItems,
@@ -32,7 +32,7 @@ const SettingsPanel: React.FC<{
     activeButton: string | null;
     isOpen: boolean;
   }>({ activeButton: null, isOpen: false });
-  const { setLayer, setSpeed, resetView, isOnline, setSliderValue } = useMapLayerContext();
+  const { setLayer, setSpeed, resetView, isOnline, setIsOnline, setSliderValue } = useMapLayerContext();
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
     'https://default-api-endpoint.com',
   );
@@ -214,6 +214,11 @@ const SettingsPanel: React.FC<{
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
+  const handleSelectOnlineMode = async (onlineMode: boolean) => {
+    setIsOnline(onlineMode);
+    setDropdownState({ activeButton: null, isOpen: false });
+  };
+
   const resetConfig = async () => {
     try {
       localStorage.setItem('language', 'en');
@@ -373,6 +378,38 @@ const SettingsPanel: React.FC<{
 
       <div className="dropdown-button">
         <button
+            className={`button ${dropdownState.activeButton === 'internet' ? 'active' : ''}`}
+            onClick={() => toggleDropdown('internet')}
+            aria-expanded={dropdownState.activeButton === 'internet'}
+            aria-label="internet"
+            data-testid="internet-dropdown-button"
+          >
+            {isOnline ? (<PiGlobeLight size={32} />) : (<PiGlobeXLight size={32} />)}
+          </button>
+        {dropdownState.activeButton === 'internet' && (
+        <div className="dropdown-content show">
+          <button onClick={() => handleSelectOnlineMode(true)}>
+              {isOnline ? (
+                <IoCheckmark size={24} fill="black" />
+              ) : (
+                <PiArrowClockwiseFill size={24} fill="none" />
+              )}
+              {t('online')}
+            </button>
+            <button onClick={() => handleSelectOnlineMode(false)}>
+              {!isOnline ? (
+                <IoCheckmark size={24} fill="black" />
+              ) : (
+                <PiArrowClockwiseFill size={24} fill="none" />
+              )}
+              {t('offline')}
+            </button>
+        </div>
+        )}
+      </div>
+
+      <div className="dropdown-button">
+        <button
           className={`button ${dropdownState.activeButton === 'reset' ? 'active' : ''}`}
           onClick={() => toggleDropdown('reset')}
           aria-expanded={dropdownState.activeButton === 'reset'}
@@ -398,29 +435,6 @@ const SettingsPanel: React.FC<{
           </div>
         )}
       </div>
-
-      {!isOnline &&
-      <div className="dropdown-button">
-        <button
-            className={`button ${dropdownState.activeButton === 'internet' ? 'active' : ''}`}
-            onClick={() => toggleDropdown('internet')}
-            aria-expanded={dropdownState.activeButton === 'internet'}
-            aria-label="internet"
-            data-testid="internet-dropdown-button"
-          >
-            <PiGlobeXLight size={32} />
-          </button>
-        {dropdownState.activeButton === 'internet' && (
-        <div className="dropdown-content show">
-          <div className="settings-information">
-            <label data-testid="internet-button" style={{ color: '#dc143c' }}>
-              <PiX size={24} fill="red" />
-              {t('no_internet_access')}
-            </label>
-            </div>
-        </div>
-        )}
-      </div>}
     </div>
   );
 };

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -184,6 +184,13 @@ const SettingsPanel: React.FC<{
   };
 
   const handleFactoryReset = async () => {
+    if(!isOnline){
+      toast.error(`${t('disabled')} - ${t('no_internet_access')}`, {
+        toastId: 'online-disabled',
+      });
+      return;
+    }
+    
     MySwal.fire({
       title: t('factory_reset'),
       text: t('confirm_factory_reset_data_from_endpoint'),

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -72,6 +72,10 @@ const SettingsPanel: React.FC<{
         toast.success(t('language_retrieved'));
       }
       setLanguageInitialized(true);
+      
+      if(config.onlineMode != undefined){
+        setIsOnline(config.onlineMode);
+      }
 
       // Check if endpoint is "No endpoint saved" and prompt user to enter a new one
       if (
@@ -216,6 +220,9 @@ const SettingsPanel: React.FC<{
 
   const handleSelectOnlineMode = async (onlineMode: boolean) => {
     setIsOnline(onlineMode);
+    const config = await getConfig();
+    config.onlineMode = onlineMode;
+    await saveConfig(config);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -391,7 +391,11 @@ const SettingsPanel: React.FC<{
             aria-label="internet"
             data-testid="internet-dropdown-button"
           >
-            {isOnline ? (<PiGlobeLight size={32} />) : (<PiGlobeXLight size={32} />)}
+            {isOnline ? (
+              <PiGlobeLight size={32} data-testid="online-icon"/>
+              ) : (
+              <PiGlobeXLight size={32} data-testid="offline-icon"/>
+              )}
           </button>
         {dropdownState.activeButton === 'internet' && (
         <div className="dropdown-content show">

--- a/apps/frontend/src/app/components/Sidebar.tsx
+++ b/apps/frontend/src/app/components/Sidebar.tsx
@@ -23,8 +23,8 @@ const Sidebar = () => {
 
   const handleLayerChange = (layerName: string) => {
     if(!isOnline && layerName != 'default'){
-      toast.error(`${t('view_disabled')} - ${t('no_internet_access')}`, {
-        toastId: 'view-disabled',
+      toast.error(`${t('disabled')} - ${t('no_internet_access')}`, {
+        toastId: 'online-disabled',
       });
       return;
     }

--- a/apps/frontend/src/app/context/MapContext.tsx
+++ b/apps/frontend/src/app/context/MapContext.tsx
@@ -21,7 +21,7 @@ interface MapLayerContextValue{
 const MapLayerContext = createContext<MapLayerContextValue | undefined>(undefined);
 
 export const MapProvider: React.FC<PropsWithChildren> = ({children}) => {
-    const [layer, setLayer] = useState<string | null>(null);
+    const [layer, setLayer] = useState<string | null>('default');
     const mapRef = useRef<Map | null>(null);
     const [timeStamps, setTimeStamps] = useState<string[]>([]);
     const [sliderValue, setSliderValue] = useState<number>(0);

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -20,6 +20,7 @@ const resources = {
       copied_to_clipboard: 'Copied to clipboard',
       online: 'Online',
       offline: 'Offline',
+      disabled: 'Disabled',
       no_internet_access: 'No internet access',
       //Language
       english: 'English',
@@ -99,6 +100,7 @@ const resources = {
       copied_to_clipboard: 'Copié dans le presse-papiers',
       online: 'En ligne',
       offline: 'Hors ligne',
+      disabled: "Désactivé",
       no_internet_access: 'Aucune connexion',
       //Language
       english: 'Anglais',

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -18,6 +18,8 @@ const resources = {
       api_endpoint_saved:
         'API endpoint successfully saved',
       copied_to_clipboard: 'Copied to clipboard',
+      online: 'Online',
+      offline: 'Offline',
       no_internet_access: 'No internet access',
       //Language
       english: 'English',
@@ -95,6 +97,8 @@ const resources = {
       api_endpoint_saved:
         'Endpoint enregistré avec succès',
       copied_to_clipboard: 'Copié dans le presse-papiers',
+      online: 'En ligne',
+      offline: 'Hors ligne',
       no_internet_access: 'Aucune connexion',
       //Language
       english: 'Anglais',


### PR DESCRIPTION
### Summary
Refactored the offline functionality

### Changes Made
- Modified the dropdown button to toggle between online and offline mode
- Added logic to save the online mode into the config and to fetch it at startup
- Disabled some features when in offline mode
  - change view
  - load dataset
  - factory reset
- Updated tests to reflect the changes

### Testing Instructions
1. Build and run the app
2. Press the online/offline toggle button
3. Select the mode that you would like to use
4. Verify that the correct option has a check mark beside it and that the button icon changes
5. Verify that the map switches to the offline version

### Screenshots
![image](https://github.com/user-attachments/assets/f6b6ed1a-13bf-42ba-93b6-b527ecf4d221)
![image](https://github.com/user-attachments/assets/cee23f2e-fbd3-40d2-8e70-b1a59f917098)
