### PR TITLE
#0 - feat(backend): prod fix adding docker env geoserver url

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,6 +47,7 @@ jobs:
           NEXT_PUBLIC_BACKEND_URL: http://localhost:8080
           CONFIG_FILE_PATH: /var/config/app-config.json
           GEOSERVER_DATA_DIR: /var/geoserver/data_dir/tiffs
+          GEOSERVER_URL: http://geoserver:8080/geoserver
 
       # Push Docker images to Docker Hub
       - name: Push Docker Images

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,6 +38,7 @@ jobs:
           SPRING_DATASOURCE_USERNAME: postgres
           SPRING_DATASOURCE_PASSWORD: password
           GEOSERVER_DATA_DIR: /var/geoserver/data_dir/tiffs
+          GEOSERVER_URL: http://geoserver:8080/geoserver
 
       # Wait for Database to be Ready using Health Check
       - name: Wait for Database

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -14,7 +14,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.postgis.Po
 
 management.endpoints.web.exposure.include=health
 
-geoserver.url=http://localhost:8090/geoserver
+geoserver.url=${GEOSERVER_URL:http://localhost:8090/geoserver}
 geoserver.workspace=Default
 geoserver.username=geoserver
 geoserver.password=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - SPRING_DATASOURCE_PASSWORD=password
       - CONFIG_FILE_PATH=/var/config/app-config.json
       - GEOSERVER_DATA_DIR=/var/geoserver/data_dir/tiffs
+      - GEOSERVER_URL=http://geoserver:8080/geoserver
     networks:
       - app-network
     volumes:


### PR DESCRIPTION
**Description**  
This pull request updates the backend configuration to properly reference the GeoServer URL in production environments by introducing a Docker-specific environment variable. The fix ensures that the backend service uses `http://geoserver:8080` when running inside Docker Compose, while still allowing local development to point to `http://localhost:8090` as needed.

**Changes**  
1. Added a new environment variable (e.g., `GEOSERVER_URL`) to specify the internal Docker network hostname and port for GeoServer.  
2. Updated backend configuration to use the `GEOSERVER_URL` in production.  
3. Preserved local development settings so developers can still use `localhost:8090`.  

**Testing**  
- Verified the backend can successfully connect to GeoServer using the Docker service name `geoserver` when running in Docker Compose.  
- Confirmed that local dev remains unaffected (still uses `http://localhost:8090`).  
