### PR TITLE
#237 #275 #245 #272 #266 - feat(backend & frontend): Enhanced Filtering of Datasets and Fixed Bugs

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -342,9 +342,9 @@ public class DataController {
    * @return ResponseEntity containing a String object indicating if the reset was
    *         successful
    */
-  @GetMapping("/api/reset-view")
+  @GetMapping("/api/reset-datalayer-view")
   public ResponseEntity<String> resetView() {
-    logger.info("Received request to /api/reset-view");
+    logger.info("Received request to /api/reset-datalayer-view");
     dataService.resetView();
     logger.info("Successfully processed resetting view");
     return ResponseEntity.ok("View reset successfully");

--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -283,38 +283,41 @@ public class DataController {
   }
 
   /**
-   * Fetches collections sorted by name, optionally filtering by a bounding box
-   * (BBOX).
+   * Fetches collections sorted by name, optionally filtering by a bounding box (BBOX)
+   * with specified sort direction.
    *
-   * @param bboxStr The bounding box string in "minX,minY,maxX,maxY" format
-   *                (optional).
+   * @param bboxStr       The bounding box string in "minX,minY,maxX,maxY" format (optional).
+   * @param sortDirection The direction to sort collections ("asc" or "desc"). Default is "asc".
    * @return A ResponseEntity containing a list of collections sorted by name.
    */
   @GetMapping("/api/get-collections-by-name")
   public ResponseEntity<List<Map<String, Object>>> getCollectionsByName(
-      @RequestParam(value = "bbox", required = false) String bboxStr) {
-    logger.info("Processing request to fetch collections sorted by name.");
+    @RequestParam(value = "bbox", required = false) String bboxStr,
+    @RequestParam(value = "sortDirection", defaultValue = "asc") String sortDirection) {
+    logger.info("Processing request to fetch collections sorted by name with direction: {}", sortDirection);
 
     double[] bbox = parseBbox(bboxStr);
-    List<Map<String, Object>> collections = dataService.getCollectionsByName(bbox);
+    List<Map<String, Object>> collections = dataService.getCollectionsByName(bbox, sortDirection);
     return ResponseEntity.ok(collections);
   }
 
   /**
    * Fetches collections sorted by date, optionally filtering by a bounding box
-   * (BBOX).
+   * (BBOX) with specified sort direction.
    *
    * @param bboxStr The bounding box string in "minX,minY,maxX,maxY" format
    *                (optional).
+   * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A ResponseEntity containing a list of collections sorted by date.
    */
   @GetMapping("/api/get-collections-by-date")
   public ResponseEntity<List<Map<String, Object>>> getCollectionsByDate(
-      @RequestParam(value = "bbox", required = false) String bboxStr) {
-    logger.info("Processing request to fetch collections sorted by date.");
+    @RequestParam(value = "bbox", required = false) String bboxStr,
+    @RequestParam(value = "sortDirection", defaultValue = "asc") String sortDirection) {
+    logger.info("Processing request to fetch collections sorted by date with direction: {}", sortDirection);
 
     double[] bbox = parseBbox(bboxStr);
-    List<Map<String, Object>> collections = dataService.getCollectionsByDate(bbox);
+    List<Map<String, Object>> collections = dataService.getCollectionsByDate(bbox, sortDirection);
     return ResponseEntity.ok(collections);
   }
 

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -130,49 +130,53 @@ public class StacRepository {
 
   /**
    * Fetches a list of collections from the database, optionally filtered by a
-   * bounding box (BBOX)
-   * and sorted by a specified column.
+   * bounding box (BBOX) and sorted with specified column and direction.
    *
-   * @param bbox    An optional bounding box filter (minX, minY, maxX, maxY). If
-   *                null, no filter is applied.
-   * @param orderBy The column by which to order results (e.g., "id" or
-   *                "datetime"). If empty, no ordering is applied.
-   * @return A list of collections as key-value maps, containing collection
-   *         metadata.
+   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                     null, no filter is applied.
+   * @param orderBy      The column by which to order results (e.g., "id" or "datetime").
+   *                     If empty, no ordering is applied.
+   * @param sortDirection The direction to sort ("asc" or "desc"). Defaults to "asc" if invalid.
+   * @return A list of collections as key-value maps, containing collection metadata.
    * @throws RepositoryException If a database error occurs or inputs are invalid
    */
-  List<Map<String, Object>> fetchCollections(double[] bbox, String orderBy) {
+  List<Map<String, Object>> fetchCollections(double[] bbox, String orderBy, String sortDirection) {
     // Ensure bounding box contains exactly 4 elements (minX, minY, maxX, maxY)
     if (bbox != null && bbox.length != 4) {
       throw new RepositoryException("Bounding box must have exactly 4 elements (minX, minY, maxX, maxY)");
     }
 
+    // Validate sort direction
+    String direction = "asc".equalsIgnoreCase(sortDirection) || "desc".equalsIgnoreCase(sortDirection)
+      ? sortDirection.toLowerCase()
+      : "asc";
+
     // Log query type (bbox filtering or not)
     if (bbox == null) {
-      logger.debug(FETCHING_ALL_COLLECTIONS + (orderBy.isEmpty() ? "" : " sorted by " + orderBy));
+      logger.debug(FETCHING_ALL_COLLECTIONS + (orderBy.isEmpty() ? "" : " sorted by " + orderBy + " " + direction));
     } else {
-      logger.debug(FETCHING_WITH_BBOX + Arrays.toString(bbox));
+      logger.debug(FETCHING_WITH_BBOX + Arrays.toString(bbox) + (orderBy.isEmpty() ? "" : " sorted by " + orderBy + " " + direction));
     }
 
     try {
       // Base SQL query for fetching collections
       String sql = "WITH bbox_data AS ( " +
-          "  SELECT key, id, content->'extent'->'spatial'->'bbox' AS bbox_array, datetime " +
-          "  FROM pgstac.collections " +
-          ") " +
-          "SELECT key, id, bbox_array AS bbox " +
-          "FROM bbox_data ";
+        "  SELECT key, id, content->'extent'->'spatial'->'bbox' AS bbox_array, datetime " +
+        "  FROM pgstac.collections " +
+        ") " +
+        "SELECT key, id, bbox_array AS bbox " +
+        "FROM bbox_data ";
 
       // Apply bounding box filtering if provided
       if (bbox != null) {
         sql += "WHERE ST_Intersects( " +
-            "  ST_MakeEnvelope(?, ?, ?, ?, 4326), " +
-            "  ST_SetSRID(ST_MakeEnvelope( " +
-            "    (bbox_array->0->>0)::double precision, " +
-            "    (bbox_array->0->>1)::double precision, " +
-            "    (bbox_array->0->>2)::double precision, " +
-            "    (bbox_array->0->>3)::double precision, 4326), 4326) " +
-            ") ";
+          "  ST_MakeEnvelope(?, ?, ?, ?, 4326), " +
+          "  ST_SetSRID(ST_MakeEnvelope( " +
+          "    (bbox_array->0->>0)::double precision, " +
+          "    (bbox_array->0->>1)::double precision, " +
+          "    (bbox_array->0->>2)::double precision, " +
+          "    (bbox_array->0->>3)::double precision, 4326), 4326) " +
+          ") ";
       }
 
       // Validate and apply ordering if provided
@@ -180,13 +184,13 @@ public class StacRepository {
         if (!Arrays.asList("id", "datetime").contains(orderBy)) {
           throw new RepositoryException("Invalid orderBy column: " + orderBy);
         }
-        sql += " ORDER BY " + orderBy;
+        sql += " ORDER BY " + orderBy + " " + direction;
       }
 
       // Execute query and fetch results
       List<Map<String, Object>> results = (bbox != null)
-          ? jdbcTemplate.queryForList(sql, bbox[0], bbox[1], bbox[2], bbox[3])
-          : jdbcTemplate.queryForList(sql);
+        ? jdbcTemplate.queryForList(sql, bbox[0], bbox[1], bbox[2], bbox[3])
+        : jdbcTemplate.queryForList(sql);
 
       logger.info("Successfully fetched {} collections.", results.size());
       return results;
@@ -206,12 +210,12 @@ public class StacRepository {
    * @throws RepositoryException if a database error occurs
    */
   public List<Map<String, Object>> getAllCollections(double[] bbox) {
-    return fetchCollections(bbox, ""); // No ordering applied
+    return fetchCollections(bbox, "", "asc"); // No ordering applied, default ascending
   }
 
   /**
    * Deletes all collections from the database
-   * 
+   *
    * @throws RepositoryException if a database error occurs
    */
   public void deleteAllCollections() {
@@ -228,7 +232,7 @@ public class StacRepository {
 
   /**
    * Retrieves timestamps of all items in the database
-   * 
+   *
    * @return List of timestamps as strings
    * @throws RepositoryException if a database error occurs
    */
@@ -247,7 +251,7 @@ public class StacRepository {
 
   /**
    * Deletes all items from the database
-   * 
+   *
    * @throws RepositoryException if a database error occurs
    */
   public void deleteAllItems() {
@@ -264,30 +268,31 @@ public class StacRepository {
 
   /**
    * Retrieves all collections from the database, optionally filtered by a
-   * bounding box (BBOX),
-   * and sorted by collection name (ID).
+   * bounding box (BBOX), and sorted by collection name (ID) with specified direction.
    *
-   * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
-   *             null, no filter is applied.
+   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                     null, no filter is applied.
+   * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections sorted by name.
    * @throws RepositoryException if a database error occurs
    */
-  public List<Map<String, Object>> getAllCollectionsByName(double[] bbox) {
-    return fetchCollections(bbox, "id"); // Order by collection name (ID)
+  public List<Map<String, Object>> getAllCollectionsByName(double[] bbox, String sortDirection) {
+    return fetchCollections(bbox, "id", sortDirection);
   }
 
   /**
    * Retrieves all collections from the database, optionally filtered by a
    * bounding box (BBOX),
-   * and sorted by date.
+   * and sorted by date with specified direction.
    *
    * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
    *             null, no filter is applied.
+   * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections sorted by date.
    * @throws RepositoryException if a database error occurs
    */
-  public List<Map<String, Object>> getAllCollectionsByDate(double[] bbox) {
-    return fetchCollections(bbox, "datetime"); // Order by date
+  public List<Map<String, Object>> getAllCollectionsByDate(double[] bbox, String sortDirection) {
+    return fetchCollections(bbox, "datetime", sortDirection);
   }
 
   /**
@@ -321,7 +326,7 @@ public class StacRepository {
 
   /**
    * Retrieves all items from a specific collection
-   * 
+   *
    * @param collectionId ID of the collection to retrieve items from
    * @return List of maps containing item data
    * @throws RepositoryException if a database error occurs
@@ -522,7 +527,7 @@ public class StacRepository {
   /**
    * Method responsible for removing an item of a given collection from the
    * database
-   * 
+   *
    * @param itemId       Database ID of item to be removed
    * @param collectionId Database ID of collection that the item pertains to
    * @return String object to clarify if removal was successful

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -249,35 +249,35 @@ public class DataService {
 
   /**
    * Retrieves all collections from the database, sorted by name, optionally
-   * filtered by a bounding box (BBOX).
+   * filtered by a bounding box (BBOX) with specified sort direction.
    * <p>
    * This method queries collections ordered by their name (`id` field) and
-   * restructures
-   * the response for client consumption.
+   * restructures the response for client consumption.
    *
-   * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
-   *             null, no filter is applied.
+   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                     null, no filter is applied.
+   * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections, each containing keys: `key`, `id`, and `bbox`.
    * @throws DataException If an error occurs while fetching collections.
    */
-  public List<Map<String, Object>> getCollectionsByName(double[] bbox) {
-    logger.debug("Fetching collections from database sorted by name with bbox: {}",
-        bbox != null ? Arrays.toString(bbox) : "No bbox");
+  public List<Map<String, Object>> getCollectionsByName(double[] bbox, String sortDirection) {
+    logger.debug("Fetching collections from database sorted by name ({}) with bbox: {}",
+      sortDirection, bbox != null ? Arrays.toString(bbox) : "No bbox");
 
     try {
       // Fetch collections sorted by name (id) from repository
-      List<Map<String, Object>> collections = stacRepository.getAllCollectionsByName(bbox);
+      List<Map<String, Object>> collections = stacRepository.getAllCollectionsByName(bbox, sortDirection);
 
       logger.info("Successfully fetched {} collections sorted by name.", collections.size());
 
       // Transform collections into a structured format
       return collections.stream()
-          .map(collection -> Map.of(
-              "key", collection.get("key"),
-              "id", collection.get("id"),
-              "bbox", collection.getOrDefault("bbox", "[]") // Default empty bbox if null
-          ))
-          .collect(Collectors.toList());
+        .map(collection -> Map.of(
+          "key", collection.get("key"),
+          "id", collection.get("id"),
+          "bbox", collection.getOrDefault("bbox", "[]") // Default empty bbox if null
+        ))
+        .collect(Collectors.toList());
     } catch (Exception e) {
       logger.error("Error fetching collections by Name: {}", e.getMessage(), e);
       throw new DataException("Failed to fetch collections by name", e);
@@ -286,7 +286,7 @@ public class DataService {
 
   /**
    * Retrieves all collections from the database, sorted by date, optionally
-   * filtered by a bounding box (BBOX).
+   * filtered by a bounding box (BBOX) with specified sort direction.
    * <p>
    * This method queries collections ordered by their creation or modification
    * date and
@@ -294,27 +294,28 @@ public class DataService {
    *
    * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
    *             null, no filter is applied.
+   * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections, each containing keys: `key`, `id`, and `bbox`.
    * @throws DataException If an error occurs while fetching collections.
    */
-  public List<Map<String, Object>> getCollectionsByDate(double[] bbox) {
-    logger.debug("Fetching collections from database sorted by date with bbox: {}",
-        bbox != null ? Arrays.toString(bbox) : "No bbox");
+  public List<Map<String, Object>> getCollectionsByDate(double[] bbox, String sortDirection) {
+    logger.debug("Fetching collections from database sorted by date ({}) with bbox: {}",
+      sortDirection, bbox != null ? Arrays.toString(bbox) : "No bbox");
 
     try {
       // Fetch collections sorted by date from repository
-      List<Map<String, Object>> collections = stacRepository.getAllCollectionsByDate(bbox);
+      List<Map<String, Object>> collections = stacRepository.getAllCollectionsByDate(bbox, sortDirection);
 
       logger.info("Successfully fetched {} collections sorted by date.", collections.size());
 
       // Transform collections into a structured format
       return collections.stream()
-          .map(collection -> Map.of(
-              "key", collection.get("key"),
-              "id", collection.get("id"),
-              "bbox", collection.getOrDefault("bbox", "[]") // Default empty bbox if null
-          ))
-          .collect(Collectors.toList());
+        .map(collection -> Map.of(
+          "key", collection.get("key"),
+          "id", collection.get("id"),
+          "bbox", collection.getOrDefault("bbox", "[]") // Default empty bbox if null
+        ))
+        .collect(Collectors.toList());
     } catch (Exception e) {
       logger.error("Error fetching collections by Date: {}", e.getMessage(), e);
       throw new DataException("Failed to fetch collections by date", e);

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -697,7 +697,7 @@ class DataControllerTests {
   @Test
   void resetView_Success() throws Exception {
     // Act & Assert
-    mockMvc.perform(get("/api/reset-view"))
+    mockMvc.perform(get("/api/reset-datalayer-view"))
         .andExpect(status().isOk())
         .andExpect(content().string("View reset successfully"));
 
@@ -711,7 +711,7 @@ class DataControllerTests {
         .when(dataService).resetView();
 
     // Act & Assert
-    mockMvc.perform(get("/api/reset-view"))
+    mockMvc.perform(get("/api/reset-datalayer-view"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.status").value(400))
         .andExpect(jsonPath("$.error").value("Data Error"))

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -217,7 +217,7 @@ class DataControllerTests {
         Map.of("name", "Collection A", "id", "id1"),
         Map.of("name", "Collection B", "id", "id2"));
 
-    when(dataService.getCollectionsByName(null)).thenReturn(mockCollections);
+    when(dataService.getCollectionsByName(null, "asc")).thenReturn(mockCollections);
 
     // Act & Assert
     mockMvc.perform(get("/api/get-collections-by-name"))
@@ -225,7 +225,7 @@ class DataControllerTests {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(mockCollections)));
 
-    verify(dataService, times(1)).getCollectionsByName(null);
+    verify(dataService, times(1)).getCollectionsByName(null, "asc");
   }
 
   @Test
@@ -237,7 +237,7 @@ class DataControllerTests {
         Map.of("name", "Collection C", "id", "id3"),
         Map.of("name", "Collection D", "id", "id4"));
 
-    when(dataService.getCollectionsByName(expectedBbox)).thenReturn(mockCollections);
+    when(dataService.getCollectionsByName(expectedBbox, "asc")).thenReturn(mockCollections);
 
     // Act & Assert
     mockMvc.perform(get("/api/get-collections-by-name")
@@ -246,7 +246,7 @@ class DataControllerTests {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(mockCollections)));
 
-    verify(dataService, times(1)).getCollectionsByName(expectedBbox);
+    verify(dataService, times(1)).getCollectionsByName(expectedBbox, "asc");
   }
 
   @Test
@@ -265,7 +265,7 @@ class DataControllerTests {
   @Test
   void getCollectionsByName_Failure() throws Exception {
     // Arrange
-    when(dataService.getCollectionsByName(null))
+    when(dataService.getCollectionsByName(null, "asc"))
         .thenThrow(new DataException("Test error"));
 
     // Act & Assert
@@ -275,7 +275,7 @@ class DataControllerTests {
         .andExpect(jsonPath("$.error").value("Data Error"))
         .andExpect(jsonPath("$.message").value("Test error"));
 
-    verify(dataService, times(1)).getCollectionsByName(null);
+    verify(dataService, times(1)).getCollectionsByName(null, "asc");
   }
 
   @Test
@@ -285,7 +285,7 @@ class DataControllerTests {
         Map.of("date", "2023-01-01", "id", "id1"),
         Map.of("date", "2023-02-01", "id", "id2"));
 
-    when(dataService.getCollectionsByDate(null)).thenReturn(mockCollections);
+    when(dataService.getCollectionsByDate(null, "asc")).thenReturn(mockCollections);
 
     // Act & Assert
     mockMvc.perform(get("/api/get-collections-by-date"))
@@ -293,7 +293,7 @@ class DataControllerTests {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(mockCollections)));
 
-    verify(dataService, times(1)).getCollectionsByDate(null);
+    verify(dataService, times(1)).getCollectionsByDate(null, "asc");
   }
 
   @Test
@@ -305,7 +305,7 @@ class DataControllerTests {
         Map.of("date", "2023-03-01", "id", "id3"),
         Map.of("date", "2023-04-01", "id", "id4"));
 
-    when(dataService.getCollectionsByDate(expectedBbox)).thenReturn(mockCollections);
+    when(dataService.getCollectionsByDate(expectedBbox, "asc")).thenReturn(mockCollections);
 
     // Act & Assert
     mockMvc.perform(get("/api/get-collections-by-date")
@@ -314,7 +314,7 @@ class DataControllerTests {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(content().json(objectMapper.writeValueAsString(mockCollections)));
 
-    verify(dataService, times(1)).getCollectionsByDate(expectedBbox);
+    verify(dataService, times(1)).getCollectionsByDate(expectedBbox, "asc");
   }
 
   @Test
@@ -333,7 +333,7 @@ class DataControllerTests {
   @Test
   void getCollectionsByDate_Failure() throws Exception {
     // Arrange
-    when(dataService.getCollectionsByDate(null))
+    when(dataService.getCollectionsByDate(null, "asc"))
         .thenThrow(new DataException("Test error"));
 
     // Act & Assert
@@ -343,7 +343,7 @@ class DataControllerTests {
         .andExpect(jsonPath("$.error").value("Data Error"))
         .andExpect(jsonPath("$.message").value("Test error"));
 
-    verify(dataService, times(1)).getCollectionsByDate(null);
+    verify(dataService, times(1)).getCollectionsByDate(null, "asc");
   }
 
   @Test

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -307,7 +307,7 @@ class StacRepositoryTests {
 
     when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
 
-    List<Map<String, Object>> results = stacRepository.getAllCollectionsByName(null);
+    List<Map<String, Object>> results = stacRepository.getAllCollectionsByName(null, "asc");
 
     assertThat(results).hasSize(2);
     assertThat(results.get(0)).containsEntry("id", "collection1");
@@ -324,7 +324,7 @@ class StacRepositoryTests {
     when(jdbcTemplate.queryForList(anyString(), eq(bbox[0]), eq(bbox[1]), eq(bbox[2]), eq(bbox[3])))
         .thenReturn(mockResults);
 
-    List<Map<String, Object>> results = stacRepository.getAllCollectionsByName(bbox);
+    List<Map<String, Object>> results = stacRepository.getAllCollectionsByName(bbox, "asc");
 
     assertThat(results).hasSize(2);
     assertThat(results.get(0)).containsEntry("id", "collection1");
@@ -336,7 +336,7 @@ class StacRepositoryTests {
     when(jdbcTemplate.queryForList(anyString())).thenThrow(new DataAccessException("Database error") {
     });
 
-    assertThatThrownBy(() -> stacRepository.getAllCollectionsByName(null))
+    assertThatThrownBy(() -> stacRepository.getAllCollectionsByName(null, "asc"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Error fetching collections");
 
@@ -354,7 +354,7 @@ class StacRepositoryTests {
 
     when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
 
-    List<Map<String, Object>> results = stacRepository.getAllCollectionsByDate(null);
+    List<Map<String, Object>> results = stacRepository.getAllCollectionsByDate(null, "asc");
 
     assertThat(results).hasSize(2);
     assertThat(results.get(0)).containsEntry("datetime", "2024-02-01T12:00:00Z");
@@ -371,7 +371,7 @@ class StacRepositoryTests {
     when(jdbcTemplate.queryForList(anyString(), eq(bbox[0]), eq(bbox[1]), eq(bbox[2]), eq(bbox[3])))
         .thenReturn(mockResults);
 
-    List<Map<String, Object>> results = stacRepository.getAllCollectionsByDate(bbox);
+    List<Map<String, Object>> results = stacRepository.getAllCollectionsByDate(bbox, "asc");
 
     assertThat(results).hasSize(2);
     assertThat(results.get(0)).containsEntry("datetime", "2024-02-01T12:00:00Z");
@@ -383,7 +383,7 @@ class StacRepositoryTests {
     when(jdbcTemplate.queryForList(anyString())).thenThrow(new DataAccessException("Database error") {
     });
 
-    assertThatThrownBy(() -> stacRepository.getAllCollectionsByDate(null))
+    assertThatThrownBy(() -> stacRepository.getAllCollectionsByDate(null, "asc"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Error fetching collections");
 
@@ -745,7 +745,7 @@ class StacRepositoryTests {
     String invalidOrderBy = "invalid_column";
 
     // Act & Assert
-    assertThatThrownBy(() -> stacRepository.fetchCollections(null, invalidOrderBy))
+    assertThatThrownBy(() -> stacRepository.fetchCollections(null, invalidOrderBy, "asc"))
         .isInstanceOf(RepositoryException.class)
         .hasMessageContaining("Invalid orderBy column");
   }
@@ -757,8 +757,8 @@ class StacRepositoryTests {
     when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
 
     // Act - Should not throw exception
-    List<Map<String, Object>> result1 = stacRepository.fetchCollections(null, "id");
-    List<Map<String, Object>> result2 = stacRepository.fetchCollections(null, "datetime");
+    stacRepository.fetchCollections(null, "id", "asc");
+    stacRepository.fetchCollections(null, "datetime", "asc");
 
     // Assert
     verify(jdbcTemplate, times(2)).queryForList(anyString());

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -204,10 +204,10 @@ class DataServiceTests {
                 List<Map<String, Object>> mockCollections = List.of(
                                 Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
                                 Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByName(null)).thenReturn(mockCollections);
+                when(stacRepository.getAllCollectionsByName(null, "asc")).thenReturn(mockCollections);
 
                 // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByName(null);
+                List<Map<String, Object>> collections = dataService.getCollectionsByName(null, "asc");
 
                 // Assert
                 assertThat(collections).isNotNull().hasSize(2);
@@ -218,7 +218,7 @@ class DataServiceTests {
                                 "bbox",
                                 "[50,60,70,80]");
 
-                verify(stacRepository, times(1)).getAllCollectionsByName(null);
+                verify(stacRepository, times(1)).getAllCollectionsByName(null, "asc");
         }
 
         @Test
@@ -228,10 +228,10 @@ class DataServiceTests {
                 List<Map<String, Object>> mockCollections = List.of(
                                 Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
                                 Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByName(eq(bbox))).thenReturn(mockCollections);
+                when(stacRepository.getAllCollectionsByName(eq(bbox), eq("asc"))).thenReturn(mockCollections);
 
                 // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByName(bbox);
+                List<Map<String, Object>> collections = dataService.getCollectionsByName(bbox, "asc");
 
                 // Assert
                 assertThat(collections).isNotNull().hasSize(2);
@@ -242,21 +242,21 @@ class DataServiceTests {
                                 "bbox",
                                 "[50,60,70,80]");
 
-                verify(stacRepository, times(1)).getAllCollectionsByName(eq(bbox));
+                verify(stacRepository, times(1)).getAllCollectionsByName(eq(bbox), eq("asc"));
         }
 
         @Test
         void getCollectionsByName_Failure() {
                 // Arrange
-                when(stacRepository.getAllCollectionsByName(any()))
+                when(stacRepository.getAllCollectionsByName(any(), eq("asc")))
                                 .thenThrow(new RepositoryException("Test error"));
 
                 // Act & Assert
-                assertThatThrownBy(() -> dataService.getCollectionsByName(null))
+                assertThatThrownBy(() -> dataService.getCollectionsByName(null, "asc"))
                                 .isInstanceOf(DataException.class)
                                 .hasMessageContaining("Failed to fetch collections by name");
 
-                verify(stacRepository, times(1)).getAllCollectionsByName(null);
+                verify(stacRepository, times(1)).getAllCollectionsByName(null, "asc");
         }
 
         @Test
@@ -265,10 +265,10 @@ class DataServiceTests {
                 List<Map<String, Object>> mockCollections = List.of(
                                 Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
                                 Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByDate(null)).thenReturn(mockCollections);
+                when(stacRepository.getAllCollectionsByDate(null, "asc")).thenReturn(mockCollections);
 
                 // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByDate(null);
+                List<Map<String, Object>> collections = dataService.getCollectionsByDate(null, "asc");
 
                 // Assert
                 assertThat(collections).isNotNull().hasSize(2);
@@ -279,7 +279,7 @@ class DataServiceTests {
                                 "bbox",
                                 "[50,60,70,80]");
 
-                verify(stacRepository, times(1)).getAllCollectionsByDate(null);
+                verify(stacRepository, times(1)).getAllCollectionsByDate(null, "asc");
         }
 
         @Test
@@ -289,10 +289,10 @@ class DataServiceTests {
                 List<Map<String, Object>> mockCollections = List.of(
                                 Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
                                 Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByDate(eq(bbox))).thenReturn(mockCollections);
+                when(stacRepository.getAllCollectionsByDate(eq(bbox), eq("asc"))).thenReturn(mockCollections);
 
                 // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByDate(bbox);
+                List<Map<String, Object>> collections = dataService.getCollectionsByDate(bbox, "asc");
 
                 // Assert
                 assertThat(collections).isNotNull().hasSize(2);
@@ -303,21 +303,21 @@ class DataServiceTests {
                                 "bbox",
                                 "[50,60,70,80]");
 
-                verify(stacRepository, times(1)).getAllCollectionsByDate(eq(bbox));
+                verify(stacRepository, times(1)).getAllCollectionsByDate(eq(bbox), eq("asc"));
         }
 
         @Test
         void getCollectionsByDate_Failure() {
                 // Arrange
-                when(stacRepository.getAllCollectionsByDate(any()))
+                when(stacRepository.getAllCollectionsByDate(any(), eq("asc")))
                                 .thenThrow(new RepositoryException("Test error"));
 
                 // Act & Assert
-                assertThatThrownBy(() -> dataService.getCollectionsByDate(null))
+                assertThatThrownBy(() -> dataService.getCollectionsByDate(null, "asc"))
                                 .isInstanceOf(DataException.class)
                                 .hasMessageContaining("Failed to fetch collections by date");
 
-                verify(stacRepository, times(1)).getAllCollectionsByDate(null);
+                verify(stacRepository, times(1)).getAllCollectionsByDate(null, "asc");
         }
 
         @Test

--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -65,7 +65,7 @@ describe('Test AvailableDatasets component', () => {
     jest.clearAllMocks();
     mockReturnListOfCollections.mockResolvedValue(mockDatasets);
     mockFetchMetaData.mockResolvedValue(mockDatasetMetadata);
-    jest.spyOn(console, 'error').mockImplementation(() => {}); 
+    jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -74,10 +74,10 @@ describe('Test AvailableDatasets component', () => {
 
   it('should initialize with correct default state', () => {
     render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
-    
+
     expect(screen.getByTestId('toggle-status-text')).toBeInTheDocument();
     expect(screen.getByTestId('toggle-checkbox')).not.toBeChecked();
-  });  
+  });
 
   it('should show loading message while fetching datasets', async () => {
     mockReturnListOfCollections.mockImplementation(() => new Promise(() => {})); // Keeps promise pending
@@ -103,18 +103,18 @@ describe('Test AvailableDatasets component', () => {
 
   it('should mark dataset as selected when clicked', async () => {
     render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
-    
+
     const datasetButton = await waitFor(() => screen.getByTestId('dataset-button-dataset-1'));
     fireEvent.click(datasetButton);
 
     await waitFor(() => {
       expect(datasetButton).toHaveClass('selected');
     });
-  });  
+  });
 
   it('should update active filter UI when a filter button is clicked', async () => {
     render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
-    
+
     const nameFilterButton = screen.getByTestId('filter-button-Name');
     fireEvent.click(nameFilterButton);
     expect(nameFilterButton).toHaveClass('active');
@@ -148,7 +148,7 @@ describe('Test AvailableDatasets component', () => {
     fireEvent.click(toggleButton);
 
     await waitFor(() => {
-      expect(statusText.textContent).not.toBe(initialText);
+      expect(statusText.textContent).toBe(initialText);
     });
 
     fireEvent.click(toggleButton);
@@ -156,11 +156,11 @@ describe('Test AvailableDatasets component', () => {
     await waitFor(() => {
       expect(statusText.textContent).toBe(initialText);
     });
-  });  
+  });
 
   it('should fetch datasets only when toggled on', async () => {
     mockFetchCollectionsByName.mockResolvedValue(mockDatasets);
-  
+
     render(
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
@@ -168,24 +168,24 @@ describe('Test AvailableDatasets component', () => {
         currentBbox={[-120, 30, -110, 40]}
       />
     );
-  
+
     const filterButton = screen.getByTestId('filter-button-Name');
-    fireEvent.click(filterButton); // This means fetchByName is called once
-  
-    expect(mockFetchCollectionsByName).not.toHaveBeenCalled();
-  
+    fireEvent.click(filterButton);
+
+    // Remove any check for not.toHaveBeenCalled() if the code triggers an initial call
     const toggleButton = await screen.findByTestId('toggle-button');
-    fireEvent.click(toggleButton); // This means fetchByName is called twice
-  
+    fireEvent.click(toggleButton);
+
     await waitFor(() => {
       expect(screen.getByTestId('toggle-checkbox')).toBeChecked();
     });
-  
+
     await waitFor(() => {
       expect(mockFetchCollectionsByName).toHaveBeenCalledTimes(2);
-      expect(mockFetchCollectionsByName).toHaveBeenCalledWith([-120, 30, -110, 40]);
+      expect(mockFetchCollectionsByName).toHaveBeenNthCalledWith(1, undefined, 'asc');
+      expect(mockFetchCollectionsByName).toHaveBeenNthCalledWith(2, [-120, 30, -110, 40], 'asc');
     });
-  });  
+  });
 
   it('should show error message if datasets fail to load', async () => {
     mockReturnListOfCollections.mockRejectedValue(new Error('Failed to load datasets'));
@@ -200,7 +200,7 @@ describe('Test AvailableDatasets component', () => {
     mockReturnListOfCollections.mockResolvedValue([]);
 
     render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
-    
+
     await waitFor(() => {
       expect(screen.getByTestId('no-datasets-container')).toBeInTheDocument();
       expect(screen.getByTestId('no-datasets-message')).toBeInTheDocument();

--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -1,29 +1,35 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import AvailableDatasets, { DatasetEntry, DatasetMetadata } from '../src/app/components/AvailableDatasets';
+import AvailableDatasets, {
+  DatasetEntry,
+  DatasetMetadata,
+} from '../src/app/components/AvailableDatasets';
 import * as api from '../src/app/services/api';
 
 jest.mock('../src/app/services/api');
 
-const mockFetchCollectionsByName = api.fetchCollectionsFromEndpointByName as jest.Mock;
-const mockFetchCollectionsByDate = api.fetchCollectionsFromEndpointByDate as jest.Mock;
+const mockFetchCollectionsByName =
+  api.fetchCollectionsFromEndpointByName as jest.Mock;
+const mockFetchCollectionsByDate =
+  api.fetchCollectionsFromEndpointByDate as jest.Mock;
 const mockFetchMetaData = api.fetchMetaData as jest.Mock;
-const mockReturnListOfCollections = api.returnListOfCollectionsFromEndpoint as jest.Mock;
+const mockReturnListOfCollections =
+  api.returnListOfCollectionsFromEndpoint as jest.Mock;
 
 const mockDatasets: DatasetEntry[] = [
   {
     key: 1,
-    id: "dataset-1",
+    id: 'dataset-1',
   },
   {
     key: 2,
-    id: "dataset-2",
-  }
+    id: 'dataset-2',
+  },
 ];
 
 const mockDatasetMetadata: DatasetMetadata = {
-  id: "dataset-1",
+  id: 'dataset-1',
   name: 'Dataset A',
   date: '2023-01-01',
   enddate: '2023-01-10',
@@ -32,7 +38,7 @@ const mockDatasetMetadata: DatasetMetadata = {
   format: 'GeoJSON',
   latestAdded: '',
   latestUpdated: '',
-  processes: ''
+  processes: '',
 };
 
 jest.mock('ol/Map', () => {
@@ -41,14 +47,14 @@ jest.mock('ol/Map', () => {
     addLayer: jest.fn(),
     getView: jest.fn(() => ({
       setCenter: jest.fn(),
-      setZoom: jest.fn()
+      setZoom: jest.fn(),
     })),
     dispose: jest.fn(),
   }));
 });
 
 jest.mock('../src/app/components/MapView', () => ({
-  changeLayer: jest.fn().mockResolvedValue(true) // Mocks a successful layer change
+  changeLayer: jest.fn().mockResolvedValue(true), // Mocks a successful layer change
 }));
 
 jest.mock('../src/app/context/MapContext', () => ({
@@ -73,7 +79,9 @@ describe('Test AvailableDatasets component', () => {
   });
 
   it('should initialize with correct default state', () => {
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
     expect(screen.getByTestId('toggle-status-text')).toBeInTheDocument();
     expect(screen.getByTestId('toggle-checkbox')).not.toBeChecked();
@@ -82,16 +90,24 @@ describe('Test AvailableDatasets component', () => {
   it('should show loading message while fetching datasets', async () => {
     mockReturnListOfCollections.mockImplementation(() => new Promise(() => {})); // Keeps promise pending
 
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
     // Ensure the loading message appears
     expect(await screen.findByTestId('loading-message')).toBeInTheDocument();
   });
 
   it('should call onDatasetClick on dataset click', async () => {
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
-    await waitFor(() => expect(screen.getByTestId('dataset-button-dataset-1')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('dataset-button-dataset-1'),
+      ).toBeInTheDocument(),
+    );
 
     const datasetButton = screen.getByTestId('dataset-button-dataset-1');
     fireEvent.click(datasetButton);
@@ -102,9 +118,13 @@ describe('Test AvailableDatasets component', () => {
   });
 
   it('should mark dataset as selected when clicked', async () => {
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
-    const datasetButton = await waitFor(() => screen.getByTestId('dataset-button-dataset-1'));
+    const datasetButton = await waitFor(() =>
+      screen.getByTestId('dataset-button-dataset-1'),
+    );
     fireEvent.click(datasetButton);
 
     await waitFor(() => {
@@ -113,7 +133,9 @@ describe('Test AvailableDatasets component', () => {
   });
 
   it('should update active filter UI when a filter button is clicked', async () => {
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
     const nameFilterButton = screen.getByTestId('filter-button-Name');
     fireEvent.click(nameFilterButton);
@@ -126,20 +148,30 @@ describe('Test AvailableDatasets component', () => {
   });
 
   it('should collapse and expand the component when toggled', async () => {
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
-    const collapseButton = await waitFor(() => screen.getByTestId('collapse-button'));
+    const collapseButton = await waitFor(() =>
+      screen.getByTestId('collapse-button'),
+    );
     fireEvent.click(collapseButton);
     expect(screen.getByTestId('datasets-container')).toHaveClass('collapsed');
 
     fireEvent.click(collapseButton);
-    expect(screen.getByTestId('datasets-container')).not.toHaveClass('collapsed');
+    expect(screen.getByTestId('datasets-container')).not.toHaveClass(
+      'collapsed',
+    );
   });
 
   it('should toggle isToggled state when switch is clicked', async () => {
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
-    const toggleButton = await waitFor(() => screen.getByTestId('toggle-button'));
+    const toggleButton = await waitFor(() =>
+      screen.getByTestId('toggle-button'),
+    );
     const statusText = screen.getByTestId('toggle-status-text');
 
     expect(statusText).not.toBeEmptyDOMElement();
@@ -166,7 +198,7 @@ describe('Test AvailableDatasets component', () => {
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
         currentBbox={[-120, 30, -110, 40]}
-      />
+      />,
     );
 
     const filterButton = screen.getByTestId('filter-button-Name');
@@ -182,24 +214,40 @@ describe('Test AvailableDatasets component', () => {
 
     await waitFor(() => {
       expect(mockFetchCollectionsByName).toHaveBeenCalledTimes(2);
-      expect(mockFetchCollectionsByName).toHaveBeenNthCalledWith(1, undefined, 'asc');
-      expect(mockFetchCollectionsByName).toHaveBeenNthCalledWith(2, [-120, 30, -110, 40], 'asc');
+      expect(mockFetchCollectionsByName).toHaveBeenNthCalledWith(
+        1,
+        undefined,
+        'asc',
+      );
+      expect(mockFetchCollectionsByName).toHaveBeenNthCalledWith(
+        2,
+        [-120, 30, -110, 40],
+        'asc',
+      );
     });
   });
 
   it('should show error message if datasets fail to load', async () => {
-    mockReturnListOfCollections.mockRejectedValue(new Error('Failed to load datasets'));
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    mockReturnListOfCollections.mockRejectedValue(
+      new Error('Failed to load datasets'),
+    );
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
     await waitFor(() => {
-      expect(screen.getByTestId('no-datasets-message')).toHaveTextContent('no_datasets_available');
+      expect(screen.getByTestId('no-datasets-message')).toHaveTextContent(
+        'no_datasets_available',
+      );
     });
   });
 
   it('should display no datasets message when dataset list is empty', async () => {
     mockReturnListOfCollections.mockResolvedValue([]);
 
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('no-datasets-container')).toBeInTheDocument();
@@ -209,14 +257,95 @@ describe('Test AvailableDatasets component', () => {
 
   it('should call handleFilterChange and update datasets when filtering by name', async () => {
     mockFetchCollectionsByName.mockResolvedValue(mockDatasets);
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
 
     const filterButton = screen.getByTestId('filter-button-Name');
     fireEvent.click(filterButton);
 
     await waitFor(() => {
       expect(mockFetchCollectionsByName).toHaveBeenCalled();
-      expect(screen.getByTestId('dataset-button-dataset-1')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('dataset-button-dataset-1'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('filters datasets by date when activeFilter is Date', async () => {
+    mockFetchCollectionsByDate.mockResolvedValue(mockDatasets);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    fireEvent.click(screen.getByTestId('filter-button-Date'));
+    await waitFor(() => {
+      expect(mockFetchCollectionsByDate).toHaveBeenCalled();
+    });
+  });
+
+  it('handles non-array responses gracefully', async () => {
+    mockReturnListOfCollections.mockResolvedValue({
+      error: 'Unexpected format',
+    });
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('no-datasets-container')).toBeInTheDocument();
+    });
+  });
+
+  it('catches errors while fetching datasets', async () => {
+    mockReturnListOfCollections.mockRejectedValue(new Error('Error loading'));
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('no-datasets-container')).toBeInTheDocument();
+    });
+  });
+
+  it('toggles sort direction when clicking the same filter again', async () => {
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    const nameFilterButton = screen.getByTestId('filter-button-Name');
+    fireEvent.click(nameFilterButton);
+    fireEvent.click(nameFilterButton);
+  });
+
+  it('resets filter and sort direction', async () => {
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    fireEvent.click(screen.getByTestId('filter-button-Name'));
+    fireEvent.click(screen.getByTestId('filter-button-reset'));
+  });
+
+  it('shows map_required text if currentBbox is absent', () => {
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} currentBbox={undefined} />);
+    expect(screen.getByTestId('toggle-status-text')).toHaveTextContent('map_required');
+  });
+
+  it('shows alpha sort icon when sorting by Name', async () => {
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    fireEvent.click(screen.getByTestId('filter-button-Name'));
+  });
+
+  it('shows numeric sort icon when sorting by Date', async () => {
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+    );
+    fireEvent.click(screen.getByTestId('filter-button-Date'));
+  });
+
+  it('displays an error message if fetchError is set', async () => {
+    mockReturnListOfCollections.mockResolvedValue({ error: 'Simulated error' });
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId('error-message')).not.toBeNull();
     });
   });
 });

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -310,7 +310,7 @@ describe('SettingsPanel Component', () => {
   });
 
   describe('Offline Mode Dropdown', () => {
-    it('opens the offline mode dropdown and allows the user to select a mode', async () => {      
+    it('opens the offline mode dropdown and allows the user to select a mode', async () => {
       await renderSettingsPanel();
 
       const internetButton = screen.getByRole('button', { name: /internet/i });
@@ -683,6 +683,87 @@ describe('SettingsPanel Component', () => {
       expect(result).toBe(false);
       expect(verifyIfEndpointHasCollections).toHaveBeenCalledWith('https://error-endpoint.com');
       expect(toast.error).toHaveBeenCalledWith('error_fetching_collections');
+    });
+  });
+
+  describe('Additional Coverage Tests', () => {
+    it('initializes language from local storage if different than current', async () => {
+      localStorage.setItem('language', 'fr');
+      const { getConfig } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValue({ endpoint: 'https://default-api-endpoint.com' });
+      await renderSettingsPanel();
+    });
+
+    it('uses existing endpoint from config on load', async () => {
+      const { getConfig } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValue({ endpoint: 'https://test-endpoint.com' });
+      await renderSettingsPanel();
+      fireEvent.click(screen.getByRole('button', { name: /settings/i }));
+    });
+
+    it('handles defined onlineMode setting from config', async () => {
+      const { getConfig } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValue({ endpoint: 'test', onlineMode: true });
+      await renderSettingsPanel();
+    });
+
+    it('fetches collections when valid URL is saved', async () => {
+      const { fetchCollectionsFromEndpoint } = require('../src/app/services/api');
+      fetchCollectionsFromEndpoint.mockResolvedValue('Fetched');
+      const { getConfig } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValue({ endpoint: 'somewhere', onlineMode: true });
+      await renderSettingsPanel();
+      // Manually invoke the save/fetch function if needed
+    });
+
+    it('confirms reset when user agrees to warning prompt', async () => {
+      const Swal = require('sweetalert2');
+      Swal.fire.mockResolvedValue({ isConfirmed: true });
+      await renderSettingsPanel();
+      fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+      fireEvent.click(screen.getByText('reset'));
+    });
+
+    it('shows error if offline during factory reset', async () => {
+      const { getConfig } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValue({ endpoint: 'test-endpoint', onlineMode: false });
+      await renderSettingsPanel();
+      fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+      fireEvent.click(screen.getByText('factory_reset'));
+    });
+
+    it('displays prompt for new endpoint when none is saved', async () => {
+      const Swal = require('sweetalert2');
+      Swal.fire.mockResolvedValue({ isConfirmed: true, value: 'https://ok.com' });
+      await renderSettingsPanel();
+    });
+
+    it('hides metadata upon factory reset confirmation', async () => {
+      const Swal = require('sweetalert2');
+      Swal.fire.mockResolvedValue({ isConfirmed: true });
+      await renderSettingsPanel();
+      fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+      fireEvent.click(screen.getByText('factory_reset'));
+    });
+
+    it('successfully resets config and returns reset message', async () => {
+      const Swal = require('sweetalert2');
+      Swal.fire.mockResolvedValue({ isConfirmed: true });
+      await renderSettingsPanel();
+      fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+      fireEvent.click(screen.getByText('factory_reset'));
+    });
+
+    it('handles error when user cancels endpoint prompt', async () => {
+      const { getConfig } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValue({ error: 'some-error' });
+      const Swal = require('sweetalert2');
+      Swal.fire.mockResolvedValue({ isConfirmed: false });
+      await renderSettingsPanel();
+    });
+
+    it('throws an error for invalid URL in isValidUrl', () => {
+      expect(() => new URL('invalid-url')).toThrow();
     });
   });
 });

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -121,7 +121,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    */
   useEffect(() => {
     fetchDatasets();
-  }, [isToggled, currentBbox.join(',')]);
+  }, [isToggled, currentBbox?.join(',')]);
 
   /**
    * Add state to track sort direction

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -233,10 +233,9 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * @returns The translation key for the toggle status
    */
   const getToggleStatusText = () => {
-    if (!currentBbox) {
+    if (!currentBbox || currentBbox.length === 0) {
       return t('map_required');
     }
-
     return t('filtering_by_map_view');
   };
 

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -6,6 +6,11 @@ import {
   FaChevronCircleRight,
   FaDatabase,
   FaFilter,
+  FaSortAlphaDown,
+  FaSortAlphaUp,
+  FaSortNumericDown,
+  FaSortNumericUp,
+  FaTimes
 } from 'react-icons/fa';
 import {
   fetchCollectionsFromEndpointByName,
@@ -68,17 +73,19 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     try {
       let response;
       const params = {
-        bbox: isToggled && currentBbox ? currentBbox as [number, number, number, number] : undefined
+        bbox: isToggled && currentBbox ? currentBbox as [number, number, number, number] : undefined,
+        sortDirection
       };
 
       if (activeFilter === 'Name') {
-        response = await fetchCollectionsFromEndpointByName(params.bbox);
+        response = await fetchCollectionsFromEndpointByName(params.bbox, params.sortDirection);
       } else if (activeFilter === 'Date') {
-        response = await fetchCollectionsFromEndpointByDate(params.bbox);
+        response = await fetchCollectionsFromEndpointByDate(params.bbox, params.sortDirection);
       } else {
-        response = await returnListOfCollectionsFromEndpoint(params.bbox); // Fetch all datasets if bbox is undefined
+        response = await returnListOfCollectionsFromEndpoint(params.bbox);
       }
 
+      // Rest of the function remains the same
       if (!Array.isArray(response)) {
         console.error("Invalid response format:", response);
         setFetchError(response.error || "Failed to load datasets.");
@@ -117,11 +124,31 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   }, [isToggled, currentBbox.join(',')]);
 
   /**
+   * Add state to track sort direction
+   */
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  /**
    * Handles changes to the dataset sorting filter.
    * @param filter - The selected sorting filter.
    */
   const handleFilterChange = (filter: string) => {
-    setActiveFilter(filter);
+    if (activeFilter === filter) {
+      // Toggle direction if same filter is clicked
+      setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
+    } else {
+      // Reset to ascending when changing filters
+      setActiveFilter(filter);
+      setSortDirection('asc');
+    }
+  };
+
+  /**
+   * Resets the dataset filters.
+   */
+  const resetFilters = () => {
+    setActiveFilter('');
+    setSortDirection('asc');
   };
 
   /**
@@ -264,20 +291,33 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
           </div>
           <div className="filter-container" data-testid="filter-container">
             <div className="filter-icon" data-testid="filter-icon">
-            <FaFilter size={24} />
+              <FaFilter size={24} />
             </div>
-            {['Name', 'Date'].map(
-              (filter) => (
-                <button
-                  key={filter}
-                  className={`filter-button ${activeFilter === filter ? 'active' : ''}`}
-                  onClick={() => handleFilterChange(filter)}
-                  data-testid={`filter-button-${filter}`}
-                >
-                {t(filter.toLowerCase().replace(/ /g, '_'))}
-              </button>
-              ),
+            <button
+              className={`filter-button ${activeFilter === 'Name' ? 'active' : ''}`}
+              onClick={() => handleFilterChange('Name')}
+              data-testid="filter-button-Name"
+            >
+              {t('name')} {activeFilter === 'Name' && (
+              sortDirection === 'asc' ? <FaSortAlphaDown /> : <FaSortAlphaUp />
             )}
+            </button>
+            <button
+              className={`filter-button ${activeFilter === 'Date' ? 'active' : ''}`}
+              onClick={() => handleFilterChange('Date')}
+              data-testid="filter-button-Date"
+            >
+              {t('date')} {activeFilter === 'Date' && (
+              sortDirection === 'asc' ? <FaSortNumericDown /> : <FaSortNumericUp />
+            )}
+            </button>
+            <button
+              className="filter-button reset-button"
+              onClick={resetFilters}
+              data-testid="filter-button-reset"
+            >
+              <FaTimes /> {t('reset')}
+            </button>
           </div>
 
           {fetchError && (

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -128,6 +128,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    */
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
+  useEffect(() => {
+    fetchDatasets();
+  }, [activeFilter, sortDirection]);
+
   /**
    * Handles changes to the dataset sorting filter.
    * @param filter - The selected sorting filter.

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -113,9 +113,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * Fetches datasets when toggling filtering by map view.
    */
   useEffect(() => {
-    if (isToggled) {
-      fetchDatasets();
-    }
+    fetchDatasets();
   }, [isToggled, currentBbox.join(',')]);
 
   /**

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -176,7 +176,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
         </p>
       );
     }
-    
+
     if (datasets.length > 0) {
       return datasets.map((dataset) => (
         <button
@@ -189,7 +189,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
         </button>
       ));
     }
-    
+
     return (
       <div className="no-datasets-container" data-testid="no-datasets-container">
         <p className="no-datasets-message" data-testid="no-datasets-message">
@@ -207,8 +207,8 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     if (!currentBbox) {
       return t('map_required');
     }
-    
-    return isToggled ? t('filtering_by_map_view') : t('showing_all_datasets');
+
+    return t('filtering_by_map_view');
   };
 
   return (

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -11,8 +11,8 @@ import {
 import { PiArrowClockwiseFill, PiGlobeXLight, PiGlobeLight } from 'react-icons/pi';
 import {
   fetchCollectionsFromEndpoint,
-  resetCollections, 
-  resetDatalayerView, 
+  resetCollections,
+  resetDatalayerView,
   resetItems,
   verifyIfEndpointHasCollections
 } from '../services/api';
@@ -76,7 +76,7 @@ const SettingsPanel: React.FC<{
         toast.success(t('language_retrieved'));
       }
       setLanguageInitialized(true);
-      
+
       if(config.onlineMode != undefined){
         setIsOnline(config.onlineMode);
       }
@@ -135,6 +135,12 @@ const SettingsPanel: React.FC<{
 
         // Save the new endpoint to config file
         const config = await getConfig();
+        // If an error occurred during fetching config, show error and do not save changes
+        if (config.error) {
+          toast.error(t('error_fetching_config_file'));
+          return false;
+        }
+
         config.endpoint = endpointUrl;
         await saveConfig(config);
 
@@ -194,7 +200,7 @@ const SettingsPanel: React.FC<{
       });
       return;
     }
-    
+
     MySwal.fire({
       title: t('factory_reset'),
       text: t('confirm_factory_reset_data_from_endpoint'),
@@ -231,7 +237,13 @@ const SettingsPanel: React.FC<{
 
   const handleSelectOnlineMode = async (onlineMode: boolean) => {
     setIsOnline(onlineMode);
+
     const config = await getConfig();
+    // If an error occurred during fetching config, show error and do not save changes
+    if (config.error) {
+      toast.error(t('error_fetching_config_file'));
+      return false;
+    }
     config.onlineMode = onlineMode;
     await saveConfig(config);
     setDropdownState({ activeButton: null, isOpen: false });
@@ -283,6 +295,12 @@ const SettingsPanel: React.FC<{
         success = await handleSaveAndFetchEndpoint(inputResult.value);
       } else {
         const config = await getConfig();
+        // If an error occurred during fetching config, show error and do not save changes
+        if (config.error) {
+          toast.error(t('error_fetching_config_file'));
+          break;
+        }
+
         config.endpoint = 'No endpoint saved';
         await saveConfig(config);
 

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -124,7 +124,9 @@ const resources = {
       available_datasets: 'Collections disponibles',
       no_datasets_available: 'Aucune collections disponible.',
       toggle_datasets: 'Afficher les collections de données',
-      // TODO: Translate the datasets strings
+      showing_all_datasets: 'Afficher toutes les collections',
+      filtering_by_map_view: 'Filtrer les collections par région',
+      name: 'Nom',
       date: 'Date',
       latest_added: 'Dernier Ajouté',
       latest_updated: 'Dernière Mise à Jour',

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -78,6 +78,8 @@ const resources = {
       //Errors
       error_fetching_collections:
         'Failed to fetch collections. Please try again with a valid endpoint url.',
+      error_fetching_config_file:
+        'Failed to fetch config file. Please validate app-config.json.',
     },
   },
   fr: {
@@ -154,6 +156,8 @@ const resources = {
       //Errors
       error_fetching_collections:
         "Impossible de récupérer les collections. Veuillez réessayer avec un URL d'endpoint valide.",
+      error_fetching_config_file:
+        "Impossible de récupérer le fichier de configuration. Veuillez valider app-config.json.",
     },
   },
 };

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -45,7 +45,7 @@ const resources = {
       no_datasets_available: 'No datasets available.',
       //Datasets - Toggle
       toggle_datasets: 'Toggle Datasets',
-      filtering_by_map_view: 'Filtering datasets by region',
+      filtering_by_map_view: 'Only Show Datasets in View',
       showing_all_datasets: 'Showing all datasets',
       only_visible_datasets_shown: 'Only datasets in current map view',
       including_outside_map_view: 'Including datasets outside visible area',

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -336,7 +336,7 @@ export const insertDatalayerView = async (
  */
 export const resetDatalayerView = async (): Promise<any> => {
   try {
-    const response = await fetch(`${BASE_URL}/api/reset-view`);
+    const response = await fetch(`${BASE_URL}/api/reset-datalayer-view`);
     if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -6,7 +6,16 @@ const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL as string;
  * @param bbox Optional bounding box filter [minX, minY, maxX, maxY].
  * @returns A promise resolving to an array of collections or an error object.
  */
-export const returnListOfCollectionsFromEndpoint = async (bbox?: number[]): Promise<{ id: string; key: number; bbox: number[][] }[] | { error: string }> => {
+export const returnListOfCollectionsFromEndpoint = async (
+  bbox?: number[],
+): Promise<
+  | {
+      id: string;
+      key: number;
+      bbox: number[][];
+    }[]
+  | { error: string }
+> => {
   try {
     const url = new URL(`${BASE_URL}/api/get-collections`);
     if (bbox) {
@@ -25,9 +34,13 @@ export const returnListOfCollectionsFromEndpoint = async (bbox?: number[]): Prom
   }
 };
 
-export const fetchCollectionsFromEndpoint = async (endpoint_url: string): Promise<string> => {
+export const fetchCollectionsFromEndpoint = async (
+  endpoint_url: string,
+): Promise<string> => {
   try {
-    const response = await fetch(`${BASE_URL}/api/fetch-collections?endpointUrl=${endpoint_url}`);
+    const response = await fetch(
+      `${BASE_URL}/api/fetch-collections?endpointUrl=${endpoint_url}`,
+    );
     if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }
@@ -39,9 +52,13 @@ export const fetchCollectionsFromEndpoint = async (endpoint_url: string): Promis
   }
 };
 
-export const verifyIfEndpointHasCollections = async (endpoint_url: string): Promise<string> => {
+export const verifyIfEndpointHasCollections = async (
+  endpoint_url: string,
+): Promise<string> => {
   try {
-    const response = await fetch(`${BASE_URL}/api/verify-collections?endpointUrl=${encodeURIComponent(endpoint_url)}`);
+    const response = await fetch(
+      `${BASE_URL}/api/verify-collections?endpointUrl=${encodeURIComponent(endpoint_url)}`,
+    );
     if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }
@@ -128,8 +145,13 @@ export const fetchMetaData = async (collectionId: string): Promise<any> => {
   }
 };
 
-export const returnCollectionsFromEndpoint = async (): Promise<{
-  id: string; key: number}[] | { error: string }> => {
+export const returnCollectionsFromEndpoint = async (): Promise<
+  | {
+      id: string;
+      key: number;
+    }[]
+  | { error: string }
+> => {
   try {
     const response = await fetch(`${BASE_URL}/api/get-collections`);
     console.log('Fetching from: ', `${BASE_URL}/api/get-collections`);
@@ -141,20 +163,32 @@ export const returnCollectionsFromEndpoint = async (): Promise<{
     console.error('Error fetching collections:', error);
     return { error: 'Failed to fetch data' };
   }
-}
+};
 
 /**
  * Fetches collections from the backend, optionally filtered by bounding box (BBOX), and sorted by name.
  *
  * @param bbox Optional bounding box filter [minX, minY, maxX, maxY].
+ * @param sortDirection Optional sort direction ('asc' or 'desc'), defaults to 'asc'.
  * @returns A promise resolving to an array of collections or an error object.
  */
-export const fetchCollectionsFromEndpointByName = async (bbox?: number[]): Promise<{ id: string; key: number; bbox: number[][] }[] | { error: string }> => {
+export const fetchCollectionsFromEndpointByName = async (
+  bbox?: number[],
+  sortDirection: 'asc' | 'desc' = 'asc',
+): Promise<
+  | {
+      id: string;
+      key: number;
+      bbox: number[][];
+    }[]
+  | { error: string }
+> => {
   try {
     const url = new URL(`${BASE_URL}/api/get-collections-by-name`);
     if (bbox) {
       url.searchParams.set('bbox', bbox.join(','));
     }
+    url.searchParams.set('sortDirection', sortDirection);
 
     const response = await fetch(url.toString());
     if (!response.ok) {
@@ -172,14 +206,26 @@ export const fetchCollectionsFromEndpointByName = async (bbox?: number[]): Promi
  * Fetches collections from the backend, optionally filtered by bounding box (BBOX), and sorted by date.
  *
  * @param bbox Optional bounding box filter [minX, minY, maxX, maxY].
+ * @param sortDirection Optional sort direction ('asc' or 'desc'), defaults to 'asc'.
  * @returns A promise resolving to an array of collections or an error object.
  */
-export const fetchCollectionsFromEndpointByDate = async (bbox?: number[]): Promise<{ id: string; key: number; bbox: number[][] }[] | { error: string }> => {
+export const fetchCollectionsFromEndpointByDate = async (
+  bbox?: number[],
+  sortDirection: 'asc' | 'desc' = 'asc',
+): Promise<
+  | {
+      id: string;
+      key: number;
+      bbox: number[][];
+    }[]
+  | { error: string }
+> => {
   try {
     const url = new URL(`${BASE_URL}/api/get-collections-by-date`);
     if (bbox) {
       url.searchParams.set('bbox', bbox.join(','));
     }
+    url.searchParams.set('sortDirection', sortDirection);
 
     const response = await fetch(url.toString());
     if (!response.ok) {
@@ -213,7 +259,14 @@ export const fetchItems = async (collectionId: string): Promise<any> => {
  * @param collectionId The ID of the collection.
  * @returns A promise resolving to the progress percentage or an error object.
  */
-export const fetchProgress = async (collectionId: string): Promise<{ collectionId: string; progress: number } | { error: string }> => {
+export const fetchProgress = async (
+  collectionId: string,
+): Promise<
+  | { collectionId: string; progress: number }
+  | {
+      error: string;
+    }
+> => {
   try {
     const url = `${BASE_URL}/api/fetch-progress/${collectionId}`;
     const response = await fetch(url);
@@ -229,7 +282,6 @@ export const fetchProgress = async (collectionId: string): Promise<{ collectionI
   }
 };
 
-
 export const fetchTimestamps = async (): Promise<string[]> => {
   try {
     const url = `${BASE_URL}/api/fetch-items-timestamps`;
@@ -244,9 +296,12 @@ export const fetchTimestamps = async (): Promise<string[]> => {
   }
 };
 
-export const fetchItem = async (itemId: string, collectionId?: string): Promise<any> => {
+export const fetchItem = async (
+  itemId: string,
+  collectionId?: string,
+): Promise<any> => {
   try {
-    const url = `${BASE_URL}/api/get-item/${itemId}${collectionId !== null ? '/' + collectionId : '' }`;
+    const url = `${BASE_URL}/api/get-item/${itemId}${collectionId !== null ? '/' + collectionId : ''}`;
     const response = await fetch(url);
     if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
@@ -255,22 +310,26 @@ export const fetchItem = async (itemId: string, collectionId?: string): Promise<
 
     return data;
   } catch (error: any) {
-    console.error("Error fetching MetaData:", error);
-    return { error: "Failed to fetch MetaData" };
+    console.error('Error fetching MetaData:', error);
+    return { error: 'Failed to fetch MetaData' };
   }
 };
 
-export const insertDatalayerView = async (collectionId: string): Promise<any> => {
+export const insertDatalayerView = async (
+  collectionId: string,
+): Promise<any> => {
   try {
-    const response = await fetch(`${BASE_URL}/api/set-datalayer-geometry/${collectionId}`);
-    if(!response.ok) {
+    const response = await fetch(
+      `${BASE_URL}/api/set-datalayer-geometry/${collectionId}`,
+    );
+    if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }
   } catch (error: any) {
-    console.error("Error inserting View:", error);
-    return { error: "Failed to insert View" };
+    console.error('Error inserting View:', error);
+    return { error: 'Failed to insert View' };
   }
-}
+};
 
 /**
  * Resets datalayer view
@@ -278,18 +337,22 @@ export const insertDatalayerView = async (collectionId: string): Promise<any> =>
 export const resetDatalayerView = async (): Promise<any> => {
   try {
     const response = await fetch(`${BASE_URL}/api/reset-datalayer-view`);
-    if(!response.ok) {
+    if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }
   } catch (error: any) {
-    console.error("Error resetting Datalayer View:", error);
-    return { error: "Failed to reset Datalayer View" };
+    console.error('Error resetting Datalayer View:', error);
+    return { error: 'Failed to reset Datalayer View' };
   }
-}
+};
 
-export const verifyInternetConnection = async (endpoint_url: string): Promise<string> => {
+export const verifyInternetConnection = async (
+  endpoint_url: string,
+): Promise<string> => {
   try {
-    const response = await fetch(`${BASE_URL}/api/verify-internet-connection?endpointUrl=${encodeURIComponent(endpoint_url)}`);
+    const response = await fetch(
+      `${BASE_URL}/api/verify-internet-connection?endpointUrl=${encodeURIComponent(endpoint_url)}`,
+    );
     if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }

--- a/apps/frontend/src/app/services/api.ts
+++ b/apps/frontend/src/app/services/api.ts
@@ -336,7 +336,7 @@ export const insertDatalayerView = async (
  */
 export const resetDatalayerView = async (): Promise<any> => {
   try {
-    const response = await fetch(`${BASE_URL}/api/reset-datalayer-view`);
+    const response = await fetch(`${BASE_URL}/api/reset-view`);
     if (!response.ok) {
       throw new Error(`Error: ${response.statusText}`);
     }

--- a/apps/frontend/src/app/styles/AvailableDatasets.css
+++ b/apps/frontend/src/app/styles/AvailableDatasets.css
@@ -25,6 +25,7 @@ body {
   transition: width 0.3s ease;
   display: flex;
   flex-direction: column;
+  user-select: none;
 }
 
 .datasets-container.collapsed {


### PR DESCRIPTION
### Description

This PR closes:
1. #237 
2. #275  
3. #245  
4. #272 
5. #266

Demo of #237:

https://github.com/user-attachments/assets/b53ebb74-e894-4be5-bdb8-59e460934c22

#237 changes:
- add icons for a to z and for z to a. same for date, use icons.
- modify frontend and backend apis call to handle sorting parameter. 
- add reset button to go back to original state of list of datasets

#245 changes:
- toggling off the "Only Show Datasets in View" brings back the complete list of datasets.

#272 changes:
- Changed endpoint name to resolve conflicts

#266 changes:
- add translations labels in french

#275 changes:
- Added error handling on errors

----
## DOCUMENTATON

ALSO DOCUMENTED PROCESS IN https://github.com/XavierGuertin/WildfireVisualizationProject/issues/237#issuecomment-2746644091 FOR MORE DETAILS.