### PR TITLE
#0 - feat(backend): prod fix adding docker env geoserver url

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
@@ -18,6 +18,9 @@ public class GeoTIFFService {
   @Value("${geoserver.url}")
   private String geoServerUrl;
 
+  @Value("${geoserver.url.local}")
+  private String geoServerLocalUrl;
+
   @Value("${geoserver.workspace}")
   private String workspace;
 
@@ -39,7 +42,7 @@ public class GeoTIFFService {
   public boolean processGeoTIFF(String itemId, String collectionId, String assetName, String tiffUrl) {
     try {
       String localFilePath = tiffStoragePath + "/" + assetName + ".tif";
-      String layerUrl = geoServerUrl + "/" + workspace + "/wms?service=WMS&request=GetMap&layers=" + workspace + ":" + assetName;
+      String layerUrl = geoServerLocalUrl + "/" + workspace + "/wms?service=WMS&request=GetMap&layers=" + workspace + ":" + assetName;
 
       // Download TIFF to GeoServer storage
       downloadFile(tiffUrl, localFilePath);

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.postgis.Po
 management.endpoints.web.exposure.include=health
 
 geoserver.url=${GEOSERVER_URL:http://localhost:8090/geoserver}
+geoserver.url.local=http://localhost:8090/geoserver
 geoserver.workspace=Default
 geoserver.username=geoserver
 geoserver.password=password


### PR DESCRIPTION
**Description**  
This pull request adds a localhost endpoint (`http://localhost:8090`) to the backend, enabling the frontend to display GeoServer data correctly in local development. It ensures that developers can continue to work with a local endpoint while production environments still reference `http://geoserver:8080` inside Docker.  

**Changes**  
- Added a localhost endpoint to the backend configuration for local development.  
- Preserved the production endpoint (`geoserver:8080`) for Docker Compose setups.  

**Testing**  
- Verified the frontend can receive data from `localhost:8090` in local dev.  
- Confirmed production builds use the Docker container reference (`geoserver:8080`).  
