### PR TITLE
#295 #296 - fix(frontend): added fix for views and assets being blocked

### DIFF
--- a/apps/frontend/src/app/styles/footer.css
+++ b/apps/frontend/src/app/styles/footer.css
@@ -7,11 +7,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow-x: hidden;
-  overflow-y: hidden;
   z-index: 1000;
   margin-bottom: 5px;
-  padding-top: 200px;
 }
 
 .sliderContainer {


### PR DESCRIPTION
### Summary
This PR ensures that the views and loaded assets lists is accessible.

### Changes Made
- Removed footer padding, and hidden overflow css styling. 

### Testing Instructions
Clicking on views and loaded assets should both be accessible. 