### PR TITLE
#231 - fix(frontend): Persisting Toast Notifications

### DIFF
--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -132,6 +132,6 @@ describe('MapMetaData', () => {
 
     // Ensure progress reached 100%
     expect(fetchProgress).toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith("items_fetch_success");
+    expect(toast.success).toHaveBeenCalledWith("items_fetch_success", {toastId: 'items-success',});
   });
 });

--- a/apps/frontend/__tests__/TestFooterComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestFooterComponent.spec.tsx
@@ -167,11 +167,11 @@ describe('Footer component', () => {
 
     render(<MapProvider><Footer /></MapProvider>);
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('speed_retrieved'));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('speed_retrieved', { toastId: 'speed-success' }));
   });
   it('should display toast message when default speed is used (no speed in localStorage)', async () => {
     render(<MapProvider><Footer /></MapProvider>);
 
-    await waitFor(() => expect(toast.info).toHaveBeenCalledWith('default_speed_retrieved'));
+    await waitFor(() => expect(toast.info).toHaveBeenCalledWith('default_speed_retrieved', { toastId: 'speed-default' }));
   });
 });

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -25,9 +25,9 @@ const Footer = () => {
         const savedSpeed = localStorage.getItem('playbackSpeed');
         if (savedSpeed) {
           setSpeed(parseFloat(savedSpeed));
-          toast.success(t('speed_retrieved'));
+          toast.success(t('speed_retrieved'), {toastId: 'speed-success'});
         } else {
-          toast.info(t('default_speed_retrieved'));
+          toast.info(t('default_speed_retrieved'), {toastId: 'speed-default'});
         }
         setSpeedInitialized(true);
         intitializeTimestampIfItemsPresent();
@@ -51,7 +51,7 @@ const Footer = () => {
   const handlePlayPause = () => setIsPlaying((prev) => !prev);
   const handleSpeedChange = (newSpeed: number) => {
     setSpeed(newSpeed);
-    toast.success(t('speed_changed') + newSpeed + 'x');
+    toast.success(t('speed_changed') + newSpeed + 'x', {toastId: 'speed-changed'});
   };
 
   useEffect(() => {

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -74,7 +74,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
           if (response != "Fetching started in the background. Check progress separately.") {
             throw new Error(t("timestamps_fetch_error"));
           }
-          toast.success(t("timestamps_fetch_success"));
+          toast.success(t("timestamps_fetch_success"), {toastId: 'timestamps-success',});
 
           const pollProgress = async () => {
             while (true) {
@@ -87,7 +87,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
                 // Stop the loop when progress reaches 100%
                 if (progressResponse.progress >= 100) {
                   setLoading(false);
-                  toast.success(t("items_fetch_success"));
+                  toast.success(t("items_fetch_success"), {toastId: 'items-success',});
                   return;
                 }
               }
@@ -99,7 +99,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
 
           pollProgress(); // Call the async function for polling
         } catch (error) {
-          toast.error("Error loading dataset: " + error);
+          toast.error("Error loading dataset: " + error), {toastId: 'loading-dataset-error',};
           setLoading(false);
         }
       }

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -328,7 +328,6 @@ const SettingsPanel: React.FC<{
 
   return (
     <div className="button-container" ref={dropdownRef}>
-      <ToastContainer />
       <div className="dropdown-button">
         <button
           className={`button ${dropdownState.activeButton === 'settings' ? 'active' : ''}`}

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -14,7 +14,7 @@ import {
   resetCollections, resetItems,
   verifyIfEndpointHasCollections
 } from '../services/api';
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import Swal from 'sweetalert2';
 import withReactContent from 'sweetalert2-react-content';

--- a/apps/frontend/src/app/components/Sidebar.tsx
+++ b/apps/frontend/src/app/components/Sidebar.tsx
@@ -9,7 +9,7 @@ const viewsIcon = '/assets/layers_white.png';
 const satelliteImage = '/assets/Satellite_layer.png';
 const defaultImage = '/assets/Default_layer.png';
 const terrainImage = '/assets/Terrain_layer.png';
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 const Sidebar = () => {

--- a/apps/frontend/src/app/components/Sidebar.tsx
+++ b/apps/frontend/src/app/components/Sidebar.tsx
@@ -37,41 +37,38 @@ const Sidebar = () => {
   }, [isOnline]);
 
   return (
-    <div>
-      <ToastContainer />
-      <div className={`sidebar-component ${isCollapsed ? 'collapsed' : 'expanded'}`}>
-        {isCollapsed ? (
-          <button className='sidebar-toggle' onClick={toggleCollapse}>
-            <img className='icon' src={viewsIcon} alt={t('views')} />
-            <span style={{ marginLeft: '5px', color: 'white' }}>{t('views')}</span>
-          </button>
-        ) : (
-          <>
-            <div className='sidebar-toggle' onClick={toggleCollapse}>
-              <img className='icon' src={viewsIcon} alt={t('collapse')} />
-            </div>
+    <div className={`sidebar-component ${isCollapsed ? 'collapsed' : 'expanded'}`}>
+      {isCollapsed ? (
+        <button className='sidebar-toggle' onClick={toggleCollapse}>
+          <img className='icon' src={viewsIcon} alt={t('views')} />
+          <span style={{ marginLeft: '5px', color: 'white' }}>{t('views')}</span>
+        </button>
+      ) : (
+        <>
+          <div className='sidebar-toggle' onClick={toggleCollapse}>
+            <img className='icon' src={viewsIcon} alt={t('collapse')} />
+          </div>
 
-            <img
-              className='layer-image'
-              src={defaultImage}
-              alt={t('default_layer')}
-              onClick={() => handleLayerChange('default')}
-            />
-            <img
-              className='layer-image'
-              src={terrainImage}
-              alt={t('topographical_layer')}
-              onClick={() => handleLayerChange('topographical')}
-            />
-            <img
-              className='layer-image'
-              src={satelliteImage}
-              alt={t('satellite_layer')}
-              onClick={() => handleLayerChange('satellite')}
-            />
-          </>
-        )}
-      </div>
+          <img
+            className='layer-image'
+            src={defaultImage}
+            alt={t('default_layer')}
+            onClick={() => handleLayerChange('default')}
+          />
+          <img
+            className='layer-image'
+            src={terrainImage}
+            alt={t('topographical_layer')}
+            onClick={() => handleLayerChange('topographical')}
+          />
+          <img
+            className='layer-image'
+            src={satelliteImage}
+            alt={t('satellite_layer')}
+            onClick={() => handleLayerChange('satellite')}
+          />
+        </>
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -12,6 +12,7 @@ import './layout.css';
 import LoadingModule from './components/LoadingModule';
 import { MapProvider } from './context/MapContext';
 import { fetchMetaData } from './services/api';
+import { ToastContainer } from 'react-toastify';
 
 const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [loading, setLoading] = useState(false);
@@ -87,6 +88,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <MapProvider>
         <html lang="en">
         <body>
+        <ToastContainer/>
         <SettingsPanel refreshDatasets={refreshDatasets} setMetadataVisible={setMetadataVisible} />
         <div className="layout-container relative">
           <LoadingModule


### PR DESCRIPTION
**Summary**

This PR addresses the issue that toast notifications did not dismiss once the timer ended.

**Changes Made**

Moved the ToastContainer to the highest level and it fixed the issues
Removed ToastContainer from SettingsPanel and Sidebar

**Testing & Validation**

Open the app and click on any of the datasets, click 'load dataset' and any of the speed change buttons.
The toast notification should appear, and once the countdown has ended, it will dismiss itself.
