### PR TITLE
#287 - bugfix(frontend): Loaded label persists after Factory Reset

### DIFF
--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -513,6 +513,7 @@ describe('SettingsPanel Component', () => {
         } else {
           const config = await getConfig();
           config.endpoint = 'No endpoint saved';
+          config.loadedDataset = '';
           await saveConfig(config);
           refreshDatasets();
         }
@@ -578,6 +579,7 @@ describe('SettingsPanel Component', () => {
 
             const config = await getConfig();
             config.endpoint = endpointUrl;
+            config.loadedDataset = "";
             await saveConfig(config);
 
             toast.success(mockT('api_endpoint_saved'));
@@ -599,6 +601,12 @@ describe('SettingsPanel Component', () => {
       // Verify all expected behaviors
       expect(result).toBe(true);
       // Rest of expectations unchanged
+      expect(saveConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: 'https://valid-endpoint.com',
+          loadedDataset: ''
+        })
+      );
     });
     // Test with valid URL but no collections found
     it('returns false for valid URL with no collections', async () => {

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -142,6 +142,7 @@ const SettingsPanel: React.FC<{
         }
 
         config.endpoint = endpointUrl;
+        config.loadedDataset = "";
         await saveConfig(config);
 
         toast.success(t('api_endpoint_saved'));
@@ -302,6 +303,7 @@ const SettingsPanel: React.FC<{
         }
 
         config.endpoint = 'No endpoint saved';
+        config.loadedDataset = "";
         await saveConfig(config);
 
         refreshDatasets(); // Trigger the refresh


### PR DESCRIPTION
## Summary
Fixes a bug where the **"Loaded" label** remains visible after a Factory Reset.

## Context
After performing a Factory Reset, the application config was not clearing the `loadedDataset` key, causing the UI to still treat the dataset as loaded.

## Changes
- Set `config.loadedDataset = ''` in `handleSaveAndFetchEndpoint()` to fully clear app state.

## Result
- The application state is now properly reset.
- The "Loaded" label no longer appears after a Factory Reset.

Proof:

https://github.com/user-attachments/assets/25bf8adc-fbb8-4800-931b-fec94b74dc01


