### PR TITLE
#261-263-265 - fix(frontend & backend): factory reset errors

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -198,12 +198,7 @@ public class StacRepository {
 
   public void deleteAllCollections() {
     try {
-      String sql = "DELETE FROM pgstac.datalayer";
-      logger.info("Deleting Datalayer view from pgstac.collections");
-      jdbcTemplate.update(sql);
-      logger.info("Datalayer view deleted successfully");
-
-      sql = "DELETE FROM pgstac.collections";
+      String sql = "DELETE FROM pgstac.collections";
       logger.info("Deleting all collections from pgstac.collections");
       jdbcTemplate.update(sql);
       logger.info("All collections deleted successfully");

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -141,7 +141,7 @@ public class DataService {
       logger.info("View successfully reset in database");
     } catch (Exception e) {
       logger.error("Error resetting Datalayer view: {}", e.getMessage(), e);
-      throw new RuntimeException("Failed to reset Datalayer view: " + e.getMessage(), e);
+      throw new IllegalStateException("Failed to reset Datalayer view: " + e.getMessage(), e);
     }
   }
 

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -132,39 +132,16 @@ public class DataService {
   }
 
   /**
-   * Overloaded method responsible for resetting datalayer view
+   * Method responsible for resetting the Datalayer view.
    */
   public void resetView() {
-    resetView(50);
-  }
-
-  /**
-  * Method responsible for resetting the Datalayer view. The thread sleep time can be set using sleepMillis.
-  *
-  * @param sleepMillis The thread sleep amount in milliseconds
-  */
-  public void resetView(int sleepMillis) {
-    stacRepository.resetDatalayerView();
-    boolean check = true;
-    int count = 0;
-
-    while (check && count < 50) {
-        check = stacRepository.checkDatalayerView();
-        count++;
-        try {
-            Thread.sleep(sleepMillis);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logger.error("Thread interrupted while waiting for the view to be reset", e);
-            break;
-        }
-    }
-
-    if (!check) {
-        logger.info("View successfully reset in database");
-    } else {
-        logger.warn("View was still in database after 50 attempts");
-        throw new IllegalStateException("View could not be reset");
+    logger.info("Resetting Datalayer view");
+    try {
+      stacRepository.resetDatalayerView();
+      logger.info("View successfully reset in database");
+    } catch (Exception e) {
+      logger.error("Error resetting Datalayer view: {}", e.getMessage(), e);
+      throw new RuntimeException("Failed to reset Datalayer view: " + e.getMessage(), e);
     }
   }
 

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -266,7 +266,6 @@ class StacRepositoryTests {
     stacRepository.deleteAllCollections();
 
     // Assert
-    verify(jdbcTemplate, times(1)).update("DELETE FROM pgstac.datalayer");
     verify(jdbcTemplate, times(1)).update("DELETE FROM pgstac.collections");
   }
 

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -798,7 +798,7 @@ class DataServiceTests {
 
         // Act & Assert
         assertThatThrownBy(() -> dataService.resetView())
-                .isInstanceOf(RuntimeException.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Failed to reset Datalayer view: Test exception");
 
         verify(stacRepository, times(1)).resetDatalayerView();

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -781,49 +781,26 @@ class DataServiceTests {
     // Verify that it attempted to fetch config before failing
     verify(configController, times(1)).getConfig();
   }
-  @Test
-  void resetView_Default_Success() {
-    // Arrange
-    doNothing().when(stacRepository).resetDatalayerView();
-    when(stacRepository.checkDatalayerView()).thenReturn(false);
-
-    // Act
-    dataService.resetView();
-
-    // Assert
-    verify(stacRepository, atLeastOnce()).resetDatalayerView();
-    verify(stacRepository, atLeastOnce()).checkDatalayerView();
-  }
 
   @Test
-  void resetView_SleepMillisAdjusted_Failure() {
-    // Arrange
-    doNothing().when(stacRepository).resetDatalayerView();
-      when(stacRepository.checkDatalayerView()).thenReturn(true); // View remains, causing failure
+    void resetView_Success() {
+        // Act
+        dataService.resetView();
 
-    // Act & Assert
-    assertThatThrownBy(() -> dataService.resetView(0))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("View could not be reset");
+        // Assert
+        verify(stacRepository, times(1)).resetDatalayerView();
+    }
 
-    verify(stacRepository, atLeastOnce()).resetDatalayerView();
-    verify(stacRepository, atLeastOnce()).checkDatalayerView();
-  }
+    @Test
+    void resetView_ShouldLogError_WhenExceptionThrown() {
+        // Arrange
+        doThrow(new RuntimeException("Test exception")).when(stacRepository).resetDatalayerView();
 
-  @Test
-  void resetView_ShouldHandleInterruptedException() {
-    // Arrange
-    doNothing().when(stacRepository).resetDatalayerView();
-    when(stacRepository.checkDatalayerView()).thenReturn(true); // View remains, causing loop
+        // Act & Assert
+        assertThatThrownBy(() -> dataService.resetView())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to reset Datalayer view: Test exception");
 
-    // Act & Assert
-    assertThatThrownBy(() -> {
-        Thread.currentThread().interrupt(); // Simulate interruption
-        dataService.resetView(0);
-    }).isInstanceOf(IllegalStateException.class)
-            .hasMessageContaining("View could not be reset");
-
-    verify(stacRepository, atLeastOnce()).resetDatalayerView();
-    verify(stacRepository, atLeastOnce()).checkDatalayerView();
-  }
+        verify(stacRepository, times(1)).resetDatalayerView();
+    }
 }

--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -109,6 +109,7 @@ describe('MapMetaData', () => {
       dataItems: [],
       setTimeStamps: jest.fn(),
       isOnline: true,
+      setSliderValue: jest.fn(),
     });
 
     const { getByTestId } = render(

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -57,6 +57,20 @@ jest.mock('sweetalert2', () => {
   };
 });
 
+jest.mock('ol/source/XYZ', () => jest.fn().mockImplementation(() => ({})));
+
+jest.mock('ol/layer/Tile', () => {
+  return jest.fn().mockImplementation(() => {
+    const properties: Record<string, any> = {}; // Store layer properties
+
+    return {
+      set: jest.fn((key: string, value: any) => {
+        properties[key] = value; // Store key-value pairs
+      }),
+    };
+  });
+});
+
 // Ensure the clipboard API exists.
 Object.assign(navigator, {
   clipboard: {

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -38,7 +38,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   const [progress, setProgress] = useState(0);
 
   const MySwal = withReactContent(Swal);
-  const { setTimeStamps, isOnline } = useMapLayerContext();
+  const { setTimeStamps, isOnline, setSliderValue } = useMapLayerContext();
 
   const onLoadDataset = async () => {
     if(!isOnline){
@@ -67,6 +67,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
         setProgress(0);
         await resetItems();
         localStorage.setItem("sliderValue", "0");
+        setSliderValue(0)
 
         try {
           // Start fetching items asynchronously

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import '../styles/MapMetaData.css';
 import { IoInformationCircle } from 'react-icons/io5';
 import { RiCollapseDiagonalFill } from 'react-icons/ri';
@@ -64,10 +64,10 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
 
       if (result.isConfirmed) {
         setLoading(true); // Show loading overlay
+        localStorage.setItem('sliderValue','0')
+        setSliderValue(0)
         setProgress(0);
         await resetItems();
-        localStorage.setItem("sliderValue", "0");
-        setSliderValue(0)
 
         try {
           // Start fetching items asynchronously

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -11,7 +11,9 @@ import {
 import { PiArrowClockwiseFill, PiGlobeXLight, PiGlobeLight } from 'react-icons/pi';
 import {
   fetchCollectionsFromEndpoint,
-  resetCollections, resetItems,
+  resetCollections, 
+  resetDatalayerView, 
+  resetItems,
   verifyIfEndpointHasCollections
 } from '../services/api';
 import { toast, ToastContainer } from 'react-toastify';
@@ -243,6 +245,7 @@ const SettingsPanel: React.FC<{
       setLayer('default');
       await resetCollections();
       await resetItems();
+      await resetDatalayerView();
       setSpeed(1);
       return 'Reset was successful';
     } catch (error: any) {

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -22,6 +22,8 @@ import Swal from 'sweetalert2';
 import withReactContent from 'sweetalert2-react-content';
 import { useMapLayerContext } from '../context/MapContext';
 import { getConfig, saveConfig } from '../services/configApi';
+import { changeLayer } from './MapView';
+import { Map } from 'ol';
 
 const MySwal = withReactContent(Swal);
 
@@ -34,7 +36,7 @@ const SettingsPanel: React.FC<{
     activeButton: string | null;
     isOpen: boolean;
   }>({ activeButton: null, isOpen: false });
-  const { setLayer, setSpeed, resetView, isOnline, setIsOnline, setSliderValue } = useMapLayerContext();
+  const { setLayer, setSpeed, resetView, isOnline, setIsOnline, setSliderValue, mapRef } = useMapLayerContext();
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
     'https://default-api-endpoint.com',
   );
@@ -225,7 +227,6 @@ const SettingsPanel: React.FC<{
     });
 
     setDropdownState({ activeButton: null, isOpen: false });
-    localStorage.setItem('selectedDatasetId','')
   };
 
   const handleSelectOnlineMode = async (onlineMode: boolean) => {
@@ -240,6 +241,7 @@ const SettingsPanel: React.FC<{
     try {
       localStorage.setItem('language', 'en');
       localStorage.setItem('playbackSpeed', '1');
+      localStorage.setItem('selectedDatasetId','')
       localStorage.setItem('sliderValue', '0');
       setSliderValue(0);
 
@@ -247,6 +249,8 @@ const SettingsPanel: React.FC<{
       await resetCollections();
       await resetItems();
       await resetDatalayerView();
+      const map = mapRef.current as Map;
+      changeLayer(map, true)
       setSpeed(1);
       return 'Reset was successful';
     } catch (error: any) {

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -225,6 +225,7 @@ const SettingsPanel: React.FC<{
     });
 
     setDropdownState({ activeButton: null, isOpen: false });
+    localStorage.setItem('selectedDatasetId','')
   };
 
   const handleSelectOnlineMode = async (onlineMode: boolean) => {


### PR DESCRIPTION
#### **Summary**  
This PR addresses three issues:  
1. **[Bug #261] Slider Value not updated when loading new dataset**
2. **[Bug #263] MapMetaData opens after factory reset**
3. **[Bug #265] Unable to fetch collections from endpoint**

#### **Changes Made**  

 **Slider Value**  
- Slider Value resets correctly when calling factory reset and loading a new dataset

 **Metadata**  
- localStorage value for selectedDatasetId is reset when calling factory reset. MapMetada no longer opens after factory reset

 **Fetch Collections**  
- Logic for resetting Datalayer is removed from deleteAllCollections. 
- resetLayer is now called when calling factory reset
- Collection bbox is also now removed when calling factory reset

#### **Testing & Validation**  
- Call factory reset and fetch new endpoint
- Ensure sliderValue is set 0
- Load new dataset ensure sliderValue is 0
- Call factory reset, ensure that MapMedata does not pop up and that the layer is removed from screen