### PR TITLE
#240 - bug(frontend): Fixed timeline blocking Available Datasets

### DIFF
--- a/apps/frontend/src/app/styles/AvailableDatasets.css
+++ b/apps/frontend/src/app/styles/AvailableDatasets.css
@@ -27,6 +27,13 @@ body {
   flex-direction: column;
 }
 
+@media (max-height: 700px) {
+  .datasets-container {
+    height: auto;
+    max-height: 85vh;
+  }
+}
+
 .datasets-container.collapsed {
   width: 75px;
   height: 75px;

--- a/apps/frontend/src/app/styles/AvailableDatasets.css
+++ b/apps/frontend/src/app/styles/AvailableDatasets.css
@@ -27,13 +27,6 @@ body {
   flex-direction: column;
 }
 
-@media (max-height: 700px) {
-  .datasets-container {
-    height: auto;
-    max-height: 85vh;
-  }
-}
-
 .datasets-container.collapsed {
   width: 75px;
   height: 75px;
@@ -309,4 +302,20 @@ body {
   right: calc(100% + 8px);
   color: #f44336;
   font-size: 0.8rem;
+}
+
+/* Optimizations for smaller screens*/
+@media (max-height: 700px) {
+  .datasets-container {
+    height: auto;
+    max-height: 85vh;
+  }
+}
+
+@media screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+  .datasets-container {
+    height: auto;
+    max-height: 85vh;
+    width: 450px;
+  }
 }

--- a/apps/frontend/src/app/styles/MapMetaData.css
+++ b/apps/frontend/src/app/styles/MapMetaData.css
@@ -115,3 +115,12 @@
 .load-dataset-button:active {
   transform: scale(0.98);
 }
+
+/* Optimizations for smaller screens */
+@media (max-height: 700px) {
+  .metadata-container {
+    top: 15%;
+  }
+}
+
+

--- a/apps/frontend/src/app/styles/Sidebar.css
+++ b/apps/frontend/src/app/styles/Sidebar.css
@@ -54,3 +54,26 @@
     opacity: 0.8;
   }
 }
+
+/* Optimizations for smaller screens */
+@media (max-height: 800px) {
+  .sidebar-component.expanded {
+    max-height: 30vh;
+    width:80px;
+    padding: 5px 15px 10px 15px;
+    bottom: 10vh;
+  }
+
+  .sidebar-component.collapsed {
+    width:80px;
+    padding: 5px 15px 10px 15px;
+    bottom: 10vh;
+  }
+
+  .icon {
+    width: 25px;
+    height: 25px;
+  }
+}
+
+


### PR DESCRIPTION
### Summary
This PR ensures that the available datasets container, and the views container both remain fully visible on smaller screens by adjusting its height dynamically.

Clarification for smaller screens: not optimized for mobile, but for reduced desktop browser screens.

### Changes Made
- Added media queries targeting screens with a max height of 700px.

### Testing Instructions
1. Reduce the screen height to 700px or smaller.
2. Verify that the available datasets and views container adjusts its size dynamically.
3. Ensure that the container is no longer blocked. 

https://github.com/user-attachments/assets/26d5bb40-e39c-4909-9acb-ff1f2e296172

