### PR TITLE
#266 - fix(frontend): Add Missing French Translations for AvailableDatasets component

### DIFF
--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -219,4 +219,55 @@ describe('Test AvailableDatasets component', () => {
       expect(screen.getByTestId('dataset-button-dataset-1')).toBeInTheDocument();
     });
   });
+
+  it('should display translated error when fetch fails with "Failed to fetch data by name"', async () => {
+    mockFetchCollectionsByName.mockResolvedValue({ error: 'Failed to fetch data by name' });
+  
+    render(
+      <AvailableDatasets
+        onDatasetClick={mockOnDatasetClick}
+        refreshKey={0}
+      />
+    );
+  
+    const nameFilterButton = screen.getByTestId('filter-button-Name');
+    fireEvent.click(nameFilterButton);
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data_by_name');
+    });
+  });
+
+  it('should display translated error when fetch fails with "Failed to fetch data by date"', async () => {
+    mockFetchCollectionsByDate.mockResolvedValue({ error: 'Failed to fetch data by date' });
+  
+    render(
+      <AvailableDatasets
+        onDatasetClick={mockOnDatasetClick}
+        refreshKey={0}
+      />
+    );
+  
+    const dateFilterButton = screen.getByTestId('filter-button-Date');
+    fireEvent.click(dateFilterButton);
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data_by_date');
+    });
+  });
+
+  it('should display translated error when fetch fails with "Failed to fetch data"', async () => {
+    mockReturnListOfCollections.mockResolvedValue({ error: 'Failed to fetch data' });
+  
+    render(
+      <AvailableDatasets
+        onDatasetClick={mockOnDatasetClick}
+        refreshKey={0}
+      />
+    );
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data');
+    });
+  });
 });

--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -270,4 +270,34 @@ describe('Test AvailableDatasets component', () => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data');
     });
   });
+
+  it('should display default translation key when response.error is undefined', async () => {
+    mockReturnListOfCollections.mockResolvedValue({ error: undefined });
+  
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data');
+    });
+  });
+
+  it('should display raw error string when it does not match any known translation key', async () => {
+    mockReturnListOfCollections.mockResolvedValue({ error: 'Some random backend error' });
+  
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('Some random backend error');
+    });
+  });
+
+  it('should trigger fetchDatasets catch block and display fallback error message', async () => {
+    mockReturnListOfCollections.mockRejectedValue(new Error('Something broke'));
+  
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+  
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message')).toHaveTextContent('Failed to load datasets.');
+    });
+  });
 });

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -59,6 +59,19 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const {mapRef} = useMapLayerContext();
 
+  const getTranslatedErrorMessage = (rawError: string): string => {
+    switch (rawError) {
+      case 'Failed to fetch data by name':
+        return t('error_fetching_data_by_name');
+      case 'Failed to fetch data by date':
+        return t('error_fetching_data_by_date');
+      case 'Failed to fetch data':
+        return t('error_fetching_data');
+      default:
+        return rawError; // fallback if no match
+    }
+  };
+  
   /**
    * Fetches dataset collections based on the selected filter and bounding box.
    * Uses debounce to limit frequent API calls.
@@ -81,7 +94,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
 
       if (!Array.isArray(response)) {
         console.error("Invalid response format:", response);
-        setFetchError(response.error || "Failed to load datasets.");
+        setFetchError(getTranslatedErrorMessage(response.error || ''));
         setDatasets([]);
         return;
       }

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -59,16 +59,27 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const {mapRef} = useMapLayerContext();
 
-  const getTranslatedErrorMessage = (rawError: string): string => {
+  /**
+ * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
+ * This ensures that user-facing error messages are displayed in the selected language
+ * while allowing the service layer (api.ts) to remain free of localization logic.
+ *
+ * @param rawError - The raw error string returned from the API service
+ * @returns A translated error message string based on the active language
+ */
+  const getTranslatedErrorMessageKey = (rawError: string): string => {
     switch (rawError) {
       case 'Failed to fetch data by name':
-        return t('error_fetching_data_by_name');
+        return 'error_fetching_data_by_name';
       case 'Failed to fetch data by date':
-        return t('error_fetching_data_by_date');
+        return 'error_fetching_data_by_date';
       case 'Failed to fetch data':
-        return t('error_fetching_data');
+        return 'error_fetching_data';
+      case '':
+      case undefined:
+        return 'error_fetching_data';
       default:
-        return rawError; // fallback if no match
+        return rawError;// fallback if no match
     }
   };
   
@@ -93,8 +104,8 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
       }
 
       if (!Array.isArray(response)) {
-        console.error("Invalid response format:", response);
-        setFetchError(getTranslatedErrorMessage(response.error || ''));
+        console.error("Invalid response:", response.error || response);
+        setFetchError(getTranslatedErrorMessageKey(response.error || ''));
         setDatasets([]);
         return;
       }
@@ -297,7 +308,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
 
           {fetchError && (
             <div className="error-message" data-testid="error-message">
-              {fetchError}
+              {t(fetchError)}
             </div>
           )}
 

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -47,9 +47,8 @@ const resources = {
       toggle_datasets: 'Toggle Datasets',
       filtering_by_map_view: 'Filtering datasets by region',
       showing_all_datasets: 'Showing all datasets',
-      only_visible_datasets_shown: 'Only datasets in current map view',
-      including_outside_map_view: 'Including datasets outside visible area',
       map_required: 'Load map first',
+      // Filters
       name: 'Name',
       date: 'Date',
       latest_added: 'Latest Added',
@@ -78,6 +77,9 @@ const resources = {
       //Errors
       error_fetching_collections:
         'Failed to fetch collections. Please try again with a valid endpoint url.',
+      error_fetching_data: 'Failed to fetch data',
+      error_fetching_data_by_name: 'Failed to fetch data by name',
+      error_fetching_data_by_date: 'Failed to fetch data by date',
     },
   },
   fr: {
@@ -122,9 +124,14 @@ const resources = {
       confirm_deletion_items_from_previous_collection: "Les items de la collection précédente seront supprimés et remplacés par la nouvelle. \nVoulez-vous continuer",
       //Datasets
       available_datasets: 'Collections disponibles',
-      no_datasets_available: 'Aucune collections disponible.',
-      toggle_datasets: 'Afficher les collections de données',
-      // TODO: Translate the datasets strings
+      no_datasets_available: 'Aucune collection disponible.',
+      //Datasets - Toggle
+      toggle_datasets: "Basculer les jeux de données",
+      filtering_by_map_view: "Filtrer les données par région",
+      showing_all_datasets: "Affichage de toutes les données",
+      map_required: "Charger la carte d'abord",
+      // Filters
+      name: 'Nom',
       date: 'Date',
       latest_added: 'Dernier Ajouté',
       latest_updated: 'Dernière Mise à Jour',
@@ -152,6 +159,9 @@ const resources = {
       //Errors
       error_fetching_collections:
         "Impossible de récupérer les collections. Veuillez réessayer avec un URL d'endpoint valide.",
+      error_fetching_data: 'Échec de la récupération des données',
+      error_fetching_data_by_name: 'Échec de la récupération des données par nom',
+      error_fetching_data_by_date: 'Échec de la récupération des données par date',
     },
   },
 };


### PR DESCRIPTION
### Summary
This PR adds missing French translations related to dataset fetch errors in the AvailableDatasets component and ensures that error messages are properly mapped using i18n for localization.

### Changes Made
- Added missing French translation keys for dataset fetch errors (`error_fetching_data`, `error_fetching_data_by_name`, `error_fetching_data_by_date`)
- Implemented error message mapping in `AvailableDatasets.tsx` to use `i18n` translations instead of hardcoded strings

### Testing Instructions
1. Set application language to French via language button.
2. Trigger dataset fetch scenarios:
   - Filter by **Name** or **Date**
   - Simulate failed dataset fetch (e.g., by disabling internet or pointing to an invalid endpoint)
3. Verify that the displayed error messages appear in French and correspond to the appropriate scenario.

### Screenshots

| | | |
|:--:|:--:|:--:|
| ![image1](https://github.com/user-attachments/assets/7c629837-c6f0-45c9-8eed-5b04a3ea44a1) | ![image2](https://github.com/user-attachments/assets/e3a12ed7-b6a0-47af-9029-0d700ee67243) | ![image3](https://github.com/user-attachments/assets/5eb1bc2b-a00c-4f44-939d-71c27389a514) |
| ![image4](https://github.com/user-attachments/assets/6bee3430-284f-4f74-b7f0-8ca8409098dd) | ![image5](https://github.com/user-attachments/assets/fb1bedcf-cb81-4ab8-93d5-8130d51ac42d) |  |



### Additional Notes
- Error messages are still returned in English from the API services layer, but are now translated in the UI using `useTranslation`.
