### PR TITLE
#238 - fix(frontend): Remove Print Statements for Map Extent

### DIFF
--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -189,12 +189,6 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
           zoom: 1,
         }),
       });
-
-      // Calculate and update the initial bounding box
-      const initialExtent = mapRef.current
-        .getView()
-        .calculateExtent(mapRef.current.getSize());
-      console.debug(`Initial Map Extent: ${initialExtent}`);
     } else {
       const map = mapRef.current;
       const layers = map.getLayers().getArray();
@@ -219,14 +213,12 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
       view.on('change:resolution', () => {
         const mapExtent = view.calculateExtent(map.getSize());
         debouncedBboxChange(mapExtent);
-        console.debug('Map extent updated due to zoom change.');
       });
 
       // Listen for pan events and update bounding box
       view.on('change:center', () => {
         const mapExtent = view.calculateExtent(map.getSize());
         debouncedBboxChange(mapExtent);
-        console.debug('Map extent updated due to pan movement.');
       });
     }
 


### PR DESCRIPTION
### Summary
This small PR removes unnecessary `console.debug` statements from the frontend codebase to reduce noise in the browser console and improve readability during runtime.

### Changes
- Removed leftover debug statements

### Reason for Change
These console statements were used during development and are no longer needed. Cleaning them up helps maintain a clean developer console and avoids confusion during testing or production use.
