### PR TITLE
#239 - fix(frontend): Fixed loading bar being stuck on screen after l…

### DIFF
--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -44,6 +44,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       setProgress((prevProgress) => {
         if (prevProgress >= 100) {
           clearInterval(progressInterval); // Stop auto-progress at 100%
+          setLoading(false);
           return 100;
         }
         return prevProgress + 10; // Increment progress


### PR DESCRIPTION
### Summary
Closed the loading bar after it reaches 100% so that it doesn't stay on the screen

### Changes Made
- Made the loading variable equal to false when its finished loading

### Testing Instructions
- Select a dataset from the available datasets
- In the metadata section, click on load dataset
- See if the loading bar closes after reaching 100%