### PR TITLE
#251 - feat(backend): Adding endpoints to handle item asset display and caching

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,6 +46,7 @@ jobs:
           NEXT_PUBLIC_TILESERVER_URL: http://localhost:8081/data/OAM-World-1-8-min-J80
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
           CONFIG_FILE_PATH: /var/config/app-config.json
+          GEOSERVER_DATA_DIR: /var/geoserver/data_dir/tiffs
 
       # Push Docker images to Docker Hub
       - name: Push Docker Images

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,6 +37,7 @@ jobs:
           SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/postgres
           SPRING_DATASOURCE_USERNAME: postgres
           SPRING_DATASOURCE_PASSWORD: password
+          GEOSERVER_DATA_DIR: /var/geoserver/data_dir/tiffs
 
       # Wait for Database to be Ready using Health Check
       - name: Wait for Database

--- a/apps/backend/pom.xml
+++ b/apps/backend/pom.xml
@@ -142,6 +142,11 @@
       <artifactId>jacoco-maven-plugin</artifactId>
       <version>0.8.11</version>
     </dependency>
+      <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+          <version>42.7.5</version>
+      </dependency>
 
   </dependencies>
 

--- a/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
@@ -1,0 +1,28 @@
+package wildfire.visualization.backend.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import jakarta.annotation.PostConstruct;
+
+@Component
+public class DatabaseInitializer {
+
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @PostConstruct
+  public void initializeDatabase() {
+    String sql = """
+            CREATE TABLE IF NOT EXISTS ItemAssets (
+                id SERIAL PRIMARY KEY,
+                item_id TEXT NOT NULL,
+                collection_id TEXT NOT NULL,
+                asset_name TEXT NOT NULL,
+                layer_url TEXT NOT NULL,
+                UNIQUE (item_id, collection_id, asset_name)
+            );
+        """;
+    jdbcTemplate.execute(sql);
+  }
+}

--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -2,6 +2,7 @@ package wildfire.visualization.backend.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import wildfire.visualization.backend.service.DataService;
 import wildfire.visualization.backend.exception.DataException;
+import wildfire.visualization.backend.service.GeoTIFFService;
 
 import java.net.URI;
 import java.net.URLDecoder;
@@ -26,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
  */
 @RestController
 public class DataController {
+
   private static final Logger logger = LoggerFactory.getLogger(DataController.class);
 
   private final DataService dataService;
@@ -33,6 +36,29 @@ public class DataController {
   public DataController(DataService dataService) {
     this.dataService = dataService;
   }
+
+  @GetMapping("/load-assets/{collectionId}/{itemId}")
+  public ResponseEntity<String> loadAssets(
+    @PathVariable String collectionId,
+    @PathVariable String itemId
+  ) {
+    logger.info("Received request to load assets asynchronously for collection: {}, item: {}", collectionId, itemId);
+    try {
+      // Run the processing task asynchronously
+      CompletableFuture.runAsync(() -> dataService.processItemAssets(collectionId, itemId));
+      // Return immediate response to frontend
+      return ResponseEntity.ok("Processing started in the background. Check logs for completion.");
+    } catch (Exception e) {
+      logger.error("Error processing assets for item: {} in collection: {}", itemId, collectionId, e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to start processing.");
+    }
+  }
+
+  @GetMapping("/get-loaded-layers")
+  public ResponseEntity<List<Map<String, Object>>> getLoadedLayers() {
+    return ResponseEntity.ok(dataService.getLoadedLayers());
+  }
+
 
   /**
    * Parses a bounding box (BBOX) string from a request parameter.

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -545,4 +545,23 @@ public class StacRepository {
       throw new RepositoryException("Error removing item with ID: " + itemId + " from collection: " + collectionId, e);
     }
   }
+
+  public void saveLayer(String itemId, String collectionId, String assetName, String layerUrl) {
+    String sql = """
+            INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT (item_id, collection_id, asset_name) DO NOTHING;
+        """;
+    jdbcTemplate.update(sql, itemId, collectionId, assetName, layerUrl);
+  }
+
+  public List<Map<String, Object>> getLoadedLayers() {
+    String sql = "SELECT * FROM ItemAssets";
+    return jdbcTemplate.queryForList(sql);
+  }
+
+  public void clearLayers() {
+    jdbcTemplate.update("DELETE FROM ItemAssets");
+  }
+
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -546,6 +546,14 @@ public class StacRepository {
     }
   }
 
+  /**
+   * Method responsible for saving a layer URL to the database
+   *
+   * @param itemId       Database ID of the item
+   * @param collectionId Database ID of the collection
+   * @param assetName    Name of the asset
+   * @param layerUrl     URL of the layer
+   */
   public void saveLayer(String itemId, String collectionId, String assetName, String layerUrl) {
     String sql = """
             INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url)
@@ -555,11 +563,19 @@ public class StacRepository {
     jdbcTemplate.update(sql, itemId, collectionId, assetName, layerUrl);
   }
 
+  /**
+   * Method responsible for fetching all loaded layers from the database
+   *
+   * @return List object containing all loaded layers
+   */
   public List<Map<String, Object>> getLoadedLayers() {
     String sql = "SELECT * FROM ItemAssets";
     return jdbcTemplate.queryForList(sql);
   }
 
+  /**
+   * Method responsible for clearing all layers from the database
+   */
   public void clearLayers() {
     jdbcTemplate.update("DELETE FROM ItemAssets");
   }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -607,6 +607,8 @@ public class DataService {
     List<Map<String, Object>> queryResults = stacRepository.getItem(itemId);
     if (queryResults.isEmpty()) return;
 
+    fetchProgress.put(itemId, new AtomicInteger(0)); // Initialize progress
+
     // Extract JSON from `pgstac.get_item()`
     Object jsonObject = queryResults.get(0).get("get_item");
     String itemJson;
@@ -632,14 +634,21 @@ public class DataService {
       // Clear previously registered layers
       stacRepository.clearLayers();
 
+      // Get total number of assets
+      int totalAssets = assets.size();
+      int counter = 0;
+
       for (Iterator<String> it = assets.fieldNames(); it.hasNext(); ) {
         String assetKey = it.next();
         JsonNode asset = assets.get(assetKey);
         String tiffUrl = asset.get("href").asText();
 
         boolean success = geoTIFFService.processGeoTIFF(itemId, collectionId, assetKey, tiffUrl);
+        counter++;
+        fetchProgress.put(itemId, new AtomicInteger((int) Math.floor(((double) counter / totalAssets) * 100)));
         if (!success) return;
       }
+      fetchProgress.put(itemId, new AtomicInteger(100));
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -602,6 +602,12 @@ public class DataService {
   }
 
 
+  /**
+   * Method responsible for processing all assets of a given item
+   *
+   * @param collectionId String object representing the id of the collection
+   * @param itemId       String object representing the id of the item
+   */
   @Async
   public void processItemAssets(String collectionId, String itemId) {
     List<Map<String, Object>> queryResults = stacRepository.getItem(itemId);
@@ -654,6 +660,11 @@ public class DataService {
     }
   }
 
+  /**
+   * Method responsible for retrieving all loaded layers
+   *
+   * @return List object containing all loaded layers
+   */
   public List<Map<String, Object>> getLoadedLayers() {
     return stacRepository.getLoadedLayers();
   }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -655,7 +655,8 @@ public class DataService {
       }
       fetchProgress.put(itemId, new AtomicInteger(100));
     } catch (Exception e) {
-      e.printStackTrace();
+      logger.error("Error processing item assets: {}", e.getMessage(), e);
+      fetchProgress.put(itemId, new AtomicInteger(-1)); // Set error state
     }
   }
 

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -634,7 +634,6 @@ public class DataService {
       for (Map<String, Object> layer : existingLayers) {
         String layerName = (String) layer.get("asset_name");
         geoServerService.unregisterLayer(layerName);
-        geoServerService.deleteCoverageStore(layerName);
       }
 
       // Clear previously registered layers

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -1,6 +1,7 @@
 package wildfire.visualization.backend.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.postgresql.util.PGobject;
 
 import wildfire.visualization.backend.controller.ConfigController;
 import wildfire.visualization.backend.exception.DataException;
@@ -43,6 +45,12 @@ public class DataService {
 
   @Autowired
   private ConfigController configController;
+
+  @Autowired
+  private GeoTIFFService geoTIFFService;
+
+  @Autowired
+  private GeoServerService geoServerService;
 
   private final Map<String, AtomicInteger> fetchProgress = new ConcurrentHashMap<>();
 
@@ -591,5 +599,53 @@ public class DataService {
       logger.info("No internet connection could be established");
       return "No internet connection could be established";
     }
+  }
+
+
+  @Async
+  public void processItemAssets(String collectionId, String itemId) {
+    List<Map<String, Object>> queryResults = stacRepository.getItem(itemId);
+    if (queryResults.isEmpty()) return;
+
+    // Extract JSON from `pgstac.get_item()`
+    Object jsonObject = queryResults.get(0).get("get_item");
+    String itemJson;
+    if (jsonObject instanceof PGobject) {
+      itemJson = ((PGobject) jsonObject).getValue();
+    } else {
+      throw new RuntimeException("Unexpected data type from database");
+    }
+
+    try {
+      JsonNode jsonNode = objectMapper.readTree(itemJson);
+      JsonNode assets = jsonNode.get("assets");
+
+      if (assets == null || assets.isEmpty()) return;
+
+      List<Map<String, Object>> existingLayers = stacRepository.getLoadedLayers();
+      for (Map<String, Object> layer : existingLayers) {
+        String layerName = (String) layer.get("asset_name");
+        geoServerService.unregisterLayer(layerName);
+        geoServerService.deleteCoverageStore(layerName);
+      }
+
+      // Clear previously registered layers
+      stacRepository.clearLayers();
+
+      for (Iterator<String> it = assets.fieldNames(); it.hasNext(); ) {
+        String assetKey = it.next();
+        JsonNode asset = assets.get(assetKey);
+        String tiffUrl = asset.get("href").asText();
+
+        boolean success = geoTIFFService.processGeoTIFF(itemId, collectionId, assetKey, tiffUrl);
+        if (!success) return;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  public List<Map<String, Object>> getLoadedLayers() {
+    return stacRepository.getLoadedLayers();
   }
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
@@ -28,6 +28,12 @@ public class GeoServerService {
 
   private final RestTemplate restTemplate = new RestTemplate();
 
+
+  /**
+   * Creates and returns HTTP headers with basic authentication for GeoServer interaction.
+   *
+   * @return HttpHeaders object with content type set to JSON and basic authentication included.
+   */
   private HttpHeaders createHeaders() {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
@@ -36,6 +42,12 @@ public class GeoServerService {
     return headers;
   }
 
+  /**
+   * Registers a new coverage store in the GeoServer under the specified workspace.
+   *
+   * @param layerName the name of the coverage store to be registered
+   * @return true if the registration was successful, false otherwise
+   */
   public boolean registerCoverageStore(String layerName) {
     String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores";
 
@@ -57,6 +69,13 @@ public class GeoServerService {
     return response.getStatusCode().is2xxSuccessful();
   }
 
+
+  /**
+   * Registers a new coverage layer in the GeoServer under the specified workspace and coverage store.
+   *
+   * @param layerName the name of the layer to be registered
+   * @return true if the registration was successful, false otherwise
+   */
   public boolean registerCoverageLayer(String layerName) {
     String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "/coverages";
 
@@ -77,16 +96,35 @@ public class GeoServerService {
     return response.getStatusCode().is2xxSuccessful();
   }
 
+
+  /**
+   * Removes a registered layer from the GeoServer within the specified workspace.
+   *
+   * @param layerName the name of the layer to be unregistered
+   * @return true if the layer was successfully unregistered, false otherwise
+   */
   public boolean unregisterLayer(String layerName) {
     String url = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
     return sendDeleteRequest(url);
   }
 
+  /**
+   * Deletes a coverage store from the GeoServer within the specified workspace.
+   *
+   * @param storeName the name of the coverage store to be deleted
+   * @return true if the coverage store was successfully deleted, false otherwise
+   */
   public boolean deleteCoverageStore(String storeName) {
     String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + storeName + "?purge=all&recurse=true";
     return sendDeleteRequest(url);
   }
 
+  /**
+   * Sends a DELETE request to the specified URL with basic authentication.
+   *
+   * @param url the URL to send the DELETE request to
+   * @return true if the request was successful, false otherwise
+   */
   private boolean sendDeleteRequest(String url) {
     HttpHeaders headers = new HttpHeaders();
     headers.setBasicAuth(geoserverUsername, geoserverPassword);

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
@@ -5,8 +5,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Base64;
-import java.util.Map;
 
 @Service
 public class GeoServerService {
@@ -26,8 +29,10 @@ public class GeoServerService {
   @Value("${geoserver.dataDir}")
   private String geoserverDataDir;
 
-  private final RestTemplate restTemplate = new RestTemplate();
+  @Value("${geoserver.downloadDir}")
+  private String geoserverDownloadDir;
 
+  private final RestTemplate restTemplate = new RestTemplate();
 
   /**
    * Creates and returns HTTP headers with basic authentication for GeoServer interaction.
@@ -37,8 +42,7 @@ public class GeoServerService {
   private HttpHeaders createHeaders() {
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
-    String auth = geoserverUsername + ":" + geoserverPassword;
-    headers.setBasicAuth(Base64.getEncoder().encodeToString(auth.getBytes()));
+    headers.setBasicAuth(geoserverUsername, geoserverPassword);
     return headers;
   }
 
@@ -69,7 +73,6 @@ public class GeoServerService {
     return response.getStatusCode().is2xxSuccessful();
   }
 
-
   /**
    * Registers a new coverage layer in the GeoServer under the specified workspace and coverage store.
    *
@@ -96,27 +99,21 @@ public class GeoServerService {
     return response.getStatusCode().is2xxSuccessful();
   }
 
-
   /**
    * Removes a registered layer from the GeoServer within the specified workspace.
+   * Also deletes the corresponding .tif file from local storage.
    *
    * @param layerName the name of the layer to be unregistered
    * @return true if the layer was successfully unregistered, false otherwise
    */
   public boolean unregisterLayer(String layerName) {
-    String url = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
-    return sendDeleteRequest(url);
-  }
+    String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
 
-  /**
-   * Deletes a coverage store from the GeoServer within the specified workspace.
-   *
-   * @param storeName the name of the coverage store to be deleted
-   * @return true if the coverage store was successfully deleted, false otherwise
-   */
-  public boolean deleteCoverageStore(String storeName) {
-    String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + storeName + "?purge=all&recurse=true";
-    return sendDeleteRequest(url);
+    boolean apiSuccess = sendDeleteRequest(url);
+    if (apiSuccess) {
+      deleteTifFile(layerName);
+    }
+    return apiSuccess;
   }
 
   /**
@@ -126,11 +123,29 @@ public class GeoServerService {
    * @return true if the request was successful, false otherwise
    */
   private boolean sendDeleteRequest(String url) {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setBasicAuth(geoserverUsername, geoserverPassword);
+    HttpHeaders headers = createHeaders();
     HttpEntity<String> entity = new HttpEntity<>(headers);
 
     ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.DELETE, entity, String.class);
     return response.getStatusCode().is2xxSuccessful();
+  }
+
+  /**
+   * Deletes the .tif file corresponding to a given layer or store from the local storage.
+   *
+   * @param layerName the name of the file to be deleted (without extension)
+   */
+  private void deleteTifFile(String layerName) {
+    try {
+      Path filePath = Paths.get(geoserverDownloadDir, layerName + ".tif");
+      if (Files.exists(filePath)) {
+        Files.delete(filePath);
+        System.out.println("Deleted: " + filePath.toAbsolutePath());
+      } else {
+        System.out.println("File not found: " + filePath.toAbsolutePath());
+      }
+    } catch (Exception e) {
+      System.err.println("Error deleting file: " + layerName + ".tif. " + e.getMessage());
+    }
   }
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
@@ -1,0 +1,98 @@
+package wildfire.visualization.backend.service;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.Base64;
+import java.util.Map;
+
+@Service
+public class GeoServerService {
+
+  @Value("${geoserver.url}")
+  private String geoserverUrl;
+
+  @Value("${geoserver.workspace}")
+  private String workspace;
+
+  @Value("${geoserver.username}")
+  private String geoserverUsername;
+
+  @Value("${geoserver.password}")
+  private String geoserverPassword;
+
+  @Value("${geoserver.dataDir}")
+  private String geoserverDataDir;
+
+  private final RestTemplate restTemplate = new RestTemplate();
+
+  private HttpHeaders createHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    String auth = geoserverUsername + ":" + geoserverPassword;
+    headers.setBasicAuth(Base64.getEncoder().encodeToString(auth.getBytes()));
+    return headers;
+  }
+
+  public boolean registerCoverageStore(String layerName) {
+    String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores";
+
+    String body = """
+            {
+              "coverageStore": {
+                "name": "%s",
+                "type": "GeoTIFF",
+                "url": "file:%s/%s.tif",
+                "workspace": "%s",
+                "enabled": true
+              }
+            }
+        """.formatted(layerName, geoserverDataDir, layerName, workspace);
+
+    HttpEntity<String> entity = new HttpEntity<>(body, createHeaders());
+    ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+
+    return response.getStatusCode().is2xxSuccessful();
+  }
+
+  public boolean registerCoverageLayer(String layerName) {
+    String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "/coverages";
+
+    String body = """
+            {
+              "coverage": {
+                "name": "%s",
+                "title": "%s",
+                "nativeCRS": "EPSG:4326",
+                "srs": "EPSG:4326"
+              }
+            }
+        """.formatted(layerName, layerName);
+
+    HttpEntity<String> entity = new HttpEntity<>(body, createHeaders());
+    ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+
+    return response.getStatusCode().is2xxSuccessful();
+  }
+
+  public boolean unregisterLayer(String layerName) {
+    String url = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
+    return sendDeleteRequest(url);
+  }
+
+  public boolean deleteCoverageStore(String storeName) {
+    String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + storeName + "?purge=all&recurse=true";
+    return sendDeleteRequest(url);
+  }
+
+  private boolean sendDeleteRequest(String url) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBasicAuth(geoserverUsername, geoserverPassword);
+    HttpEntity<String> entity = new HttpEntity<>(headers);
+
+    ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.DELETE, entity, String.class);
+    return response.getStatusCode().is2xxSuccessful();
+  }
+}

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
@@ -27,6 +27,15 @@ public class GeoTIFFService {
   @Autowired
   private StacRepository stacRepository;
 
+  /**
+   * Processes a GeoTIFF asset by downloading it, storing it in GeoServer, and saving its layer URL in the database.
+   *
+   * @param itemId The ID of the STAC item containing the asset.
+   * @param collectionId The ID of the STAC collection containing the item.
+   * @param assetName The name of the asset to process.
+   * @param tiffUrl The URL of the GeoTIFF asset.
+   * @return true if the asset was successfully processed, false otherwise.
+   */
   public boolean processGeoTIFF(String itemId, String collectionId, String assetName, String tiffUrl) {
     try {
       String localFilePath = tiffStoragePath + "/" + assetName + ".tif";
@@ -51,10 +60,16 @@ public class GeoTIFFService {
     }
   }
 
-  private void downloadFile(String sourceUrl, String destinationPath) throws IOException {
+  /**
+   * Downloads a file from the specified source URL and saves it to the destination path.
+   *
+   * @param sourceUrl The URL of the file to download.
+   * @param destinationPath The local file system path where the file should be saved.
+   * @throws IOException If an I/O error occurs during file download or saving.
+   */
+  void downloadFile(String sourceUrl, String destinationPath) throws IOException {
     Path filePath = Paths.get(destinationPath);
 
-    // ✅ Ensure the parent directory exists
     Files.createDirectories(filePath.getParent());
 
     try (InputStream in = new URL(sourceUrl).openStream()) {

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
@@ -1,0 +1,65 @@
+package wildfire.visualization.backend.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import wildfire.visualization.backend.repository.StacRepository;
+
+import java.io.*;
+import java.net.URL;
+import java.nio.file.*;
+
+@Service
+public class GeoTIFFService {
+
+  @Autowired
+  private GeoServerService geoServerService;
+
+  @Value("${geoserver.url}")
+  private String geoServerUrl;
+
+  @Value("${geoserver.workspace}")
+  private String workspace;
+
+  @Value("${geoserver.downloadDir}")
+  private String tiffStoragePath;
+
+  @Autowired
+  private StacRepository stacRepository;
+
+  public boolean processGeoTIFF(String itemId, String collectionId, String assetName, String tiffUrl) {
+    try {
+      String localFilePath = tiffStoragePath + "/" + assetName + ".tif";
+      String layerName = collectionId + "_" + itemId + "_" + assetName;
+      String layerUrl = geoServerUrl + "/" + workspace + "/wms?service=WMS&request=GetMap&layers=" + workspace + ":" + layerName;
+
+      // Download TIFF to GeoServer storage
+      downloadFile(tiffUrl, localFilePath);
+
+      // Register in GeoServer
+      boolean storeCreated = geoServerService.registerCoverageStore(assetName);
+      if (!storeCreated) return false;
+
+      boolean layerCreated = geoServerService.registerCoverageLayer(assetName);
+      if (!layerCreated) return false;
+
+      stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
+      return true;
+    } catch (Exception e) {
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  private void downloadFile(String sourceUrl, String destinationPath) throws IOException {
+    Path filePath = Paths.get(destinationPath);
+
+    // ✅ Ensure the parent directory exists
+    Files.createDirectories(filePath.getParent());
+
+    try (InputStream in = new URL(sourceUrl).openStream()) {
+      Files.copy(in, filePath, StandardCopyOption.REPLACE_EXISTING);
+    }
+  }
+
+}

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
@@ -55,7 +55,6 @@ public class GeoTIFFService {
       stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
       return true;
     } catch (Exception e) {
-      e.printStackTrace();
       return false;
     }
   }

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -13,3 +13,10 @@ spring.datasource.hikari.minimum-idle=1
 spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.postgis.PostgisPG95Dialect
 
 management.endpoints.web.exposure.include=health
+
+geoserver.url=http://localhost:8090/geoserver
+geoserver.workspace=Default
+geoserver.username=geoserver
+geoserver.password=password
+geoserver.dataDir=/var/geoserver/data_dir/tiffs
+geoserver.downloadDir=${GEOSERVER_DATA_DIR:./apps/geoserver_data/tiffs}

--- a/apps/backend/src/test/java/wildfire/visualization/backend/config/DatabaseInitializerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/config/DatabaseInitializerTests.java
@@ -1,0 +1,34 @@
+package wildfire.visualization.backend.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class) // Enables Mockito
+class DatabaseInitializerTests {
+
+  @Mock
+  private JdbcTemplate jdbcTemplate; // Mocked database
+
+  @InjectMocks
+  private DatabaseInitializer databaseInitializer; // Class under test
+
+  @BeforeEach
+  void setUp() {
+    doNothing().when(jdbcTemplate).execute(anyString()); // Mock SQL execution
+  }
+
+  @Test
+  void testInitializeDatabase() {
+    databaseInitializer.initializeDatabase();
+
+    // Verify that SQL was executed
+    verify(jdbcTemplate, times(1)).execute(anyString());
+  }
+}

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -757,6 +758,24 @@ class DataControllerTests {
     Thread.sleep(100);
 
     verify(dataService, times(1)).processItemAssets(collectionId, itemId);
+  }
+
+  @Test
+  void loadAssets_Failure_CatchException() throws Exception {
+    // Arrange
+    String collectionId = "testCollection";
+    String itemId = "testItem";
+
+    // Mock CompletableFuture to simulate an exception in async execution
+    try (MockedStatic<CompletableFuture> mockedCompletableFuture = mockStatic(CompletableFuture.class)) {
+      mockedCompletableFuture.when(() -> CompletableFuture.runAsync(any(Runnable.class)))
+        .thenThrow(new RuntimeException("Async processing error"));
+
+      // Act & Assert
+      mockMvc.perform(get("/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+        .andExpect(status().isInternalServerError())
+        .andExpect(content().string("Failed to start processing."));
+    }
   }
 
 

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -719,4 +719,80 @@ class DataControllerTests {
 
     verify(dataService, times(1)).resetView();
   }
+
+  @Test
+  void loadAssets_Success() throws Exception {
+    // Arrange
+    String collectionId = "testCollection";
+    String itemId = "testItem";
+
+    // We can't verify execution due to async, but ensure the method is called
+    doNothing().when(dataService).processItemAssets(anyString(), anyString());
+
+    // Act & Assert
+    mockMvc.perform(get("/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+      .andExpect(status().isOk())
+      .andExpect(content().string("Processing started in the background. Check logs for completion."));
+
+    // Give async execution a brief moment (useful for debugging)
+    Thread.sleep(100);
+
+    verify(dataService, times(1)).processItemAssets(collectionId, itemId);
+  }
+
+  @Test
+  void loadAssets_Failure_ShouldStillReturnSuccess() throws Exception {
+    // Arrange
+    String collectionId = "testCollection";
+    String itemId = "testItem";
+
+    doThrow(new RuntimeException("Processing error")).when(dataService).processItemAssets(anyString(), anyString());
+
+    // Since the exception is caught in `CompletableFuture.runAsync()`, the API should still return success.
+    mockMvc.perform(get("/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+      .andExpect(status().isOk()) // Still returns success because the exception is async
+      .andExpect(content().string("Processing started in the background. Check logs for completion."));
+
+    // Give async execution a brief moment
+    Thread.sleep(100);
+
+    verify(dataService, times(1)).processItemAssets(collectionId, itemId);
+  }
+
+
+  @Test
+  void getLoadedLayers_Success() throws Exception {
+    // Arrange
+    List<Map<String, Object>> mockLayers = List.of(
+      Map.of("layer", "layer1"),
+      Map.of("layer", "layer2")
+    );
+
+    when(dataService.getLoadedLayers()).thenReturn(mockLayers);
+
+    // Act & Assert
+    mockMvc.perform(get("/get-loaded-layers"))
+      .andExpect(status().isOk())
+      .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+      .andExpect(content().json(objectMapper.writeValueAsString(mockLayers)));
+
+    verify(dataService, times(1)).getLoadedLayers();
+  }
+
+  @Test
+  void getLoadedLayers_Failure() throws Exception {
+    // Arrange
+    doThrow(new DataException("Failed to fetch loaded layers")).when(dataService).getLoadedLayers();
+
+    // Act & Assert
+    mockMvc.perform(get("/get-loaded-layers"))
+      .andExpect(status().isBadRequest())
+      .andExpect(jsonPath("$.status").value(400))
+      .andExpect(jsonPath("$.error").value("Data Error"))
+      .andExpect(jsonPath("$.message").value("Failed to fetch loaded layers"));
+
+    verify(dataService, times(1)).getLoadedLayers();
+  }
+
 }
+

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -829,4 +829,90 @@ class StacRepositoryTests {
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Error resetting Datalayer view");
   }
+
+  @Test
+  void saveLayer_Success() {
+    // Arrange
+    String itemId = "test-item";
+    String collectionId = "test-collection";
+    String assetName = "test-asset";
+    String layerUrl = "http://test-layer.com";
+
+    // Act
+    stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
+
+    // Assert
+    verify(jdbcTemplate, times(1)).update(
+      eq("INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url) VALUES (?, ?, ?, ?) ON CONFLICT (item_id, collection_id, asset_name) DO NOTHING;"),
+      eq(itemId), eq(collectionId), eq(assetName), eq(layerUrl)
+    );
+  }
+
+  @Test
+  void getLoadedLayers_Success() {
+    // Arrange
+    List<Map<String, Object>> expectedLayers = List.of(
+      Map.of("item_id", "item1", "collection_id", "collection1", "asset_name", "asset1", "layer_url", "http://layer1.com"),
+      Map.of("item_id", "item2", "collection_id", "collection2", "asset_name", "asset2", "layer_url", "http://layer2.com")
+    );
+
+    when(jdbcTemplate.queryForList("SELECT * FROM ItemAssets")).thenReturn(expectedLayers);
+
+    // Act
+    List<Map<String, Object>> actualLayers = stacRepository.getLoadedLayers();
+
+    // Assert
+    assertThat(actualLayers).isEqualTo(expectedLayers);
+    verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
+  }
+
+  @Test
+  void getLoadedLayers_EmptyResult() {
+    // Arrange
+    when(jdbcTemplate.queryForList("SELECT * FROM ItemAssets")).thenReturn(List.of());
+
+    // Act
+    List<Map<String, Object>> actualLayers = stacRepository.getLoadedLayers();
+
+    // Assert
+    assertThat(actualLayers).isEmpty();
+    verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
+  }
+
+  @Test
+  void getLoadedLayers_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    when(jdbcTemplate.queryForList("SELECT * FROM ItemAssets"))
+      .thenThrow(new DataAccessException("Database error") {});
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.getLoadedLayers())
+      .isInstanceOf(RuntimeException.class)
+      .hasMessageContaining("Error fetching loaded layers");
+
+    verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
+  }
+
+  @Test
+  void clearLayers_Success() {
+    // Act
+    stacRepository.clearLayers();
+
+    // Assert
+    verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets");
+  }
+
+  @Test
+  void clearLayers_ThrowsException_WhenDatabaseError() {
+    // Arrange
+    doThrow(new DataAccessException("Database error") {}).when(jdbcTemplate).update("DELETE FROM ItemAssets");
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.clearLayers())
+      .isInstanceOf(DataAccessException.class)
+      .hasMessageContaining("Database error");
+
+    verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets");
+  }
+
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -843,10 +843,14 @@ class StacRepositoryTests {
 
     // Assert
     verify(jdbcTemplate, times(1)).update(
-      eq("INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url) VALUES (?, ?, ?, ?) ON CONFLICT (item_id, collection_id, asset_name) DO NOTHING;"),
+      argThat(query -> query.replaceAll("\\s+", " ").trim().equals(
+        "INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url) VALUES (?, ?, ?, ?) ON CONFLICT (item_id, collection_id, asset_name) DO NOTHING;"
+      )),
       eq(itemId), eq(collectionId), eq(assetName), eq(layerUrl)
     );
   }
+
+
 
   @Test
   void getLoadedLayers_Success() {
@@ -887,8 +891,8 @@ class StacRepositoryTests {
 
     // Act & Assert
     assertThatThrownBy(() -> stacRepository.getLoadedLayers())
-      .isInstanceOf(RuntimeException.class)
-      .hasMessageContaining("Error fetching loaded layers");
+      .isInstanceOf(DataAccessException.class)
+      .hasMessageContaining("Database error");
 
     verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
   }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -923,4 +923,54 @@ class DataServiceTests {
     assertThat(result).isNotNull().hasSize(1);
     assertThat(result.get(0)).containsEntry("layer", "testLayer");
   }
+
+  @Test
+  void testProcessItemAssets_Success() throws Exception {
+    // Arrange
+    String collectionId = "testCollection";
+    String itemId = "testItem";
+
+    // Mock database query result
+    PGobject pgObject = new PGobject();
+    pgObject.setType("jsonb");
+    pgObject.setValue("""
+        {
+            "assets": {
+                "asset1": {"href": "http://example.com/test1.tif"},
+                "asset2": {"href": "http://example.com/test2.tif"}
+            }
+        }
+    """);
+    List<Map<String, Object>> queryResults = List.of(Map.of("get_item", pgObject));
+    when(stacRepository.getItem(itemId)).thenReturn(queryResults);
+
+    // Mock parsing JSON
+    JsonNode mockJsonNode = new ObjectMapper().readTree(pgObject.getValue());
+    when(objectMapper.readTree(anyString())).thenReturn(mockJsonNode);
+
+    // Mock layers
+    List<Map<String, Object>> existingLayers = List.of(Map.of("asset_name", "oldLayer"));
+    when(stacRepository.getLoadedLayers()).thenReturn(existingLayers);
+
+    // Mock services
+    when(geoServerService.unregisterLayer(anyString())).thenReturn(true);
+    doNothing().when(stacRepository).clearLayers();
+    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), anyString(), anyString())).thenReturn(true);
+
+    // Act
+    dataService.processItemAssets(collectionId, itemId);
+
+    // Allow some time for async execution (optional)
+    Thread.sleep(200);
+
+    // Assert
+    verify(stacRepository, times(1)).getItem(itemId);
+    verify(objectMapper, times(1)).readTree(anyString());
+    verify(stacRepository, times(1)).getLoadedLayers();
+    verify(geoServerService, times(1)).unregisterLayer("oldLayer");
+    verify(stacRepository, times(1)).clearLayers();
+    verify(geoTIFFService, times(2)).processGeoTIFF(eq(itemId), eq(collectionId), anyString(), anyString());
+  }
+
+
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -1,6 +1,7 @@
 package wildfire.visualization.backend.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.postgresql.util.PGobject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 import wildfire.visualization.backend.controller.ConfigController;
@@ -15,6 +17,7 @@ import wildfire.visualization.backend.exception.DataException;
 import wildfire.visualization.backend.exception.RepositoryException;
 import wildfire.visualization.backend.repository.StacRepository;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,875 +32,895 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class DataServiceTests {
 
-        @Mock
-        private StacRepository stacRepository;
-
-        @Mock
-        private ConfigController configController;
-
-        @Mock
-        private RestTemplate restTemplate;
-
-        @Mock
-        private ObjectMapper objectMapper;
-
-        @InjectMocks
-        private DataService dataService;
-
-        private Map<String, Object> mockResponse;
-
-        private static final String DEFAULT_ENDPOINT_URL = "https://hirondelle.crim.ca/stac/collections";
-
-        @BeforeEach
-        void setUp() {
-                mockResponse = new HashMap<>();
-                mockResponse.put("collections", List.of(new HashMap<>()));
-        }
-
-        @Test
-        void fetchAndSaveCollections_ShouldFetchAndSaveCollections() throws JsonProcessingException {
-                // Arrange
-                Map<String, Object> collection = new HashMap<>();
-                collection.put("id", "test-collection");
-                mockResponse.put("collections", List.of(collection));
-                when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
-                when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
-
-                // Act
-                dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL);
-
-                // Assert
-                verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
-                verify(stacRepository, times(1)).checkCollectionExists("test-collection");
-                verify(stacRepository, times(1)).insertCollection("mockedJson");
-        }
-
-        @Test
-        void fetchAndSaveCollections_ShouldLogError_WhenExceptionThrown() {
-                // Arrange
-                when(restTemplate.getForObject(anyString(), eq(Map.class)))
-                                .thenThrow(new DataException("Test exception"));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Test exception");
-
-                verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
-                verify(stacRepository, times(0)).insertCollection(anyString());
-        }
-
-        @Test
-        void retrieveCollectionMetaData_IsValid() throws JsonProcessingException {
-                // retrieveMetaData is just a middle man between the controller and the
-                // repository, so there is not real functionality to test
-
-                // Arrange
-                when(dataService.retrieveCollectionMetaData(anyString())).thenReturn("[]");
-
-                // Act
-                String response = dataService.retrieveCollectionMetaData("");
-
-                // Assert
-                assertThat(response).isNotNull();
-        }
-
-        @Test
-        void fetchAndSaveCollections_ShouldNotInsert_WhenCollectionExists() {
-                // Arrange
-                Map<String, Object> collection = new HashMap<>();
-                collection.put("id", "existing-collection");
-                mockResponse.put("collections", List.of(collection));
-                when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
-                when(stacRepository.checkCollectionExists("existing-collection")).thenReturn(true);
-
-                // Act
-                dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL);
-
-                // Assert
-                verify(stacRepository, times(1)).checkCollectionExists("existing-collection");
-                verify(stacRepository, times(0)).insertCollection(anyString());
-        }
-
-        @Test
-        void fetchAndSaveCollections_ShouldInsert_WhenCollectionDoesNotExist() throws Exception {
-                // Arrange
-                Map<String, Object> collection = new HashMap<>();
-                collection.put("id", "new-collection");
-                mockResponse.put("collections", List.of(collection));
-                when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
-                when(stacRepository.checkCollectionExists("new-collection")).thenReturn(false);
-                when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
-
-                // Act
-                dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL);
-
-                // Assert
-                verify(stacRepository, times(1)).checkCollectionExists("new-collection");
-                verify(stacRepository, times(1)).insertCollection(anyString());
-        }
-
-        @Test
-        void getCollections_Success_NoBbox() {
-                // Arrange
-                List<Map<String, Object>> mockCollections = List.of(
-                                Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
-                                Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollections(null)).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollections(null);
-
-                // Assert
-                assertThat(collections).isNotNull().hasSize(2);
-                assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
-                                "bbox",
-                                "[10,20,30,40]");
-                assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
-                                "bbox",
-                                "[50,60,70,80]");
-
-                verify(stacRepository, times(1)).getAllCollections(null);
-        }
-
-        @Test
-        void getCollections_Success_WithBbox() {
-                // Arrange
-                double[] bbox = { 10.0, 20.0, 30.0, 40.0 };
-                List<Map<String, Object>> mockCollections = List.of(
-                                Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
-                                Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollections(eq(bbox))).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollections(bbox);
-
-                // Assert
-                assertThat(collections).isNotNull().hasSize(2);
-                assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
-                                "bbox",
-                                "[10,20,30,40]");
-                assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
-                                "bbox",
-                                "[50,60,70,80]");
-
-                verify(stacRepository, times(1)).getAllCollections(eq(bbox));
-        }
-
-        @Test
-        void getCollections_Failure() {
-                // Arrange
-                when(stacRepository.getAllCollections(any()))
-                                .thenThrow(new RepositoryException("Test error"));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.getCollections(null))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to fetch collections");
-
-                verify(stacRepository, times(1)).getAllCollections(null);
-        }
-
-        @Test
-        void getCollectionsByName_Success_NoBbox() {
-                // Arrange
-                List<Map<String, Object>> mockCollections = List.of(
-                                Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
-                                Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByName(null, "asc")).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByName(null, "asc");
-
-                // Assert
-                assertThat(collections).isNotNull().hasSize(2);
-                assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
-                                "bbox",
-                                "[10,20,30,40]");
-                assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
-                                "bbox",
-                                "[50,60,70,80]");
-
-                verify(stacRepository, times(1)).getAllCollectionsByName(null, "asc");
-        }
-
-        @Test
-        void getCollectionsByName_Success_WithBbox() {
-                // Arrange
-                double[] bbox = { 10.0, 20.0, 30.0, 40.0 };
-                List<Map<String, Object>> mockCollections = List.of(
-                                Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
-                                Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByName(eq(bbox), eq("asc"))).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByName(bbox, "asc");
-
-                // Assert
-                assertThat(collections).isNotNull().hasSize(2);
-                assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
-                                "bbox",
-                                "[10,20,30,40]");
-                assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
-                                "bbox",
-                                "[50,60,70,80]");
-
-                verify(stacRepository, times(1)).getAllCollectionsByName(eq(bbox), eq("asc"));
-        }
-
-        @Test
-        void getCollectionsByName_Failure() {
-                // Arrange
-                when(stacRepository.getAllCollectionsByName(any(), eq("asc")))
-                                .thenThrow(new RepositoryException("Test error"));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.getCollectionsByName(null, "asc"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to fetch collections by name");
-
-                verify(stacRepository, times(1)).getAllCollectionsByName(null, "asc");
-        }
-
-        @Test
-        void getCollectionsByDate_Success_NoBbox() {
-                // Arrange
-                List<Map<String, Object>> mockCollections = List.of(
-                                Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
-                                Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByDate(null, "asc")).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByDate(null, "asc");
-
-                // Assert
-                assertThat(collections).isNotNull().hasSize(2);
-                assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
-                                "bbox",
-                                "[10,20,30,40]");
-                assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
-                                "bbox",
-                                "[50,60,70,80]");
-
-                verify(stacRepository, times(1)).getAllCollectionsByDate(null, "asc");
-        }
-
-        @Test
-        void getCollectionsByDate_Success_WithBbox() {
-                // Arrange
-                double[] bbox = { 10.0, 20.0, 30.0, 40.0 };
-                List<Map<String, Object>> mockCollections = List.of(
-                                Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
-                                Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
-                when(stacRepository.getAllCollectionsByDate(eq(bbox), eq("asc"))).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollectionsByDate(bbox, "asc");
-
-                // Assert
-                assertThat(collections).isNotNull().hasSize(2);
-                assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
-                                "bbox",
-                                "[10,20,30,40]");
-                assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
-                                "bbox",
-                                "[50,60,70,80]");
-
-                verify(stacRepository, times(1)).getAllCollectionsByDate(eq(bbox), eq("asc"));
-        }
-
-        @Test
-        void getCollectionsByDate_Failure() {
-                // Arrange
-                when(stacRepository.getAllCollectionsByDate(any(), eq("asc")))
-                                .thenThrow(new RepositoryException("Test error"));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.getCollectionsByDate(null, "asc"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to fetch collections by date");
-
-                verify(stacRepository, times(1)).getAllCollectionsByDate(null, "asc");
-        }
-
-        @Test
-        void deleteAllCollections_Success() {
-                // Act
-                dataService.deleteAllCollections();
-
-                // Assert
-                verify(stacRepository, times(1)).deleteAllCollections();
-        }
-
-        @Test
-        void deleteAllCollections_ShouldLogError_WhenExceptionThrown() {
-                // Arrange
-                doThrow(new RepositoryException("Test exception"))
-                                .when(stacRepository).deleteAllCollections();
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.deleteAllCollections())
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to delete all collections");
-
-                verify(stacRepository, times(1)).deleteAllCollections();
-        }
-
-        @Test
-        void insertView_Default_Success() {
-                // Arrange
-                doNothing().when(stacRepository).setDatalayerView("ID");
-                when(stacRepository.checkDatalayerView()).thenReturn(true);
-
-                // Act
-                dataService.insertView("ID");
-
-                // Assert
-                verify(stacRepository, atLeastOnce()).setDatalayerView("ID");
-                verify(stacRepository, atLeastOnce()).checkDatalayerView();
-        }
-
-        @Test
-        void insertView_SleepMillisAdjusted_Failure() {
-                // Arrange
-                doNothing().when(stacRepository).setDatalayerView("ID");
-                when(stacRepository.checkDatalayerView()).thenReturn(false);
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.insertView("ID", 0))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("View could not be created for collectionId: ID");
-        }
-
-        @Test
-        void insertView_ShouldHandleInterruptedException() {
-                // Arrange
-                doNothing().when(stacRepository).setDatalayerView("ID");
-                when(stacRepository.checkDatalayerView()).thenReturn(false);
-
-                // Act & Assert
-                assertThatThrownBy(() -> {
-                        Thread.currentThread().interrupt(); // Simulate interruption
-                        dataService.insertView("ID", 0);
-                }).isInstanceOf(DataException.class)
-                                .hasMessageContaining("Thread interrupted while creating view for collection: ID");
-
-                verify(stacRepository, atLeastOnce()).setDatalayerView("ID");
-                verify(stacRepository, atLeastOnce()).checkDatalayerView();
-        }
-
-        @Test
-        void verifyCollections_ShouldThrowException_WhenCollectionsAreNull() {
-                // Arrange
-                Map<String, Object> response = new HashMap<>();
-                response.put("collections", null);
-                when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(response);
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.verifyCollections(DEFAULT_ENDPOINT_URL))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("No collections found at the provided URL");
-
-                verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
-        }
-
-        @Test
-        void verifyCollections_ShouldThrowException_WhenCollectionsAreEmpty() {
-                // Arrange
-                when(restTemplate.getForObject(anyString(), eq(Map.class)))
-                                .thenReturn(Map.of("collections", List.of()));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.verifyCollections(DEFAULT_ENDPOINT_URL))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("No collections found at the provided URL");
-
-                verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
-        }
-
-        @Test
-        void verifyCollections_ShouldLogError_WhenExceptionThrown() {
-                // Arrange
-                when(restTemplate.getForObject(anyString(), eq(Map.class)))
-                                .thenThrow(new RuntimeException("Test exception"));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.verifyCollections(DEFAULT_ENDPOINT_URL))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Error checking collections");
-
-                verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
-        }
-
-        @Test
-        void insertItem_Success() {
-                // Arrange
-                doNothing().when(stacRepository).insertItem(anyString());
-                // Act
-                dataService.insertItem("Test");
-        }
-
-        @Test
-        void insertItem_Failure() {
-                // Arrange
-                doThrow(new RepositoryException("Error inserting item"))
-                                .when(stacRepository).insertItem(anyString());
-
-                // Assert
-                assertThatThrownBy(() -> dataService.insertItem("test"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to insert item");
-        }
-
-        @Test
-        void getItem_WithId_Success() {
-                // Arrange
-                List<Map<String, Object>> mockResults = List.of(
-                                Map.of("id", "test1"));
-                when(stacRepository.getItem(anyString())).thenReturn(mockResults);
-                // Act
-                List<Map<String, Object>> result = dataService.getItem("Test");
-
-                // Assert
-                assertThat(result).isEqualTo(mockResults);
-        }
-
-        @Test
-        void getItem_WithId_Failure() {
-                // Arrange
-                doThrow(new RepositoryException("Error fetching item"))
-                                .when(stacRepository).getItem(anyString());
-
-                // Assert
-                assertThatThrownBy(() -> dataService.getItem("test"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to fetch item");
-        }
-
-        @Test
-        void getItem_WithIdAndCollectionId_Success() {
-                // Arrange
-                List<Map<String, Object>> mockResults = List.of(
-                                Map.of("id", "test1"));
-                when(stacRepository.getItem(anyString(), anyString())).thenReturn(mockResults);
-                // Act
-                List<Map<String, Object>> result = dataService.getItem("Test", "Test");
-
-                // Assert
-                assertThat(result).isEqualTo(mockResults);
-        }
-
-        @Test
-        void getItem_WithIdAndCollectionId_Failure() {
-                // Arrange
-                doThrow(new RepositoryException("Error fetching item"))
-                                .when(stacRepository).getItem(anyString(), anyString());
-
-                // Assert
-                assertThatThrownBy(() -> dataService.getItem("test", "test"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to fetch item");
-        }
-
-        @Test
-        void removeAllItems_Failure() {
-                // Arrange
-                doThrow(new RepositoryException("Error removing all items"))
-                                .when(stacRepository).removeAllItems();
-
-                // Assert
-                assertThatThrownBy(() -> dataService.removeAllItems())
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to remove all items");
-        }
-
-        @Test
-        void removeItemsFromCollection_Failure() {
-                // Arrange
-                doThrow(new RepositoryException("Error removing items from collection"))
-                                .when(stacRepository).removeItemsFromCollection(anyString());
-
-                // Assert
-                assertThatThrownBy(() -> dataService.removeItemsFromCollection("test"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to remove items from collection");
-        }
-
-        @Test
-        void removeItem_Failure() {
-                // Arrange
-                doThrow(new RepositoryException("Error removing item"))
-                                .when(stacRepository).removeItem(anyString(), anyString());
-
-                // Assert
-                assertThatThrownBy(() -> dataService.removeItem("test", "test"))
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to remove item");
-        }
-
-        @Test
-        void getCollections_HandlesNullValues() {
-                // Arrange
-                Map<String, Object> nullValueMap = new HashMap<>();
-                nullValueMap.put("key", null);
-                nullValueMap.put("id", null);
-                nullValueMap.put("bbox", null);
-
-                List<Map<String, Object>> mockCollections = List.of(nullValueMap);
-                when(stacRepository.getAllCollections(any())).thenReturn(mockCollections);
-
-                // Act
-                List<Map<String, Object>> collections = dataService.getCollections(null);
-
-                // Assert
-                assertThat(collections).hasSize(1);
-                assertThat(collections.get(0)).containsEntry("key", "")
-                                .containsEntry("id", "")
-                                .containsEntry("bbox", "[]");
-        }
-
-        @Test
-        void verifyCollections_Success() {
-                // Arrange
-                List<Map<String, Object>> mockCollections = List.of(Map.of("id", "collection1"));
-                Map<String, Object> response = Map.of("collections", mockCollections);
-                when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(response);
-
-                // Act
-                String result = dataService.verifyCollections("https://test-url.com");
-
-                // Assert
-                assertThat(result).isEqualTo("Collections found");
-        }
-
-        @Test
-        void deleteAllItems_Success() {
-                // Act
-                dataService.deleteAllItems();
-
-                // Assert
-                verify(stacRepository).deleteAllItems();
-        }
-
-        @Test
-        void deleteAllItems_ThrowsException() {
-                // Arrange
-                doThrow(new RepositoryException("Test error"))
-                                .when(stacRepository).deleteAllItems();
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.deleteAllItems())
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to delete all items");
-        }
-
-        @Test
-        void fetchAndSaveItems_Success() throws JsonProcessingException {
-                // Arrange
-                String collectionId = "testCollection";
-                Map<String, Object> configMap = Map.of("endpoint", "https://test-endpoint.com");
-                ResponseEntity<Map<String, Object>> configResponse = ResponseEntity.ok(configMap);
-                when(configController.getConfig()).thenReturn(configResponse);
-
-                // Mock Collection Metadata (from DB)
-                List<Map<String, Object>> collectionMetadata = List.of(Map.of(
-                                "datetime", "2023-08-01T12:00:00Z",
-                                "end_datetime", "2023-08-31T12:00:00Z",
-                                "item_count", 2));
-                when(stacRepository.queryCollectionMetaData(collectionId)).thenReturn(collectionMetadata);
-
-                // Mock STAC API Responses for Pagination (First call has next, second does not)
-                Map<String, Object> item1 = new HashMap<>();
-                item1.put("id", "wildfire_timestamp_2023_08_10_12_00_00");
-                Map<String, Object> item2 = new HashMap<>();
-                item2.put("id", "wildfire_timestamp_2023_08_11_12_00_00");
-
-                // First response includes "next" link
-                Map<String, Object> firstResponse = Map.of(
-                                "features", List.of(item1),
-                                "links", List.of(Map.of("rel", "next", "href", "https://next-page.com")));
-
-                // Second response has no "next" link (pagination stops)
-                Map<String, Object> secondResponse = Map.of(
-                                "features", List.of(item2), // Last item
-                                "links", List.of() // No next link, should stop looping
-                );
-
-                when(restTemplate.getForObject(anyString(), eq(Map.class)))
-                                .thenReturn(firstResponse) // First call
-                                .thenReturn(secondResponse); // Second call (stops pagination)
-
-                // Mock DB Calls for Inserting Items
-                when(stacRepository.checkCollectionExists("wildfire_timestamp_2023_08_10_12_00_00")).thenReturn(false);
-                when(stacRepository.checkCollectionExists("wildfire_timestamp_2023_08_11_12_00_00")).thenReturn(false);
-                when(objectMapper.writeValueAsString(any()))
-                                .thenReturn("{\"id\":\"wildfire_timestamp_2023_08_10_12_00_00\"}");
-
-                // Act
-                dataService.fetchAndSaveItems(collectionId);
-
-                // Wait briefly to allow async execution (not ideal but necessary for async
-                // tests)
-                try {
-                        Thread.sleep(200);
-                } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt(); // Restore the interrupted status
-                        throw new RuntimeException(e);
-                }
-
-                // Assert
-                verify(configController).getConfig();
-                verify(restTemplate, times(2)).getForObject(anyString(), eq(Map.class)); // Ensures it calls twice, then
-                                                                                         // stops
-                verify(stacRepository, times(2)).insertItem(anyString());
-                verify(stacRepository, times(2)).checkCollectionExists(anyString());
-
-                // Assert progress is updated
-                int progress = dataService.getProgress(collectionId);
-                assertTrue(progress > 90 && progress <= 100, "Progress should be a valid percentage");
-        }
-
-        @Test
-        void removeAllItems_Success() {
-                // Arrange
-                when(stacRepository.removeAllItems()).thenReturn("All items removed");
-
-                // Act
-                String result = dataService.removeAllItems();
-
-                // Assert
-                assertThat(result).isEqualTo("All items removed");
-        }
-
-        @Test
-        void removeItemsFromCollection_Success() {
-                // Arrange
-                String collectionId = "testCollection";
-                when(stacRepository.removeItemsFromCollection(collectionId)).thenReturn("Items removed");
-
-                // Act
-                String result = dataService.removeItemsFromCollection(collectionId);
-
-                // Assert
-                assertThat(result).isEqualTo("Items removed");
-        }
-
-        @Test
-        void removeItem_Success() {
-                // Arrange
-                String itemId = "item1";
-                String collectionId = "collection1";
-                when(stacRepository.removeItem(itemId, collectionId)).thenReturn("Item removed");
-
-                // Act
-                String result = dataService.removeItem(itemId, collectionId);
-
-                // Assert
-                assertThat(result).isEqualTo("Item removed");
-        }
-
-        @Test
-        void verifyInternetConnection_Success() {
-                // Arrange
-                String endpointUrl = "https://test-url.com";
-                when(restTemplate.getForObject(endpointUrl, String.class)).thenReturn("Response");
-
-                // Act
-                String result = dataService.verifyInternetConnection(endpointUrl);
-
-                // Assert
-                assertThat(result).isEqualTo("Internet connection established");
-        }
-
-        @Test
-        void verifyInternetConnection_Failure() {
-                // Arrange
-                String endpointUrl = "https://test-url.com";
-                when(restTemplate.getForObject(endpointUrl, String.class)).thenThrow(new RuntimeException("Failed"));
-
-                // Act
-                String result = dataService.verifyInternetConnection(endpointUrl);
-
-                // Assert
-                assertThat(result).isEqualTo("No internet connection could be established");
-        }
-
-        @Test
-        void fetchItemsTimestamps_Success() {
-                // Arrange
-                List<String> mockTimestamps = List.of("2023-01-01T12:00:00Z", "2023-02-01T12:00:00Z");
-                when(stacRepository.getItemsTimestamps()).thenReturn(mockTimestamps);
-
-                // Act
-                List<String> result = dataService.fetchItemsTimestamps();
-
-                // Assert
-                assertThat(result).isEqualTo(mockTimestamps);
-                verify(stacRepository).getItemsTimestamps();
-        }
-
-        @Test
-        void fetchItemsTimestamps_ThrowsException() {
-                // Arrange
-                when(stacRepository.getItemsTimestamps())
-                                .thenThrow(new RepositoryException("Database error"));
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.fetchItemsTimestamps())
-                                .isInstanceOf(DataException.class)
-                                .hasMessageContaining("Failed to fetch item timestamps");
-        }
-
-        @Test
-        void fetchAndSaveItems_SkipsExistingItems() throws JsonProcessingException {
-                // Arrange
-                String collectionId = "testCollection";
-                Map<String, Object> configMap = Map.of("endpoint", "https://test-endpoint.com");
-                ResponseEntity<Map<String, Object>> configResponse = ResponseEntity.ok(configMap);
-                when(configController.getConfig()).thenReturn(configResponse);
-
-                // Mock Collection Metadata (from DB)
-                List<Map<String, Object>> collectionMetadata = List.of(Map.of(
-                                "datetime", "2023-08-01T12:00:00Z",
-                                "end_datetime", "2023-08-31T12:00:00Z",
-                                "item_count", 1));
-                when(stacRepository.queryCollectionMetaData(collectionId)).thenReturn(collectionMetadata);
-
-                // Mock STAC API Response (with existing item)
-                Map<String, Object> item = new HashMap<>();
-                item.put("id", "existingItem");
-
-                Map<String, Object> itemsResponse = Map.of(
-                                "features", List.of(item),
-                                "links", List.of() // No "next" link to ensure no infinite loop
-                );
-
-                when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(itemsResponse);
-                when(stacRepository.checkCollectionExists("existingItem")).thenReturn(true);
-
-                // Act
-                dataService.fetchAndSaveItems(collectionId);
-
-                // Wait for async execution
-                try {
-                        Thread.sleep(100);
-                } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                        throw new RuntimeException(e);
-                }
-
-                // Assert
-                verify(stacRepository).checkCollectionExists("existingItem");
-                verify(stacRepository, never()).insertItem(anyString());
-        }
-
-        @Test
-        void fetchAndSaveItems_HandlesException() {
-                // Arrange
-                String collectionId = "testCollection";
-                when(configController.getConfig())
-                                .thenThrow(new RuntimeException("Config error"));
-
-                // Ensure the failure message contains the expected error text
-                try {
-                        dataService.fetchAndSaveItems(collectionId);
-                } catch (Exception e) {
-                        assertTrue(true);
-                }
-
-                // Verify that it attempted to fetch config before failing
-                verify(configController, times(1)).getConfig();
-        }
-
-        @Test
-        void resetView_Default_Success() throws Exception {
-                // Arrange
-                doNothing().when(stacRepository).resetDatalayerView();
-
-                // Act
-                dataService.resetView();
-
-                // Assert
-                verify(stacRepository, atLeastOnce()).resetDatalayerView();
-        }
-
-        @Test
-        void retrieveCollectionMetaData_ThrowsException() {
-                // Arrange
-                String collectionId = "nonexistent-collection";
-
-                // Mock the repository to throw an exception
-                when(stacRepository.queryCollectionMetaData(collectionId))
-                                .thenThrow(new RuntimeException("Database error"));
-
-                // Act & Assert
-                DataException exception = assertThrows(DataException.class, () -> {
-                        dataService.retrieveCollectionMetaData(collectionId);
-                });
-
-                // Verify the exception message and cause
-                assertThat(exception.getMessage())
-                                .isEqualTo("Failed to retrieve metadata for collection: nonexistent-collection");
-                assertThat(exception.getCause())
-                                .isInstanceOf(RuntimeException.class);
-                assertThat(exception.getCause().getMessage())
-                                .isEqualTo("Database error");
-
-                // Verify that the repository method was called
-                verify(stacRepository).queryCollectionMetaData(collectionId);
-        }
-
-        @Test
-        void insertView_CatchesAndWrapsGeneralExceptions() {
-                // Arrange
-                String collectionId = "test-collection";
-
-                // Mock the repository to throw an unexpected exception that isn't a
-                // DataException
-                doThrow(new RuntimeException("Unexpected database error"))
-                                .when(stacRepository).setDatalayerView(collectionId);
-
-                // Act & Assert
-                DataException exception = assertThrows(DataException.class, () -> {
-                        dataService.insertView(collectionId);
-                });
-
-                // Verify the exception was properly wrapped with the correct message
-                assertThat(exception.getMessage())
-                                .isEqualTo("Failed to insert view for collection: test-collection");
-
-                // Verify the original exception is preserved as the cause
-                assertThat(exception.getCause())
-                                .isInstanceOf(RuntimeException.class);
-                assertThat(exception.getCause().getMessage())
-                                .isEqualTo("Unexpected database error");
-
-                // Verify the repository method was called
-                verify(stacRepository).setDatalayerView(collectionId);
-
-                // Verify checkDatalayerView was never called (exception happens before that)
-                verify(stacRepository, never()).checkDatalayerView();
-        }
-
-        @Test
-        void resetView_Success() {
-                // Act
-                dataService.resetView();
-
-                // Assert
-                verify(stacRepository, times(1)).resetDatalayerView();
-        }
-
-        @Test
-        void resetView_ShouldLogError_WhenExceptionThrown() {
-                // Arrange
-                doThrow(new RuntimeException("Test exception")).when(stacRepository).resetDatalayerView();
-
-                // Act & Assert
-                assertThatThrownBy(() -> dataService.resetView())
-                                .isInstanceOf(IllegalStateException.class)
-                                .hasMessageContaining("Failed to reset Datalayer view: Test exception");
-
-                verify(stacRepository, times(1)).resetDatalayerView();
-        }
+  @Mock
+  private StacRepository stacRepository;
+
+  @Mock
+  private ConfigController configController;
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  @Mock
+  private ObjectMapper objectMapper;
+
+  @Mock
+  private GeoTIFFService geoTIFFService;
+
+  @Mock
+  private GeoServerService geoServerService;
+
+  @InjectMocks
+  private DataService dataService;
+
+  private Map<String, Object> mockResponse;
+
+  private static final String DEFAULT_ENDPOINT_URL = "https://hirondelle.crim.ca/stac/collections";
+
+  @BeforeEach
+  void setUp() {
+    mockResponse = new HashMap<>();
+    mockResponse.put("collections", List.of(new HashMap<>()));
+  }
+
+  @Test
+  void fetchAndSaveCollections_ShouldFetchAndSaveCollections() throws JsonProcessingException {
+    // Arrange
+    Map<String, Object> collection = new HashMap<>();
+    collection.put("id", "test-collection");
+    mockResponse.put("collections", List.of(collection));
+    when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
+
+    // Act
+    dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL);
+
+    // Assert
+    verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
+    verify(stacRepository, times(1)).checkCollectionExists("test-collection");
+    verify(stacRepository, times(1)).insertCollection("mockedJson");
+  }
+
+  @Test
+  void fetchAndSaveCollections_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    when(restTemplate.getForObject(anyString(), eq(Map.class)))
+      .thenThrow(new DataException("Test exception"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Test exception");
+
+    verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
+    verify(stacRepository, times(0)).insertCollection(anyString());
+  }
+
+  @Test
+  void retrieveCollectionMetaData_IsValid() throws JsonProcessingException {
+    // retrieveMetaData is just a middle man between the controller and the
+    // repository, so there is not real functionality to test
+
+    // Arrange
+    when(dataService.retrieveCollectionMetaData(anyString())).thenReturn("[]");
+
+    // Act
+    String response = dataService.retrieveCollectionMetaData("");
+
+    // Assert
+    assertThat(response).isNotNull();
+  }
+
+  @Test
+  void fetchAndSaveCollections_ShouldNotInsert_WhenCollectionExists() {
+    // Arrange
+    Map<String, Object> collection = new HashMap<>();
+    collection.put("id", "existing-collection");
+    mockResponse.put("collections", List.of(collection));
+    when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
+    when(stacRepository.checkCollectionExists("existing-collection")).thenReturn(true);
+
+    // Act
+    dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL);
+
+    // Assert
+    verify(stacRepository, times(1)).checkCollectionExists("existing-collection");
+    verify(stacRepository, times(0)).insertCollection(anyString());
+  }
+
+  @Test
+  void fetchAndSaveCollections_ShouldInsert_WhenCollectionDoesNotExist() throws Exception {
+    // Arrange
+    Map<String, Object> collection = new HashMap<>();
+    collection.put("id", "new-collection");
+    mockResponse.put("collections", List.of(collection));
+    when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(mockResponse);
+    when(stacRepository.checkCollectionExists("new-collection")).thenReturn(false);
+    when(objectMapper.writeValueAsString(any())).thenReturn("mockedJson");
+
+    // Act
+    dataService.fetchAndSaveCollections(DEFAULT_ENDPOINT_URL);
+
+    // Assert
+    verify(stacRepository, times(1)).checkCollectionExists("new-collection");
+    verify(stacRepository, times(1)).insertCollection(anyString());
+  }
+
+  @Test
+  void getCollections_Success_NoBbox() {
+    // Arrange
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
+      Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
+    when(stacRepository.getAllCollections(null)).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollections(null);
+
+    // Assert
+    assertThat(collections).isNotNull().hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
+      "bbox",
+      "[10,20,30,40]");
+    assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
+      "bbox",
+      "[50,60,70,80]");
+
+    verify(stacRepository, times(1)).getAllCollections(null);
+  }
+
+  @Test
+  void getCollections_Success_WithBbox() {
+    // Arrange
+    double[] bbox = {10.0, 20.0, 30.0, 40.0};
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
+      Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
+    when(stacRepository.getAllCollections(eq(bbox))).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollections(bbox);
+
+    // Assert
+    assertThat(collections).isNotNull().hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
+      "bbox",
+      "[10,20,30,40]");
+    assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
+      "bbox",
+      "[50,60,70,80]");
+
+    verify(stacRepository, times(1)).getAllCollections(eq(bbox));
+  }
+
+  @Test
+  void getCollections_Failure() {
+    // Arrange
+    when(stacRepository.getAllCollections(any()))
+      .thenThrow(new RepositoryException("Test error"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.getCollections(null))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to fetch collections");
+
+    verify(stacRepository, times(1)).getAllCollections(null);
+  }
+
+  @Test
+  void getCollectionsByName_Success_NoBbox() {
+    // Arrange
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
+      Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
+    when(stacRepository.getAllCollectionsByName(null, "asc")).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollectionsByName(null, "asc");
+
+    // Assert
+    assertThat(collections).isNotNull().hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
+      "bbox",
+      "[10,20,30,40]");
+    assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
+      "bbox",
+      "[50,60,70,80]");
+
+    verify(stacRepository, times(1)).getAllCollectionsByName(null, "asc");
+  }
+
+  @Test
+  void getCollectionsByName_Success_WithBbox() {
+    // Arrange
+    double[] bbox = {10.0, 20.0, 30.0, 40.0};
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
+      Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
+    when(stacRepository.getAllCollectionsByName(eq(bbox), eq("asc"))).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollectionsByName(bbox, "asc");
+
+    // Assert
+    assertThat(collections).isNotNull().hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
+      "bbox",
+      "[10,20,30,40]");
+    assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
+      "bbox",
+      "[50,60,70,80]");
+
+    verify(stacRepository, times(1)).getAllCollectionsByName(eq(bbox), eq("asc"));
+  }
+
+  @Test
+  void getCollectionsByName_Failure() {
+    // Arrange
+    when(stacRepository.getAllCollectionsByName(any(), eq("asc")))
+      .thenThrow(new RepositoryException("Test error"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.getCollectionsByName(null, "asc"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to fetch collections by name");
+
+    verify(stacRepository, times(1)).getAllCollectionsByName(null, "asc");
+  }
+
+  @Test
+  void getCollectionsByDate_Success_NoBbox() {
+    // Arrange
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
+      Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
+    when(stacRepository.getAllCollectionsByDate(null, "asc")).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollectionsByDate(null, "asc");
+
+    // Assert
+    assertThat(collections).isNotNull().hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
+      "bbox",
+      "[10,20,30,40]");
+    assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
+      "bbox",
+      "[50,60,70,80]");
+
+    verify(stacRepository, times(1)).getAllCollectionsByDate(null, "asc");
+  }
+
+  @Test
+  void getCollectionsByDate_Success_WithBbox() {
+    // Arrange
+    double[] bbox = {10.0, 20.0, 30.0, 40.0};
+    List<Map<String, Object>> mockCollections = List.of(
+      Map.of("key", "value1", "id", "id1", "bbox", "[10,20,30,40]"),
+      Map.of("key", "value2", "id", "id2", "bbox", "[50,60,70,80]"));
+    when(stacRepository.getAllCollectionsByDate(eq(bbox), eq("asc"))).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollectionsByDate(bbox, "asc");
+
+    // Assert
+    assertThat(collections).isNotNull().hasSize(2);
+    assertThat(collections.get(0)).containsEntry("key", "value1").containsEntry("id", "id1").containsEntry(
+      "bbox",
+      "[10,20,30,40]");
+    assertThat(collections.get(1)).containsEntry("key", "value2").containsEntry("id", "id2").containsEntry(
+      "bbox",
+      "[50,60,70,80]");
+
+    verify(stacRepository, times(1)).getAllCollectionsByDate(eq(bbox), eq("asc"));
+  }
+
+  @Test
+  void getCollectionsByDate_Failure() {
+    // Arrange
+    when(stacRepository.getAllCollectionsByDate(any(), eq("asc")))
+      .thenThrow(new RepositoryException("Test error"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.getCollectionsByDate(null, "asc"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to fetch collections by date");
+
+    verify(stacRepository, times(1)).getAllCollectionsByDate(null, "asc");
+  }
+
+  @Test
+  void deleteAllCollections_Success() {
+    // Act
+    dataService.deleteAllCollections();
+
+    // Assert
+    verify(stacRepository, times(1)).deleteAllCollections();
+  }
+
+  @Test
+  void deleteAllCollections_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    doThrow(new RepositoryException("Test exception"))
+      .when(stacRepository).deleteAllCollections();
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.deleteAllCollections())
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to delete all collections");
+
+    verify(stacRepository, times(1)).deleteAllCollections();
+  }
+
+  @Test
+  void insertView_Default_Success() {
+    // Arrange
+    doNothing().when(stacRepository).setDatalayerView("ID");
+    when(stacRepository.checkDatalayerView()).thenReturn(true);
+
+    // Act
+    dataService.insertView("ID");
+
+    // Assert
+    verify(stacRepository, atLeastOnce()).setDatalayerView("ID");
+    verify(stacRepository, atLeastOnce()).checkDatalayerView();
+  }
+
+  @Test
+  void insertView_SleepMillisAdjusted_Failure() {
+    // Arrange
+    doNothing().when(stacRepository).setDatalayerView("ID");
+    when(stacRepository.checkDatalayerView()).thenReturn(false);
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.insertView("ID", 0))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("View could not be created for collectionId: ID");
+  }
+
+  @Test
+  void insertView_ShouldHandleInterruptedException() {
+    // Arrange
+    doNothing().when(stacRepository).setDatalayerView("ID");
+    when(stacRepository.checkDatalayerView()).thenReturn(false);
+
+    // Act & Assert
+    assertThatThrownBy(() -> {
+      Thread.currentThread().interrupt(); // Simulate interruption
+      dataService.insertView("ID", 0);
+    }).isInstanceOf(DataException.class)
+      .hasMessageContaining("Thread interrupted while creating view for collection: ID");
+
+    verify(stacRepository, atLeastOnce()).setDatalayerView("ID");
+    verify(stacRepository, atLeastOnce()).checkDatalayerView();
+  }
+
+  @Test
+  void verifyCollections_ShouldThrowException_WhenCollectionsAreNull() {
+    // Arrange
+    Map<String, Object> response = new HashMap<>();
+    response.put("collections", null);
+    when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(response);
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.verifyCollections(DEFAULT_ENDPOINT_URL))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("No collections found at the provided URL");
+
+    verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
+  }
+
+  @Test
+  void verifyCollections_ShouldThrowException_WhenCollectionsAreEmpty() {
+    // Arrange
+    when(restTemplate.getForObject(anyString(), eq(Map.class)))
+      .thenReturn(Map.of("collections", List.of()));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.verifyCollections(DEFAULT_ENDPOINT_URL))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("No collections found at the provided URL");
+
+    verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
+  }
+
+  @Test
+  void verifyCollections_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    when(restTemplate.getForObject(anyString(), eq(Map.class)))
+      .thenThrow(new RuntimeException("Test exception"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.verifyCollections(DEFAULT_ENDPOINT_URL))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Error checking collections");
+
+    verify(restTemplate, times(1)).getForObject(anyString(), eq(Map.class));
+  }
+
+  @Test
+  void insertItem_Success() {
+    // Arrange
+    doNothing().when(stacRepository).insertItem(anyString());
+    // Act
+    dataService.insertItem("Test");
+  }
+
+  @Test
+  void insertItem_Failure() {
+    // Arrange
+    doThrow(new RepositoryException("Error inserting item"))
+      .when(stacRepository).insertItem(anyString());
+
+    // Assert
+    assertThatThrownBy(() -> dataService.insertItem("test"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to insert item");
+  }
+
+  @Test
+  void getItem_WithId_Success() {
+    // Arrange
+    List<Map<String, Object>> mockResults = List.of(
+      Map.of("id", "test1"));
+    when(stacRepository.getItem(anyString())).thenReturn(mockResults);
+    // Act
+    List<Map<String, Object>> result = dataService.getItem("Test");
+
+    // Assert
+    assertThat(result).isEqualTo(mockResults);
+  }
+
+  @Test
+  void getItem_WithId_Failure() {
+    // Arrange
+    doThrow(new RepositoryException("Error fetching item"))
+      .when(stacRepository).getItem(anyString());
+
+    // Assert
+    assertThatThrownBy(() -> dataService.getItem("test"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to fetch item");
+  }
+
+  @Test
+  void getItem_WithIdAndCollectionId_Success() {
+    // Arrange
+    List<Map<String, Object>> mockResults = List.of(
+      Map.of("id", "test1"));
+    when(stacRepository.getItem(anyString(), anyString())).thenReturn(mockResults);
+    // Act
+    List<Map<String, Object>> result = dataService.getItem("Test", "Test");
+
+    // Assert
+    assertThat(result).isEqualTo(mockResults);
+  }
+
+  @Test
+  void getItem_WithIdAndCollectionId_Failure() {
+    // Arrange
+    doThrow(new RepositoryException("Error fetching item"))
+      .when(stacRepository).getItem(anyString(), anyString());
+
+    // Assert
+    assertThatThrownBy(() -> dataService.getItem("test", "test"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to fetch item");
+  }
+
+  @Test
+  void removeAllItems_Failure() {
+    // Arrange
+    doThrow(new RepositoryException("Error removing all items"))
+      .when(stacRepository).removeAllItems();
+
+    // Assert
+    assertThatThrownBy(() -> dataService.removeAllItems())
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to remove all items");
+  }
+
+  @Test
+  void removeItemsFromCollection_Failure() {
+    // Arrange
+    doThrow(new RepositoryException("Error removing items from collection"))
+      .when(stacRepository).removeItemsFromCollection(anyString());
+
+    // Assert
+    assertThatThrownBy(() -> dataService.removeItemsFromCollection("test"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to remove items from collection");
+  }
+
+  @Test
+  void removeItem_Failure() {
+    // Arrange
+    doThrow(new RepositoryException("Error removing item"))
+      .when(stacRepository).removeItem(anyString(), anyString());
+
+    // Assert
+    assertThatThrownBy(() -> dataService.removeItem("test", "test"))
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to remove item");
+  }
+
+  @Test
+  void getCollections_HandlesNullValues() {
+    // Arrange
+    Map<String, Object> nullValueMap = new HashMap<>();
+    nullValueMap.put("key", null);
+    nullValueMap.put("id", null);
+    nullValueMap.put("bbox", null);
+
+    List<Map<String, Object>> mockCollections = List.of(nullValueMap);
+    when(stacRepository.getAllCollections(any())).thenReturn(mockCollections);
+
+    // Act
+    List<Map<String, Object>> collections = dataService.getCollections(null);
+
+    // Assert
+    assertThat(collections).hasSize(1);
+    assertThat(collections.get(0)).containsEntry("key", "")
+      .containsEntry("id", "")
+      .containsEntry("bbox", "[]");
+  }
+
+  @Test
+  void verifyCollections_Success() {
+    // Arrange
+    List<Map<String, Object>> mockCollections = List.of(Map.of("id", "collection1"));
+    Map<String, Object> response = Map.of("collections", mockCollections);
+    when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(response);
+
+    // Act
+    String result = dataService.verifyCollections("https://test-url.com");
+
+    // Assert
+    assertThat(result).isEqualTo("Collections found");
+  }
+
+  @Test
+  void deleteAllItems_Success() {
+    // Act
+    dataService.deleteAllItems();
+
+    // Assert
+    verify(stacRepository).deleteAllItems();
+  }
+
+  @Test
+  void deleteAllItems_ThrowsException() {
+    // Arrange
+    doThrow(new RepositoryException("Test error"))
+      .when(stacRepository).deleteAllItems();
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.deleteAllItems())
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to delete all items");
+  }
+
+  @Test
+  void fetchAndSaveItems_Success() throws JsonProcessingException {
+    // Arrange
+    String collectionId = "testCollection";
+    Map<String, Object> configMap = Map.of("endpoint", "https://test-endpoint.com");
+    ResponseEntity<Map<String, Object>> configResponse = ResponseEntity.ok(configMap);
+    when(configController.getConfig()).thenReturn(configResponse);
+
+    // Mock Collection Metadata (from DB)
+    List<Map<String, Object>> collectionMetadata = List.of(Map.of(
+      "datetime", "2023-08-01T12:00:00Z",
+      "end_datetime", "2023-08-31T12:00:00Z",
+      "item_count", 2));
+    when(stacRepository.queryCollectionMetaData(collectionId)).thenReturn(collectionMetadata);
+
+    // Mock STAC API Responses for Pagination (First call has next, second does not)
+    Map<String, Object> item1 = new HashMap<>();
+    item1.put("id", "wildfire_timestamp_2023_08_10_12_00_00");
+    Map<String, Object> item2 = new HashMap<>();
+    item2.put("id", "wildfire_timestamp_2023_08_11_12_00_00");
+
+    // First response includes "next" link
+    Map<String, Object> firstResponse = Map.of(
+      "features", List.of(item1),
+      "links", List.of(Map.of("rel", "next", "href", "https://next-page.com")));
+
+    // Second response has no "next" link (pagination stops)
+    Map<String, Object> secondResponse = Map.of(
+      "features", List.of(item2), // Last item
+      "links", List.of() // No next link, should stop looping
+    );
+
+    when(restTemplate.getForObject(anyString(), eq(Map.class)))
+      .thenReturn(firstResponse) // First call
+      .thenReturn(secondResponse); // Second call (stops pagination)
+
+    // Mock DB Calls for Inserting Items
+    when(stacRepository.checkCollectionExists("wildfire_timestamp_2023_08_10_12_00_00")).thenReturn(false);
+    when(stacRepository.checkCollectionExists("wildfire_timestamp_2023_08_11_12_00_00")).thenReturn(false);
+    when(objectMapper.writeValueAsString(any()))
+      .thenReturn("{\"id\":\"wildfire_timestamp_2023_08_10_12_00_00\"}");
+
+    // Act
+    dataService.fetchAndSaveItems(collectionId);
+
+    // Wait briefly to allow async execution (not ideal but necessary for async
+    // tests)
+    try {
+      Thread.sleep(200);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt(); // Restore the interrupted status
+      throw new RuntimeException(e);
+    }
+
+    // Assert
+    verify(configController).getConfig();
+    verify(restTemplate, times(2)).getForObject(anyString(), eq(Map.class)); // Ensures it calls twice, then
+    // stops
+    verify(stacRepository, times(2)).insertItem(anyString());
+    verify(stacRepository, times(2)).checkCollectionExists(anyString());
+
+    // Assert progress is updated
+    int progress = dataService.getProgress(collectionId);
+    assertTrue(progress > 90 && progress <= 100, "Progress should be a valid percentage");
+  }
+
+  @Test
+  void removeAllItems_Success() {
+    // Arrange
+    when(stacRepository.removeAllItems()).thenReturn("All items removed");
+
+    // Act
+    String result = dataService.removeAllItems();
+
+    // Assert
+    assertThat(result).isEqualTo("All items removed");
+  }
+
+  @Test
+  void removeItemsFromCollection_Success() {
+    // Arrange
+    String collectionId = "testCollection";
+    when(stacRepository.removeItemsFromCollection(collectionId)).thenReturn("Items removed");
+
+    // Act
+    String result = dataService.removeItemsFromCollection(collectionId);
+
+    // Assert
+    assertThat(result).isEqualTo("Items removed");
+  }
+
+  @Test
+  void removeItem_Success() {
+    // Arrange
+    String itemId = "item1";
+    String collectionId = "collection1";
+    when(stacRepository.removeItem(itemId, collectionId)).thenReturn("Item removed");
+
+    // Act
+    String result = dataService.removeItem(itemId, collectionId);
+
+    // Assert
+    assertThat(result).isEqualTo("Item removed");
+  }
+
+  @Test
+  void verifyInternetConnection_Success() {
+    // Arrange
+    String endpointUrl = "https://test-url.com";
+    when(restTemplate.getForObject(endpointUrl, String.class)).thenReturn("Response");
+
+    // Act
+    String result = dataService.verifyInternetConnection(endpointUrl);
+
+    // Assert
+    assertThat(result).isEqualTo("Internet connection established");
+  }
+
+  @Test
+  void verifyInternetConnection_Failure() {
+    // Arrange
+    String endpointUrl = "https://test-url.com";
+    when(restTemplate.getForObject(endpointUrl, String.class)).thenThrow(new RuntimeException("Failed"));
+
+    // Act
+    String result = dataService.verifyInternetConnection(endpointUrl);
+
+    // Assert
+    assertThat(result).isEqualTo("No internet connection could be established");
+  }
+
+  @Test
+  void fetchItemsTimestamps_Success() {
+    // Arrange
+    List<String> mockTimestamps = List.of("2023-01-01T12:00:00Z", "2023-02-01T12:00:00Z");
+    when(stacRepository.getItemsTimestamps()).thenReturn(mockTimestamps);
+
+    // Act
+    List<String> result = dataService.fetchItemsTimestamps();
+
+    // Assert
+    assertThat(result).isEqualTo(mockTimestamps);
+    verify(stacRepository).getItemsTimestamps();
+  }
+
+  @Test
+  void fetchItemsTimestamps_ThrowsException() {
+    // Arrange
+    when(stacRepository.getItemsTimestamps())
+      .thenThrow(new RepositoryException("Database error"));
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.fetchItemsTimestamps())
+      .isInstanceOf(DataException.class)
+      .hasMessageContaining("Failed to fetch item timestamps");
+  }
+
+  @Test
+  void fetchAndSaveItems_SkipsExistingItems() throws JsonProcessingException {
+    // Arrange
+    String collectionId = "testCollection";
+    Map<String, Object> configMap = Map.of("endpoint", "https://test-endpoint.com");
+    ResponseEntity<Map<String, Object>> configResponse = ResponseEntity.ok(configMap);
+    when(configController.getConfig()).thenReturn(configResponse);
+
+    // Mock Collection Metadata (from DB)
+    List<Map<String, Object>> collectionMetadata = List.of(Map.of(
+      "datetime", "2023-08-01T12:00:00Z",
+      "end_datetime", "2023-08-31T12:00:00Z",
+      "item_count", 1));
+    when(stacRepository.queryCollectionMetaData(collectionId)).thenReturn(collectionMetadata);
+
+    // Mock STAC API Response (with existing item)
+    Map<String, Object> item = new HashMap<>();
+    item.put("id", "existingItem");
+
+    Map<String, Object> itemsResponse = Map.of(
+      "features", List.of(item),
+      "links", List.of() // No "next" link to ensure no infinite loop
+    );
+
+    when(restTemplate.getForObject(anyString(), eq(Map.class))).thenReturn(itemsResponse);
+    when(stacRepository.checkCollectionExists("existingItem")).thenReturn(true);
+
+    // Act
+    dataService.fetchAndSaveItems(collectionId);
+
+    // Wait for async execution
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+
+    // Assert
+    verify(stacRepository).checkCollectionExists("existingItem");
+    verify(stacRepository, never()).insertItem(anyString());
+  }
+
+  @Test
+  void fetchAndSaveItems_HandlesException() {
+    // Arrange
+    String collectionId = "testCollection";
+    when(configController.getConfig())
+      .thenThrow(new RuntimeException("Config error"));
+
+    // Ensure the failure message contains the expected error text
+    try {
+      dataService.fetchAndSaveItems(collectionId);
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+
+    // Verify that it attempted to fetch config before failing
+    verify(configController, times(1)).getConfig();
+  }
+
+  @Test
+  void resetView_Default_Success() throws Exception {
+    // Arrange
+    doNothing().when(stacRepository).resetDatalayerView();
+
+    // Act
+    dataService.resetView();
+
+    // Assert
+    verify(stacRepository, atLeastOnce()).resetDatalayerView();
+  }
+
+  @Test
+  void retrieveCollectionMetaData_ThrowsException() {
+    // Arrange
+    String collectionId = "nonexistent-collection";
+
+    // Mock the repository to throw an exception
+    when(stacRepository.queryCollectionMetaData(collectionId))
+      .thenThrow(new RuntimeException("Database error"));
+
+    // Act & Assert
+    DataException exception = assertThrows(DataException.class, () -> {
+      dataService.retrieveCollectionMetaData(collectionId);
+    });
+
+    // Verify the exception message and cause
+    assertThat(exception.getMessage())
+      .isEqualTo("Failed to retrieve metadata for collection: nonexistent-collection");
+    assertThat(exception.getCause())
+      .isInstanceOf(RuntimeException.class);
+    assertThat(exception.getCause().getMessage())
+      .isEqualTo("Database error");
+
+    // Verify that the repository method was called
+    verify(stacRepository).queryCollectionMetaData(collectionId);
+  }
+
+  @Test
+  void insertView_CatchesAndWrapsGeneralExceptions() {
+    // Arrange
+    String collectionId = "test-collection";
+
+    // Mock the repository to throw an unexpected exception that isn't a
+    // DataException
+    doThrow(new RuntimeException("Unexpected database error"))
+      .when(stacRepository).setDatalayerView(collectionId);
+
+    // Act & Assert
+    DataException exception = assertThrows(DataException.class, () -> {
+      dataService.insertView(collectionId);
+    });
+
+    // Verify the exception was properly wrapped with the correct message
+    assertThat(exception.getMessage())
+      .isEqualTo("Failed to insert view for collection: test-collection");
+
+    // Verify the original exception is preserved as the cause
+    assertThat(exception.getCause())
+      .isInstanceOf(RuntimeException.class);
+    assertThat(exception.getCause().getMessage())
+      .isEqualTo("Unexpected database error");
+
+    // Verify the repository method was called
+    verify(stacRepository).setDatalayerView(collectionId);
+
+    // Verify checkDatalayerView was never called (exception happens before that)
+    verify(stacRepository, never()).checkDatalayerView();
+  }
+
+  @Test
+  void resetView_Success() {
+    // Act
+    dataService.resetView();
+
+    // Assert
+    verify(stacRepository, times(1)).resetDatalayerView();
+  }
+
+  @Test
+  void resetView_ShouldLogError_WhenExceptionThrown() {
+    // Arrange
+    doThrow(new RuntimeException("Test exception")).when(stacRepository).resetDatalayerView();
+
+    // Act & Assert
+    assertThatThrownBy(() -> dataService.resetView())
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Failed to reset Datalayer view: Test exception");
+
+    verify(stacRepository, times(1)).resetDatalayerView();
+  }
+
+  @Test
+  void getLoadedLayers_ShouldReturnLayers() {
+    // Arrange
+    List<Map<String, Object>> layers = List.of(Map.of("layer", "testLayer"));
+    when(stacRepository.getLoadedLayers()).thenReturn(layers);
+
+    // Act
+    List<Map<String, Object>> result = dataService.getLoadedLayers();
+
+    // Assert
+    assertThat(result).isNotNull().hasSize(1);
+    assertThat(result.get(0)).containsEntry("layer", "testLayer");
+  }
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
@@ -1,0 +1,192 @@
+package wildfire.visualization.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class GeoServerServiceTest {
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  @InjectMocks
+  private GeoServerService geoServerService;
+
+  private final String geoserverUrl = "http://localhost:8090/geoserver";
+  private final String workspace = "Default";
+  private final String username = "admin";
+  private final String password = "geoserver";
+  private final String geoserverDataDir = "/var/geoserver/data_dir/tiffs";
+  private final String layerName = "humidity";
+
+  @BeforeEach
+  void setUp() {
+    setField(geoServerService, "geoserverUrl", geoserverUrl);
+    setField(geoServerService, "workspace", workspace);
+    setField(geoServerService, "geoserverUsername", username);
+    setField(geoServerService, "geoserverPassword", password);
+    setField(geoServerService, "geoserverDataDir", geoserverDataDir);
+    setField(geoServerService, "restTemplate", restTemplate);
+  }
+
+  @Test
+  void testRegisterCoverageStore_Success() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores";
+
+    // Mock response
+    ResponseEntity<String> successResponse = new ResponseEntity<>("Created", HttpStatus.CREATED);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(successResponse);
+
+    // Execute
+    boolean result = geoServerService.registerCoverageStore(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testRegisterCoverageStore_Failure() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores";
+
+    // Mock response
+    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(failureResponse);
+
+    // Execute
+    boolean result = geoServerService.registerCoverageStore(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testRegisterCoverageLayer_Success() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "/coverages";
+
+    // Mock response
+    ResponseEntity<String> successResponse = new ResponseEntity<>("Created", HttpStatus.CREATED);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(successResponse);
+
+    // Execute
+    boolean result = geoServerService.registerCoverageLayer(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testRegisterCoverageLayer_Failure() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "/coverages";
+
+    // Mock response
+    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(failureResponse);
+
+    // Execute
+    boolean result = geoServerService.registerCoverageLayer(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testUnregisterLayer_Success() {
+    String expectedUrl = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
+
+    // Mock response
+    ResponseEntity<String> successResponse = new ResponseEntity<>("Deleted", HttpStatus.OK);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(successResponse);
+
+    // Execute
+    boolean result = geoServerService.unregisterLayer(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testUnregisterLayer_Failure() {
+    String expectedUrl = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
+
+    // Mock response
+    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(failureResponse);
+
+    // Execute
+    boolean result = geoServerService.unregisterLayer(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testDeleteCoverageStore_Success() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
+
+    // Mock response
+    ResponseEntity<String> successResponse = new ResponseEntity<>("Deleted", HttpStatus.OK);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(successResponse);
+
+    // Execute
+    boolean result = geoServerService.deleteCoverageStore(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testDeleteCoverageStore_Failure() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
+
+    // Mock response
+    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST);
+    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
+      .thenReturn(failureResponse);
+
+    // Execute
+    boolean result = geoServerService.deleteCoverageStore(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isFalse();
+  }
+
+  // ✅ Utility method to set private fields via reflection
+  private void setField(Object target, String fieldName, Object value) {
+    try {
+      var field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set field: " + fieldName, e);
+    }
+  }
+}

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.*;
 
 @ExtendWith(MockitoExtension.class)
-class GeoServerServiceTest {
+class GeoServerServiceTests {
 
   @Mock
   private RestTemplate restTemplate;

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
@@ -113,10 +113,10 @@ class GeoServerServiceTests {
 
   @Test
   void testUnregisterLayer_Success() {
-    String expectedUrl = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
 
     // Mock response
-    ResponseEntity<String> successResponse = new ResponseEntity<>("Deleted", HttpStatus.OK);
+    ResponseEntity<String> successResponse = new ResponseEntity<>(HttpStatus.NO_CONTENT);
     when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
       .thenReturn(successResponse);
 
@@ -130,10 +130,10 @@ class GeoServerServiceTests {
 
   @Test
   void testUnregisterLayer_Failure() {
-    String expectedUrl = geoserverUrl + "/rest/layers/" + workspace + ":" + layerName;
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
 
     // Mock response
-    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST);
+    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.INTERNAL_SERVER_ERROR);
     when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
       .thenReturn(failureResponse);
 
@@ -145,39 +145,6 @@ class GeoServerServiceTests {
     assertThat(result).isFalse();
   }
 
-  @Test
-  void testDeleteCoverageStore_Success() {
-    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
-
-    // Mock response
-    ResponseEntity<String> successResponse = new ResponseEntity<>("Deleted", HttpStatus.OK);
-    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
-      .thenReturn(successResponse);
-
-    // Execute
-    boolean result = geoServerService.deleteCoverageStore(layerName);
-
-    // Verify
-    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
-    assertThat(result).isTrue();
-  }
-
-  @Test
-  void testDeleteCoverageStore_Failure() {
-    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
-
-    // Mock response
-    ResponseEntity<String> failureResponse = new ResponseEntity<>("Error", HttpStatus.BAD_REQUEST);
-    when(restTemplate.exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class)))
-      .thenReturn(failureResponse);
-
-    // Execute
-    boolean result = geoServerService.deleteCoverageStore(layerName);
-
-    // Verify
-    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
-    assertThat(result).isFalse();
-  }
 
   // ✅ Utility method to set private fields via reflection
   private void setField(Object target, String fieldName, Object value) {

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
@@ -1,0 +1,138 @@
+package wildfire.visualization.backend.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import wildfire.visualization.backend.repository.StacRepository;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class GeoTIFFServiceTests {
+
+  @Mock
+  private GeoServerService geoServerService;
+
+  @Mock
+  private StacRepository stacRepository;
+
+  @Spy // ✅ FIX: Spy on GeoTIFFService to mock specific methods
+  @InjectMocks
+  private GeoTIFFService geoTIFFService;
+
+  private final String itemId = "wildfire_timestamp_2023_08_30_12_00_00";
+  private final String collectionId = "montreal_2023";
+  private final String assetName = "humidity";
+  private final String tiffUrl = "https://example.com/humidity.tif"; // Fake URL
+  private final String localFilePath = "./geoserver_data/tiffs/humidity.tif";
+
+  @BeforeEach
+  void setUp() {
+    // ✅ FIX: Use Reflection to set private fields correctly
+    setField(geoTIFFService, "geoServerUrl", "http://localhost:8090/geoserver");
+    setField(geoTIFFService, "workspace", "Default");
+    setField(geoTIFFService, "tiffStoragePath", "./geoserver_data/tiffs");
+  }
+
+  @Test
+  void testProcessGeoTIFF_Success() throws Exception {
+    // ✅ Prevent actual file download
+    doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
+
+    // ✅ Mock GeoServer interactions
+    when(geoServerService.registerCoverageStore(assetName)).thenReturn(true);
+    when(geoServerService.registerCoverageLayer(assetName)).thenReturn(true);
+
+    // ✅ Mock database save
+    doNothing().when(stacRepository).saveLayer(anyString(), anyString(), anyString(), anyString());
+
+    // Execute method
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
+
+    // Verify interactions
+    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
+    verify(geoServerService, times(1)).registerCoverageStore(assetName);
+    verify(geoServerService, times(1)).registerCoverageLayer(assetName);
+    verify(stacRepository, times(1)).saveLayer(anyString(), anyString(), anyString(), anyString());
+
+    // Assert success
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testProcessGeoTIFF_FailureOnDownload() throws Exception {
+    doThrow(new IOException("Download failed")).when(geoTIFFService).downloadFile(anyString(), anyString());
+
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
+
+    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
+    verify(geoServerService, never()).registerCoverageStore(anyString());
+    verify(geoServerService, never()).registerCoverageLayer(anyString());
+    verify(stacRepository, never()).saveLayer(anyString(), anyString(), anyString(), anyString());
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testProcessGeoTIFF_FailureOnRegisterStore() throws Exception {
+    doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
+    when(geoServerService.registerCoverageStore(assetName)).thenReturn(false);
+
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
+
+    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
+    verify(geoServerService, times(1)).registerCoverageStore(assetName);
+    verify(geoServerService, never()).registerCoverageLayer(anyString());
+    verify(stacRepository, never()).saveLayer(anyString(), anyString(), anyString(), anyString());
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testProcessGeoTIFF_FailureOnRegisterLayer() throws Exception {
+    doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
+    when(geoServerService.registerCoverageStore(assetName)).thenReturn(true);
+    when(geoServerService.registerCoverageLayer(assetName)).thenReturn(false);
+
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
+
+    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
+    verify(geoServerService, times(1)).registerCoverageStore(assetName);
+    verify(geoServerService, times(1)).registerCoverageLayer(assetName);
+    verify(stacRepository, never()).saveLayer(anyString(), anyString(), anyString(), anyString());
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testDownloadFile() throws Exception {
+    String tempFile = "./geoserver_data/tiffs/test.tif";
+
+    Files.createDirectories(Path.of("./geoserver_data/tiffs"));
+    Files.write(Path.of(tempFile), "test data".getBytes());
+
+    assertThat(Files.exists(Path.of(tempFile))).isTrue();
+
+    Files.deleteIfExists(Path.of(tempFile));
+  }
+
+  // ✅ Utility method to set private fields via reflection
+  private void setField(Object target, String fieldName, Object value) {
+    try {
+      var field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set field: " + fieldName, e);
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,12 @@ services:
       - SPRING_DATASOURCE_USERNAME=postgres
       - SPRING_DATASOURCE_PASSWORD=password
       - CONFIG_FILE_PATH=/var/config/app-config.json
+      - GEOSERVER_DATA_DIR=/var/geoserver/data_dir/tiffs
     networks:
       - app-network
     volumes:
       - ./config:/var/config/
+      - ./apps/geoserver_data/tiffs:/var/geoserver/data_dir/tiffs
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
#### **Summary**  
This PR introduces lazy loading functionality for processing dataset assets asynchronously. The backend now efficiently handles asset downloads, metadata storage, and layer registration in GeoServer, reducing blocking operations and improving performance.  

#### **Changes & Implementations**  

##### **Backend**  
- **Added Async Asset Loading Endpoint:**  
  - `GET /load-assets/{collectionId}/{itemId}`  
  - Initiates asset processing asynchronously, downloads TIFF images to PVC, registers them as GeoServer layers, and stores metadata in a new `itemAssets` table.  
  - Returns an immediate response while processing continues in the background.  

- **Added Asset Query Endpoint:**  
  - `GET /get-loaded-layers`  
  - Queries `itemAssets` to fetch already loaded assets and their associated WMS preview links.  

- **Lazy Asset Processing Logic:**  
  - Extracts asset metadata and processes each TIFF file.  
  - Removes previously registered layers before registering new ones.  
  - Tracks progress with a `fetchProgress` map for frontend status updates.  

##### **Frontend**  
- **Implemented Progress Tracking:**  
  - Added a progress bar that updates as assets are processed, allowing the UI to know when to stop querying `get-loaded-layers`.  

#### **Example Response from `get-loaded-layers`**  
```json
[
    {
        "id": 7,
        "item_id": "wildfire_timestamp_2023_08_30_12_00_00",
        "collection_id": "montreal_2023",
        "asset_name": "humidity",
        "layer_url": "http://localhost:8090/geoserver/Default/wms?service=WMS&request=GetMap&layers=Default:montreal_2023_wildfire_timestamp_2023_08_30_12_00_00_humidity"
    },
    {
        "id": 8,
        "item_id": "wildfire_timestamp_2023_08_30_12_00_00",
        "collection_id": "montreal_2023",
        "asset_name": "wind_force",
        "layer_url": "http://localhost:8090/geoserver/Default/wms?service=WMS&request=GetMap&layers=Default:montreal_2023_wildfire_timestamp_2023_08_30_12_00_00_wind_force"
    },
    {
        "id": 9,
        "item_id": "wildfire_timestamp_2023_08_30_12_00_00",
        "collection_id": "montreal_2023",
        "asset_name": "wind_direction",
        "layer_url": "http://localhost:8090/geoserver/Default/wms?service=WMS&request=GetMap&layers=Default:montreal_2023_wildfire_timestamp_2023_08_30_12_00_00_wind_direction"
    }
]
```

#### **Improvements & Fixes**  
 **Optimized GeoTIFF Processing:** Avoids redundant layer registrations and removes old layers before new ones are added.  
 **Asynchronous Processing:** Reduces frontend wait time and prevents blocking API calls.  
 **Progress Tracking Implemented:** Allows frontend to monitor and update UI based on backend asset loading progress.  
 **Fixed Timestamp Settings:** Ensures proper date handling and tracking for asset processing.  


https://drive.google.com/file/d/1207jcyAjYAstkpKfcbpeIzXQdBCr-OUV/view?usp=drive_link

![image](https://github.com/user-attachments/assets/c0c28a4c-821e-4226-beea-fd4f88b17bf6)
![image](https://github.com/user-attachments/assets/620acb3f-2d38-49cc-ad4b-1809287d8e2b)


Use this same logic to get progress of asset layers loading
![image](https://github.com/user-attachments/assets/cc9e0a36-1b9b-48e5-a26d-043f2a03069b)
This way when we are at 100%, you can know when to stop querying get loaded layers.