### PR TITLE
#237 - fix(frontend): Fixing getCollections when map moves

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,12 +98,34 @@ For setting up the development environment, follow these additional steps:
    docker compose up geoserver db tileserver tileserver-init
    ```
 
-3. **Run the Backend**
+3. **Add Environment Variables**
+   ```
+   # Navigate to the frontend directory
+   cd frontend
+
+   # Create environment files if they don't exist
+   touch .env.production .env.development
+   ```
+
+   Add the following variables to both .env.production and .env.development
+   ```ini
+   NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
+   NEXT_PUBLIC_GEOSERVER_URL=http://localhost:8090/geoserver/Default/wms
+   NEXT_PUBLIC_TILESERVER_URL=http://localhost:8081/data/OAM-World-1-8-min-J80
+   ```
+
+4. **Run the Backend**
    ```bash
    nx dev backend
    ```
 
-4. **Run the Frontend**
+5. **Install Dependencies**
+   ```bash
+   cd wildfire-visualization-platform
+   npm i
+   ```
+
+6. **Run the Frontend**
    ```bash
    nx dev frontend
    ```

--- a/README.md
+++ b/README.md
@@ -57,67 +57,58 @@ The Wildfire Visualization Platform is an innovative tool designed to provide hi
 | Oliel, Eden         | 40211989   | [eo2000](https://github.com/eo2000)        | olieleden0@gmail.com        |
 ---
 
-## Developer Getting Started Guide
+## Running the Application
 
-To get started as a developer on this project:
+To run the application, follow these steps:
 
 1. **Clone the Repository**
    ```bash
-   git clone https://github.com/your-repo/wildfire-visualization-platform.git
+   git clone https://github.com/XavierGuertin/WildfireVisualizationProject.git
    ```
-2. **Open the project with an IDE**<br>
-   ex. Visual Studio Code<br><br>
-3.  **Install Dependencies In the root directory, install the necessary npm packages:**
-    ```bash
-    cd wildfire-visualization-platform
-    npm install
-    ```
-4. **Incorporate secrets for keys in .env file:**
-    Put .env in the root folder.
-5. **Build the Backend Before launching the backend, ensure it is built:**
-    ```bash
-    nx build backend
-    ```
-6. **Launch the Backend Once built, you can serve the backend:**
-    ```bash
-    nx dev backend
-    ```
-7. **Launch the Frontend After the backend is running, you can start the frontend:**
-    ```bash
-    nx dev frontend
-    ```
 
-## Running Production
+2. **Navigate to the Project Root**
+   ```bash
+   cd WildfireVisualizationProject
+   ```
 
-To run the application in a production environment, follow these steps:
+3. **Run the Application using Docker Compose**
+   ```bash
+   docker-compose up --pull always
+   ```
 
-### Step 1: Clone the Repository
-Start by cloning the repository to your local machine.
+4. **Access the Application**
+   Once the project is running, open your browser and navigate to:
+   ```
+   http://localhost:3000
+   ```
 
-```bash
-git clone https://github.com/your-repo/wildfire-visualization-platform.git
-cd wildfire-visualization-platform
-```
-### Step 2: Navigate to the Project Root
-Ensure you're in the root directory of the project. All commands should be run from here.
-```bash
-cd wildfire-visualization-platform
-```
+---
 
-### Step 3: Pull Docker Images
-Use Docker Compose to pull any pre-built images specified in the docker-compose.yml file. This step ensures all required images are downloaded, including backend, frontend, database, and any other necessary services.
-```bash
-docker-compose pull
-```
+## Developer Guide
 
-### Step 4: Start the Application in Detached Mode
-Run the application in detached mode (-d flag) to keep the containers running in the background. This starts all services as specified in the docker-compose.yml, including the frontend, backend, database, and any other supporting services.
-```bash
-docker-compose up -d
-```
+For setting up the development environment, follow these additional steps:
 
-### Step 5: Access the Application
-Once the containers are up and running, you can access the application through the frontend URL in your browser (e.g., http://localhost:3000 if using the default port).
+1. **Pull Required Services**
+   ```bash
+   docker compose pull geoserver db tileserver tileserver-init
+   ```
+
+2. **Start Services**
+   ```bash
+   docker compose up geoserver db tileserver tileserver-init
+   ```
+
+3. **Run the Backend**
+   ```bash
+   nx dev backend
+   ```
+
+4. **Run the Frontend**
+   ```bash
+   nx dev frontend
+   ```
+
+---
 
    
 ## Running Tests

--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -65,9 +65,11 @@ jest.mock('../src/app/context/MapContext', () => ({
 
 describe('Test AvailableDatasets component', () => {
   let mockOnDatasetClick: jest.Mock;
+  let mockOnResetBbox: jest.Mock;
 
   beforeEach(() => {
     mockOnDatasetClick = jest.fn();
+    mockOnResetBbox = jest.fn();
     jest.clearAllMocks();
     mockReturnListOfCollections.mockResolvedValue(mockDatasets);
     mockFetchMetaData.mockResolvedValue(mockDatasetMetadata);
@@ -80,7 +82,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('should initialize with correct default state', () => {
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     expect(screen.getByTestId('toggle-status-text')).toBeInTheDocument();
@@ -91,7 +93,7 @@ describe('Test AvailableDatasets component', () => {
     mockReturnListOfCollections.mockImplementation(() => new Promise(() => {})); // Keeps promise pending
 
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     // Ensure the loading message appears
@@ -100,7 +102,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('should call onDatasetClick on dataset click', async () => {
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     await waitFor(() =>
@@ -119,7 +121,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('should mark dataset as selected when clicked', async () => {
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     const datasetButton = await waitFor(() =>
@@ -134,7 +136,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('should update active filter UI when a filter button is clicked', async () => {
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     const nameFilterButton = screen.getByTestId('filter-button-Name');
@@ -149,7 +151,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('should collapse and expand the component when toggled', async () => {
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     const collapseButton = await waitFor(() =>
@@ -166,7 +168,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('should toggle isToggled state when switch is clicked', async () => {
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     const toggleButton = await waitFor(() =>
@@ -198,6 +200,7 @@ describe('Test AvailableDatasets component', () => {
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
         currentBbox={[-120, 30, -110, 40]}
+        onResetBbox={mockOnResetBbox}
       />,
     );
 
@@ -232,7 +235,7 @@ describe('Test AvailableDatasets component', () => {
       new Error('Failed to load datasets'),
     );
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     await waitFor(() => {
@@ -246,7 +249,7 @@ describe('Test AvailableDatasets component', () => {
     mockReturnListOfCollections.mockResolvedValue([]);
 
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     await waitFor(() => {
@@ -258,7 +261,7 @@ describe('Test AvailableDatasets component', () => {
   it('should call handleFilterChange and update datasets when filtering by name', async () => {
     mockFetchCollectionsByName.mockResolvedValue(mockDatasets);
     render(
-      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />,
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
     );
 
     const filterButton = screen.getByTestId('filter-button-Name');
@@ -272,7 +275,7 @@ describe('Test AvailableDatasets component', () => {
 
   it('displays an error message if fetchError is set', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: 'Simulated error' });
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
     await waitFor(() => {
       expect(screen.queryByTestId('error-message')).not.toBeNull();
     });
@@ -285,6 +288,7 @@ describe('Test AvailableDatasets component', () => {
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
+        onResetBbox={mockOnResetBbox}
       />
     );
   
@@ -303,6 +307,7 @@ describe('Test AvailableDatasets component', () => {
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
+        onResetBbox={mockOnResetBbox}
       />
     );
   
@@ -321,6 +326,7 @@ describe('Test AvailableDatasets component', () => {
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
+        onResetBbox={mockOnResetBbox}
       />
     );
   
@@ -332,7 +338,7 @@ describe('Test AvailableDatasets component', () => {
   it('should display default translation key when response.error is undefined', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: undefined });
   
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
   
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data');
@@ -342,7 +348,7 @@ describe('Test AvailableDatasets component', () => {
   it('should display raw error string when it does not match any known translation key', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: 'Some random backend error' });
   
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
   
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('Some random backend error');
@@ -352,7 +358,7 @@ describe('Test AvailableDatasets component', () => {
   it('should trigger fetchDatasets catch block and display fallback error message', async () => {
     mockReturnListOfCollections.mockRejectedValue(new Error('Something broke'));
   
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} />);
+    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
   
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('Failed to load datasets.');

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -143,8 +143,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * Fetches datasets when toggling filtering by map view.
    */
   useEffect(() => {
-    fetchDatasets();
-  }, [isToggled, currentBbox?.join(',')]);
+    if(isToggled){
+      fetchDatasets();
+    }
+  }, [isToggled, currentBbox.join(',')]);
 
   /**
    * Add state to track sort direction

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -47,12 +47,14 @@ interface AvailableDatasetsProps {
   onDatasetClick: (dataset: DatasetMetadata) => void;
   refreshKey: number;
   currentBbox?: [number, number, number, number]; // [west, south, east, north]
+  onResetBbox: () => void;
 }
 
 const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   onDatasetClick,
   refreshKey,
   currentBbox = [],
+  onResetBbox
 }) => {
   const { t } = useTranslation();
   const [activeFilter, setActiveFilter] = useState<string>('');
@@ -147,6 +149,16 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
       fetchDatasets();
     }
   }, [isToggled, currentBbox.join(',')]);
+
+  /**
+   * Fetches datasets when toggling filtering by map view.
+   */
+  useEffect(() => {
+    if(!isToggled){
+      onResetBbox();
+      fetchDatasets();
+    }
+  }, [isToggled]);
 
   /**
    * Add state to track sort direction

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -18,6 +18,7 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [refreshKey, setRefreshKey] = useState(0); // Add state for refresh key
   const [isMetadataVisible, setMetadataVisible] = useState(false); // Add state for metadata visibility
   const [currentBbox, setCurrentBbox] = useState<[number, number, number, number] | undefined>(undefined);
+  const WORLD_BBOX: [number, number, number, number] = [-180, -90, 180, 90];
 
   // Handle dataset selection (no loading bar here)
   const handleDatasetClick = (dataset: DatasetMetadata) => {
@@ -60,7 +61,9 @@ const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
           <AvailableDatasets
               onDatasetClick={handleDatasetClick}
               refreshKey={refreshKey}
-              currentBbox={currentBbox ?? undefined} />
+              currentBbox={currentBbox ?? undefined}
+              onResetBbox={() => setCurrentBbox(WORLD_BBOX)}
+              />
           <MapView onBboxChange={(bbox) => {
               if (bbox && bbox.length === 4) {
                 setCurrentBbox(bbox as [number, number, number, number]);


### PR DESCRIPTION
***Summary:*** Moving the map constantly called getCollections in the backend. This is the desired behaviour when filtering by bbox is toggled, however this was not the case.

***Solution:*** Added a isToggled check before calling fetchCollections to ensure it is only called when filtering by bbox is toggled on. AvailableDatasets also now has a onResetBbox function which resets the filter by bbox to full map.