### PR TITLE
#251 - feat(backend): Add reset item assets endpoint to handle clean wipe of item assets

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -37,7 +37,7 @@ public class DataController {
     this.dataService = dataService;
   }
 
-  @GetMapping("/load-assets/{collectionId}/{itemId}")
+  @GetMapping("/api/load-assets/{collectionId}/{itemId}")
   public ResponseEntity<String> loadAssets(
     @PathVariable String collectionId,
     @PathVariable String itemId
@@ -54,7 +54,7 @@ public class DataController {
     }
   }
 
-  @GetMapping("/get-loaded-layers")
+  @GetMapping("/api/get-loaded-layers")
   public ResponseEntity<List<Map<String, Object>>> getLoadedLayers() {
     return ResponseEntity.ok(dataService.getLoadedLayers());
   }
@@ -389,5 +389,23 @@ public class DataController {
     logger.info("Checking if there is an internet connection: {}", endpointUrl);
     String result = dataService.verifyInternetConnection(endpointUrl);
     return ResponseEntity.ok(result);
+  }
+
+  /**
+   * Endpoint responsible for fetching the GeoTIFF data from a given URL
+   *
+   * @param url String object representing the URL to fetch the GeoTIFF data from
+   * @return ResponseEntity object containing a String object indicating if the
+   *         GeoTIFF data was fetched successfully
+   */
+  @PostMapping("/api/reset-item-assets")
+  public ResponseEntity<String> resetItemAssets() {
+    boolean success = dataService.itemAssetsReset();
+    if (success) {
+      return ResponseEntity.ok("Item asset layers reset successfully.");
+    } else {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body("Failed to reset item asset layers.");
+    }
   }
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -580,4 +580,13 @@ public class StacRepository {
     jdbcTemplate.update("DELETE FROM ItemAssets");
   }
 
+  /**
+   * Method responsible for deleting a layer from the database
+   *
+   * @param layerName Name of the layer to be deleted
+   */
+  public void deleteItemAssetLayer(String layerName) {
+    jdbcTemplate.update("DELETE FROM ItemAssets WHERE asset_name = ?", layerName);
+  }
+
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -630,14 +630,7 @@ public class DataService {
 
       if (assets == null || assets.isEmpty()) return;
 
-      List<Map<String, Object>> existingLayers = stacRepository.getLoadedLayers();
-      for (Map<String, Object> layer : existingLayers) {
-        String layerName = (String) layer.get("asset_name");
-        geoServerService.unregisterLayer(layerName);
-      }
-
-      // Clear previously registered layers
-      stacRepository.clearLayers();
+      itemAssetsReset(); // Reset previously registered layers
 
       // Get total number of assets
       int totalAssets = assets.size();
@@ -657,6 +650,32 @@ public class DataService {
     } catch (Exception e) {
       logger.error("Error processing item assets: {}", e.getMessage(), e);
       fetchProgress.put(itemId, new AtomicInteger(-1)); // Set error state
+    }
+  }
+
+  public boolean itemAssetsReset() {
+    try {
+      List<Map<String, Object>> existingLayers = stacRepository.getLoadedLayers();
+
+      for (Map<String, Object> layer : existingLayers) {
+        String layerName = (String) layer.get("asset_name");
+
+        try {
+          geoServerService.unregisterLayer(layerName);
+        } catch (Exception e) {
+          logger.error("Layer not found in GeoServer (likely already deleted): {}", layerName);
+        }
+
+        // Always delete the database trace of the asset, whether unregister succeeds or fails
+        stacRepository.deleteItemAssetLayer(layerName);
+      }
+
+      // Finally, clear all registered layers from the database
+      stacRepository.clearLayers();
+      return true;
+    } catch (Exception e) {
+      logger.error("Error resetting item assets: {}", e.getMessage(), e);
+      return false;
     }
   }
 

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -731,7 +731,7 @@ class DataControllerTests {
     doNothing().when(dataService).processItemAssets(anyString(), anyString());
 
     // Act & Assert
-    mockMvc.perform(get("/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+    mockMvc.perform(get("/api/load-assets/{collectionId}/{itemId}", collectionId, itemId))
       .andExpect(status().isOk())
       .andExpect(content().string("Processing started in the background. Check logs for completion."));
 
@@ -750,7 +750,7 @@ class DataControllerTests {
     doThrow(new RuntimeException("Processing error")).when(dataService).processItemAssets(anyString(), anyString());
 
     // Since the exception is caught in `CompletableFuture.runAsync()`, the API should still return success.
-    mockMvc.perform(get("/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+    mockMvc.perform(get("/api/load-assets/{collectionId}/{itemId}", collectionId, itemId))
       .andExpect(status().isOk()) // Still returns success because the exception is async
       .andExpect(content().string("Processing started in the background. Check logs for completion."));
 
@@ -772,7 +772,7 @@ class DataControllerTests {
         .thenThrow(new RuntimeException("Async processing error"));
 
       // Act & Assert
-      mockMvc.perform(get("/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+      mockMvc.perform(get("/api/load-assets/{collectionId}/{itemId}", collectionId, itemId))
         .andExpect(status().isInternalServerError())
         .andExpect(content().string("Failed to start processing."));
     }
@@ -790,7 +790,7 @@ class DataControllerTests {
     when(dataService.getLoadedLayers()).thenReturn(mockLayers);
 
     // Act & Assert
-    mockMvc.perform(get("/get-loaded-layers"))
+    mockMvc.perform(get("/api/get-loaded-layers"))
       .andExpect(status().isOk())
       .andExpect(content().contentType(MediaType.APPLICATION_JSON))
       .andExpect(content().json(objectMapper.writeValueAsString(mockLayers)));
@@ -804,7 +804,7 @@ class DataControllerTests {
     doThrow(new DataException("Failed to fetch loaded layers")).when(dataService).getLoadedLayers();
 
     // Act & Assert
-    mockMvc.perform(get("/get-loaded-layers"))
+    mockMvc.perform(get("/api/get-loaded-layers"))
       .andExpect(status().isBadRequest())
       .andExpect(jsonPath("$.status").value(400))
       .andExpect(jsonPath("$.error").value("Data Error"))

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -813,5 +813,33 @@ class DataControllerTests {
     verify(dataService, times(1)).getLoadedLayers();
   }
 
+  @Test
+  void resetItemAssets_Success() throws Exception {
+    // Arrange
+    when(dataService.itemAssetsReset()).thenReturn(true);
+
+    // Act & Assert
+    mockMvc.perform(post("/api/reset-item-assets"))
+      .andExpect(status().isOk())
+      .andExpect(content().string("Item asset layers reset successfully."));
+
+    // Verify interaction
+    verify(dataService, times(1)).itemAssetsReset();
+  }
+
+  @Test
+  void resetItemAssets_Failure() throws Exception {
+    // Arrange
+    when(dataService.itemAssetsReset()).thenReturn(false);
+
+    // Act & Assert
+    mockMvc.perform(post("/api/reset-item-assets"))
+      .andExpect(status().isInternalServerError())
+      .andExpect(content().string("Failed to reset item asset layers."));
+
+    // Verify interaction
+    verify(dataService, times(1)).itemAssetsReset();
+  }
+
 }
 

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -919,4 +919,15 @@ class StacRepositoryTests {
     verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets");
   }
 
+  @Test
+  void deleteItemAssetLayer_Success() {
+    String layerName = "test-layer";
+
+    // Act
+    stacRepository.deleteItemAssetLayer(layerName);
+
+    // Assert
+    verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets WHERE asset_name = ?", layerName);
+  }
+
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -972,5 +972,44 @@ class DataServiceTests {
     verify(geoTIFFService, times(2)).processGeoTIFF(eq(itemId), eq(collectionId), anyString(), anyString());
   }
 
+  @Test
+  void itemAssetsReset_Success() {
+    // Arrange: Mock database layers
+    List<Map<String, Object>> mockLayers = List.of(
+      Map.of("asset_name", "layer1"),
+      Map.of("asset_name", "layer2")
+    );
+    when(stacRepository.getLoadedLayers()).thenReturn(mockLayers);
+
+    // Act
+    boolean result = dataService.itemAssetsReset();
+
+    // Assert
+    verify(stacRepository, times(1)).getLoadedLayers();
+    verify(geoServerService, times(1)).unregisterLayer("layer1");
+    verify(geoServerService, times(1)).unregisterLayer("layer2");
+    verify(stacRepository, times(1)).deleteItemAssetLayer("layer1");
+    verify(stacRepository, times(1)).deleteItemAssetLayer("layer2");
+    verify(stacRepository, times(1)).clearLayers();
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void itemAssetsReset_TotalFailure_ReturnsFalse() {
+    // Arrange: Simulate an exception when getting loaded layers
+    when(stacRepository.getLoadedLayers()).thenThrow(new RuntimeException("Database error"));
+
+    // Act
+    boolean result = dataService.itemAssetsReset();
+
+    // Assert
+    verify(stacRepository, times(1)).getLoadedLayers();
+    verify(geoServerService, never()).unregisterLayer(anyString());
+    verify(stacRepository, never()).deleteItemAssetLayer(anyString());
+    verify(stacRepository, never()).clearLayers();
+
+    assertThat(result).isFalse();
+  }
 
 }


### PR DESCRIPTION
#### **Summary**
This PR introduces a new endpoint (`POST /api/reset-item-assets`) that allows for a complete reset of item asset layers in both GeoServer and the database. The functionality ensures that stale or outdated asset layers are removed before new ones are processed.

---

#### **Changes Implemented**
 **Added `resetItemAssets` endpoint** in `DataController` to trigger the item asset reset process.  
 **Refactored `itemAssetsReset` method** in `DataService` to:
   - Unregister layers from GeoServer.
   - Log an error if a layer is missing but continue the deletion process.
   - Ensure all asset traces are removed from the database.
 **Created unit tests** for:
   - `DataService.itemAssetsReset()` to verify correct behavior.
   - `DataController.resetItemAssets()` to ensure proper HTTP responses in success and failure scenarios.

---

#### **How It Works**
1. **Calls `dataService.itemAssetsReset()`** to remove all existing asset layers.
2. **Removes database traces of all layers**, even if the GeoServer deletion fails.
3. **Returns:**
   -  `200 OK` if reset was successful.
   -  `500 Internal Server Error` if any issues occur.

---

#### **Testing**
-  Unit tests added for `itemAssetsReset()` and `resetItemAssets()` to cover all success and failure cases.
-  Verified response status codes (`200` for success, `500` for failure).
-  Ensured `dataService.itemAssetsReset()` is always invoked when the endpoint is called.

---

