### PR TITLE
#247 - fix(frontend & backend): Enable User Deselect Dataset

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -372,6 +372,20 @@ public class DataController {
     }
   }
 
+  @GetMapping("/api/reset-datalayer-view")
+  public ResponseEntity<String> resetView() {
+    try {
+      logger.info("Received request to /api/reset-datalayer-view");
+      dataService.resetView();
+      logger.info("Successfully processed resetting Datalayer View");
+      return ResponseEntity.ok("Successfully reset Datalayer view");
+    } catch(Exception e) {
+      logger.error("Error resetting Datalayer View: {}", e.getMessage(), e);
+      return ResponseEntity.internalServerError()
+        .body("Error resetting Datalayer View: " + e.getMessage());
+    }
+  }
+
   /**
    * Endpoint responsible for checking if the user is connected to the internet
    *

--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -353,7 +353,7 @@ public class DataController {
   }
 
   /**
-   * Endpoint responsible for inserting a view using a given collection
+   * Endpoint responsible for inserting a view using a given collectionId
    *
    * @param collectionId Database ID of given collection
    * @return ResponseEntity containing a String object indicating if the insertion was successful
@@ -372,6 +372,11 @@ public class DataController {
     }
   }
 
+  /**
+   * Endpoint responsible for resetting the Datalayer view
+   *
+   * @return ResponseEntity containing a String object indicating if the reset was successful
+   */
   @GetMapping("/api/reset-datalayer-view")
   public ResponseEntity<String> resetView() {
     try {

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -391,7 +391,7 @@ public class StacRepository {
       logger.info("Successfully reset the Datalayer view");
     } catch(DataAccessException e) {
       logger.error("Error resetting Datalayer view: {}", e.getMessage(), e);
-      throw new RuntimeException("Error resting Datalayer view: " + e.getMessage(), e);
+      throw new RuntimeException("Error resetting Datalayer view: " + e.getMessage(), e);
     }
   }
 

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -379,6 +379,23 @@ public class StacRepository {
   }
 
   /**
+   * Method responsible for resetting the Datalayer View
+   *
+   * @param collectionId Database ID of the given collection
+   */
+  public void resetDatalayerView() {
+    try {
+      logger.info("Attempting to reset Datalayer view");
+      String sql = "DROP VIEW IF EXISTS Datalayer";
+      jdbcTemplate.execute(sql);
+      logger.info("Successfully reset the Datalayer view");
+    } catch(DataAccessException e) {
+      logger.error("Error resetting Datalayer view: {}", e.getMessage(), e);
+      throw new RuntimeException("Error resting Datalayer view: " + e.getMessage(), e);
+    }
+  }
+
+  /**
    * Method responsible for checking if DataLayerView exists
    *
    * @return boolean value clarifying if the DataLayerView exists or not

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -92,6 +92,20 @@ public class DataService {
   }
 
   /**
+   * Method responsible for reseting the Datalayer view
+   */
+  public void resetView() {
+    logger.info("Resetting Datalayer View");
+    try {
+      stacRepository.resetDatalayerView();
+      logger.info("Datalayer View successfully reset");
+    } catch (Exception e) {
+      logger.error("Error resetting Datalayer View: {}", e.getMessage(), e);
+      throw new RuntimeException("Failed to reset Datalayer View: " + e.getMessage(), e);
+    }
+  }
+
+  /**
    * Method responsible for retrieving and saving of collections into our database from a given endpoint
    *
    * @param endpointUrl Endpoint that we will be retrieving collections from

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -92,16 +92,39 @@ public class DataService {
   }
 
   /**
-   * Method responsible for reseting the Datalayer view
+   * Overloaded method responsible for resetting datalayer view
    */
   public void resetView() {
-    logger.info("Resetting Datalayer View");
-    try {
-      stacRepository.resetDatalayerView();
-      logger.info("Datalayer View successfully reset");
-    } catch (Exception e) {
-      logger.error("Error resetting Datalayer View: {}", e.getMessage(), e);
-      throw new RuntimeException("Failed to reset Datalayer View: " + e.getMessage(), e);
+    resetView(50);
+  }
+
+  /**
+  * Method responsible for resetting the Datalayer view. The thread sleep time can be set using sleepMillis.
+  *
+  * @param sleepMillis The thread sleep amount in milliseconds
+  */
+  public void resetView(int sleepMillis) {
+    stacRepository.resetDatalayerView();
+    boolean check = true;
+    int count = 0;
+
+    while (check && count < 50) {
+        check = stacRepository.checkDatalayerView();
+        count++;
+        try {
+            Thread.sleep(sleepMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("Thread interrupted while waiting for the view to be reset", e);
+            break;
+        }
+    }
+
+    if (!check) {
+        logger.info("View successfully reset in database");
+    } else {
+        logger.warn("View was still in database after 50 attempts");
+        throw new IllegalStateException("View could not be reset");
     }
   }
 

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -603,4 +603,28 @@ class DataControllerTests {
     assertThat(response.getBody()).isNull();
     verify(dataService).fetchItemsTimestamps();
   }
+
+  @Test
+  void resetView_Success() {
+    // Arrange
+    doNothing().when(dataService).resetView();
+
+    // Act
+    ResponseEntity<String> response = dataController.resetView();
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void resetView_Failure() {
+    // Arrange
+    doThrow(new RuntimeException("Test error")).when(dataService).resetView();
+
+    // Act
+    ResponseEntity<String> response = dataController.resetView();
+
+    // Assert
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -799,4 +799,28 @@ class StacRepositoryTests {
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Error querying collection");
   }
+
+  @Test
+  void resetDatalayerView_Success() {
+    // Arrange
+    doNothing().when(jdbcTemplate).execute(anyString());
+
+    // Act
+    stacRepository.resetDatalayerView();
+
+    // Assert
+    verify(jdbcTemplate, times(1)).execute("DROP VIEW IF EXISTS Datalayer");
+  }
+
+  @Test
+  void resetDatalayerView_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    doThrow(new DataAccessException("Database error") {
+    }).when(jdbcTemplate).execute(anyString());
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.resetDatalayerView())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Error resetting Datalayer view");
+  }
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -712,4 +712,49 @@ class DataServiceTests {
       .isInstanceOf(RuntimeException.class)
       .hasMessageContaining("Failed to fetch or save items");
   }
+  @Test
+  void resetView_Default_Success() {
+    // Arrange
+    doNothing().when(stacRepository).resetDatalayerView();
+    when(stacRepository.checkDatalayerView()).thenReturn(false);
+
+    // Act
+    dataService.resetView();
+
+    // Assert
+    verify(stacRepository, atLeastOnce()).resetDatalayerView();
+    verify(stacRepository, atLeastOnce()).checkDatalayerView();
+  }
+
+  @Test
+  void resetView_SleepMillisAdjusted_Failure() {
+    // Arrange
+    doNothing().when(stacRepository).resetDatalayerView();
+      when(stacRepository.checkDatalayerView()).thenReturn(true); // View remains, causing failure
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.resetView(0))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("View could not be reset");
+
+    verify(stacRepository, atLeastOnce()).resetDatalayerView();
+    verify(stacRepository, atLeastOnce()).checkDatalayerView();
+  }
+
+  @Test
+  void resetView_ShouldHandleInterruptedException() {
+    // Arrange
+    doNothing().when(stacRepository).resetDatalayerView();
+    when(stacRepository.checkDatalayerView()).thenReturn(true); // View remains, causing loop
+
+    // Act & Assert
+    assertThatThrownBy(() -> {
+        Thread.currentThread().interrupt(); // Simulate interruption
+        dataService.resetView(0);
+    }).isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("View could not be reset");
+
+    verify(stacRepository, atLeastOnce()).resetDatalayerView();
+    verify(stacRepository, atLeastOnce()).checkDatalayerView();
+  }
 }

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -156,12 +156,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     let selectedId = localStorage.getItem('selectedDatasetId')
     if(selectedId === null || selectedId !== id){
       await insertDatalayerView(id);
-      console.log("changing selectedDatasetId in localStorage")
       localStorage.setItem('selectedDatasetId',id)
       setSelectedDataset(id);
     } else {
       await resetDatalayerView()
-      console.log("resetting selectedDatasetId in localStorage")
       localStorage.setItem('selectedDatasetId', '')
       setSelectedDataset(null)
     }

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -12,10 +12,11 @@ import {
   fetchCollectionsFromEndpointByDate,
   fetchMetaData,
   returnListOfCollectionsFromEndpoint,
+  insertDatalayerView,
+  resetDatalayerView
 } from '../services/api';
 import debounce from 'lodash/debounce';
 import { useMapLayerContext } from '../context/MapContext';
-import { insertDatalayerView } from '../services/api';
 import { changeLayer } from './MapView';
 import { Map } from 'ol';
 
@@ -100,6 +101,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * Fetches datasets when the refresh key or filter changes.
    */
   useEffect(() => {
+    let selectedDatasetId = localStorage.getItem('selectedDatasetId')
+    if(selectedDatasetId !== null){
+      setSelectedDataset(selectedDatasetId)
+    }
     fetchDatasets();
     return () => fetchDatasets.cancel();
   }, [refreshKey, activeFilter]);
@@ -136,13 +141,31 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * @param id - The dataset ID.
    */
   const handleDatasetClick = async (id: string) => {
-    await insertDatalayerView(id);
-    const map = mapRef.current as Map;
-    changeLayer(map, true);
-    setSelectedDataset(id);
     const dataset = await fetchMetaData(id);
     onDatasetClick(dataset);
+    handleLocalStorageOnDatasetClick(id)
+    const map = mapRef.current as Map;
+    changeLayer(map, true);
   };
+
+  /**
+   * Handles local storage when user selects a dataset
+   * @param id - The dataset ID.
+   */
+  const handleLocalStorageOnDatasetClick = async (id: string) => {
+    let selectedId = localStorage.getItem('selectedDatasetId')
+    if(selectedId === null || selectedId !== id){
+      await insertDatalayerView(id);
+      console.log("changing selectedDatasetId in localStorage")
+      localStorage.setItem('selectedDatasetId',id)
+      setSelectedDataset(id);
+    } else {
+      await resetDatalayerView()
+      console.log("resetting selectedDatasetId in localStorage")
+      localStorage.setItem('selectedDatasetId', '')
+      setSelectedDataset(null)
+    }
+  }
 
   return (
     <div

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -101,7 +101,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * Fetches datasets when the refresh key or filter changes.
    */
   useEffect(() => {
-    let selectedDatasetId = localStorage.getItem('selectedDatasetId')
+    const selectedDatasetId = localStorage.getItem('selectedDatasetId')
     if(selectedDatasetId !== null){
       setSelectedDataset(selectedDatasetId)
     }
@@ -153,8 +153,8 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * @param id - The dataset ID.
    */
   const handleLocalStorageOnDatasetClick = async (id: string) => {
-    let selectedId = localStorage.getItem('selectedDatasetId')
-    if(selectedId === null || selectedId !== id){
+    const selectedDatasetId = localStorage.getItem('selectedDatasetId')
+    if(selectedDatasetId === null || selectedDatasetId !== id){
       await insertDatalayerView(id);
       localStorage.setItem('selectedDatasetId',id)
       setSelectedDataset(id);

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import MapView from './components/MapView';
 import Sidebar from './components/Sidebar';
 import SettingsPanel from './components/SettingsPanel';
@@ -11,6 +11,7 @@ import i18n from './resources/i18n';
 import './layout.css';
 import LoadingModule from './components/LoadingModule';
 import { MapProvider } from './context/MapContext';
+import { fetchMetaData } from './services/api';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [loading, setLoading] = useState(false);
@@ -36,9 +37,31 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: DatasetMetadata) => {
-    setSelectedDataset(dataset); // Just update the selected dataset
-    setMetadataVisible(true); // Show metadata container
+    let selectedDatasetId = localStorage.getItem('selectedDatasetId')
+    console.log("selectedDatasetId: " + selectedDataset)
+    if(selectedDatasetId !== dataset.id){
+      console.log("metadata will open")
+      setSelectedDataset(dataset); // Just update the selected dataset
+      setMetadataVisible(true); // Show metadata container
+    } else {
+      console.log("metadata should close")
+      setMetadataVisible(false)
+    }
   };
+
+  useEffect(() => {
+    const onLoadDataset = async () => {
+      let selectedDatasetId = localStorage.getItem('selectedDatasetId')
+      console.log("selectedDatasetId = " + selectedDatasetId)
+      if(selectedDatasetId !== null && selectedDatasetId !== ''){
+        const dataset = await fetchMetaData(selectedDatasetId)
+        setSelectedDataset(dataset)
+        setMetadataVisible(true)
+      }
+    }
+
+    onLoadDataset();
+  }, [])
 
   // Handle dataset loading from MapMetaData
   const handleLoadDataset = async () => {

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -37,7 +37,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: DatasetMetadata) => {
-    let selectedDatasetId = localStorage.getItem('selectedDatasetId')
+    const selectedDatasetId = localStorage.getItem('selectedDatasetId')
     if(selectedDatasetId !== dataset.id){
       setSelectedDataset(dataset); // Just update the selected dataset
       setMetadataVisible(true); // Show metadata container
@@ -49,7 +49,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Handles loading the metadata if dataset is already selected on load
   useEffect(() => {
     const onLoadDataset = async () => {
-      let selectedDatasetId = localStorage.getItem('selectedDatasetId')
+      const selectedDatasetId = localStorage.getItem('selectedDatasetId')
       if(selectedDatasetId !== null && selectedDatasetId !== ''){
         const dataset = await fetchMetaData(selectedDatasetId)
         setSelectedDataset(dataset)

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -49,6 +49,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     }
   };
 
+  // Handles loading the metadata if dataset is already selected on load
   useEffect(() => {
     const onLoadDataset = async () => {
       let selectedDatasetId = localStorage.getItem('selectedDatasetId')

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -38,13 +38,10 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: DatasetMetadata) => {
     let selectedDatasetId = localStorage.getItem('selectedDatasetId')
-    console.log("selectedDatasetId: " + selectedDataset)
     if(selectedDatasetId !== dataset.id){
-      console.log("metadata will open")
       setSelectedDataset(dataset); // Just update the selected dataset
       setMetadataVisible(true); // Show metadata container
     } else {
-      console.log("metadata should close")
       setMetadataVisible(false)
     }
   };
@@ -53,7 +50,6 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   useEffect(() => {
     const onLoadDataset = async () => {
       let selectedDatasetId = localStorage.getItem('selectedDatasetId')
-      console.log("selectedDatasetId = " + selectedDatasetId)
       if(selectedDatasetId !== null && selectedDatasetId !== ''){
         const dataset = await fetchMetaData(selectedDatasetId)
         setSelectedDataset(dataset)

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -249,6 +249,18 @@ export const insertDatalayerView = async (collectionId: string): Promise<any> =>
   }
 }
 
+export const resetDatalayerView = async (): Promise<any> => {
+  try {
+    const response = await fetch(`${BASE_URL}/api/reset-datalayer-view`);
+    if(!response.ok) {
+      throw new Error(`Error: ${response.statusText}`);
+    }
+  } catch (error: any) {
+    console.error("Error resetting Datalayer View:", error);
+    return { error: "Failed to reset Datalayer View" };
+  }
+}
+
 export const verifyInternetConnection = async (endpoint_url: string): Promise<string> => {
   try {
     const response = await fetch(`${BASE_URL}/api/verify-internet-connection?endpointUrl=${encodeURIComponent(endpoint_url)}`);

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -249,6 +249,9 @@ export const insertDatalayerView = async (collectionId: string): Promise<any> =>
   }
 }
 
+/**
+ * Resets datalayer view
+ */
 export const resetDatalayerView = async (): Promise<any> => {
   try {
     const response = await fetch(`${BASE_URL}/api/reset-datalayer-view`);


### PR DESCRIPTION
#### **Summary**  
This PR addresses two issues:  
1. **[Bug #247] Blue Rectangle Should Disappear when Selecting it Again** – Ensures that user can remove the collection layer

#### **Changes Made**  

 **Reset View**  
- Added an endpoint to reset the Datalayer view in the db.

 **Metadata + Selected Dataset**  
- Selected dataset can be removed from the map when selecting it again in the available datasets
- Metadata also follows the same behaviour as the datalayer view in terms of being opened and closed
- Metadata and selected dataset persist when the page is reloaded, bringing the user back to how the metadata and selected dataset was before the reload

#### **Testing & Validation**  
- Verified that the metadata and selected datasets can be removed
- Verified that the metadata and selected datasets persist when reloading