### PR TITLE
#307 - feat(backend): Preload and Register Wildfire Assets for Seamless Timestamp Transitions

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
@@ -11,18 +11,38 @@ public class DatabaseInitializer {
   @Autowired
   private JdbcTemplate jdbcTemplate;
 
+  //  Document method below for documentation
+  //  Initializes the database by creating the necessary tables if they do not already exist.
   @PostConstruct
   public void initializeDatabase() {
-    String sql = """
-            CREATE TABLE IF NOT EXISTS ItemAssets (
-                id SERIAL PRIMARY KEY,
-                item_id TEXT NOT NULL,
-                collection_id TEXT NOT NULL,
-                asset_name TEXT NOT NULL,
-                layer_url TEXT NOT NULL,
-                UNIQUE (item_id, collection_id, asset_name)
-            );
-        """;
-    jdbcTemplate.execute(sql);
+    String createCollections = """
+          CREATE TABLE IF NOT EXISTS TIFF_Collections (
+              id SERIAL PRIMARY KEY,
+              collection_id TEXT UNIQUE NOT NULL
+          );
+      """;
+
+    String createItems = """
+          CREATE TABLE IF NOT EXISTS TIFF_Items (
+              id SERIAL PRIMARY KEY,
+              item_id TEXT UNIQUE NOT NULL,
+              collection_id TEXT NOT NULL REFERENCES TIFF_Collections(collection_id)
+          );
+      """;
+
+    String createAssets = """
+          CREATE TABLE IF NOT EXISTS TIFF_Assets (
+              id SERIAL PRIMARY KEY,
+              item_id TEXT NOT NULL REFERENCES TIFF_Items(item_id) ON DELETE CASCADE,
+              asset_name TEXT NOT NULL,
+              layer_url TEXT NOT NULL,
+              is_registered BOOLEAN DEFAULT FALSE,
+              UNIQUE (item_id, asset_name)
+          );
+      """;
+
+    jdbcTemplate.execute(createCollections);
+    jdbcTemplate.execute(createItems);      // Must be before Assets
+    jdbcTemplate.execute(createAssets);     // Must be after Items
   }
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/controller/DataController.java
@@ -33,19 +33,32 @@ public class DataController {
     this.dataService = dataService;
   }
 
-  @GetMapping("/api/load-assets/{collectionId}/{itemId}")
+  @GetMapping("/api/load-assets/{collectionId}")
   public ResponseEntity<String> loadAssets(
-    @PathVariable String collectionId,
-    @PathVariable String itemId
+    @PathVariable String collectionId
   ) {
-    logger.info("Received request to load assets asynchronously for collection: {}, item: {}", collectionId, itemId);
+    logger.info("Received request to load assets asynchronously for collection: {}", collectionId);
     try {
       // Run the processing task asynchronously
-      CompletableFuture.runAsync(() -> dataService.processItemAssets(collectionId, itemId));
+      CompletableFuture.runAsync(() -> dataService.processItemAssets(collectionId));
       // Return immediate response to frontend
       return ResponseEntity.ok("Processing started in the background. Check logs for completion.");
     } catch (Exception e) {
-      logger.error("Error processing assets for item: {} in collection: {}", itemId, collectionId, e);
+      logger.error("Error processing assets for item: {} in collection: {}", collectionId, e);
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to start processing.");
+    }
+  }
+
+  @GetMapping("/api/load-asset-layers/{itemId}")
+  public ResponseEntity<String> loadAssetLayers(@PathVariable String itemId) {
+    logger.info("Received request to load asset layers asynchronously for item: {}", itemId);
+    try {
+      // Run the processing task asynchronously
+      dataService.processItemAssetsRefresh(itemId);
+      // Return immediate response to frontend
+      return ResponseEntity.ok("Processing started in the background. Check logs for completion.");
+    } catch (Exception e) {
+      logger.error("Error processing asset layers for item: {}", itemId, e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to start processing.");
     }
   }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -78,9 +78,9 @@ public class StacRepository {
     logger.debug("Attempting to insert collection");
     try {
       jdbcTemplate.queryForObject(
-          "SELECT pgstac.create_collection(?::jsonb)",
-          Object.class,
-          collectionJson);
+        "SELECT pgstac.create_collection(?::jsonb)",
+        Object.class,
+        collectionJson);
       logger.info("Successfully inserted collection");
     } catch (DataAccessException e) {
       logger.error("Error inserting collection: {}", e.getMessage(), e);
@@ -98,9 +98,9 @@ public class StacRepository {
     logger.debug("Attempting to insert item");
     try {
       jdbcTemplate.queryForObject(
-          "SELECT pgstac.create_item(?::jsonb)",
-          Object.class,
-          itemJson);
+        "SELECT pgstac.create_item(?::jsonb)",
+        Object.class,
+        itemJson);
       logger.info("Successfully inserted item");
     } catch (DataAccessException e) {
       logger.error("Error inserting item: {}", e.getMessage(), e);
@@ -132,10 +132,10 @@ public class StacRepository {
    * Fetches a list of collections from the database, optionally filtered by a
    * bounding box (BBOX) and sorted with specified column and direction.
    *
-   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
-   *                     null, no filter is applied.
-   * @param orderBy      The column by which to order results (e.g., "id" or "datetime").
-   *                     If empty, no ordering is applied.
+   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                      null, no filter is applied.
+   * @param orderBy       The column by which to order results (e.g., "id" or "datetime").
+   *                      If empty, no ordering is applied.
    * @param sortDirection The direction to sort ("asc" or "desc"). Defaults to "asc" if invalid.
    * @return A list of collections as key-value maps, containing collection metadata.
    * @throws RepositoryException If a database error occurs or inputs are invalid
@@ -270,8 +270,8 @@ public class StacRepository {
    * Retrieves all collections from the database, optionally filtered by a
    * bounding box (BBOX), and sorted by collection name (ID) with specified direction.
    *
-   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
-   *                     null, no filter is applied.
+   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                      null, no filter is applied.
    * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections sorted by name.
    * @throws RepositoryException if a database error occurs
@@ -285,8 +285,8 @@ public class StacRepository {
    * bounding box (BBOX),
    * and sorted by date with specified direction.
    *
-   * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
-   *             null, no filter is applied.
+   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                      null, no filter is applied.
    * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections sorted by date.
    * @throws RepositoryException if a database error occurs
@@ -307,12 +307,12 @@ public class StacRepository {
     logger.debug("Querying metadata for: {}", collectionId);
     try {
       String sql = "SELECT (content ->> 'title') AS title," +
-          " (content ->> 'description') AS description," +
-          " datetime AS datetime," +
-          " end_datetime AS end_datetime," +
-          " (content -> 'links') AS links," +
-          " (content -> 'stats:items' ->> 'count')::int AS item_count " + // Extract item count
-          " FROM pgstac.collections WHERE id = ?";
+        " (content ->> 'description') AS description," +
+        " datetime AS datetime," +
+        " end_datetime AS end_datetime," +
+        " (content -> 'links') AS links," +
+        " (content -> 'stats:items' ->> 'count')::int AS item_count " + // Extract item count
+        " FROM pgstac.collections WHERE id = ?";
 
       List<Map<String, Object>> results = jdbcTemplate.queryForList(sql, collectionId);
 
@@ -336,16 +336,16 @@ public class StacRepository {
     logger.debug("Fetching items for collection: {}", collectionId);
     try {
       String sql = "SELECT * FROM pgstac.search(" +
-          "    '{" +
-          "        \"filter\": {" +
-          "            \"op\": \"=\"," +
-          "            \"args\": [" +
-          "                { \"property\": \"collection\" }," +
-          "                \"" + collectionId + "\"" +
-          "            ]" +
-          "        }" +
-          "    }'::jsonb" +
-          ")";
+        "    '{" +
+        "        \"filter\": {" +
+        "            \"op\": \"=\"," +
+        "            \"args\": [" +
+        "                { \"property\": \"collection\" }," +
+        "                \"" + collectionId + "\"" +
+        "            ]" +
+        "        }" +
+        "    }'::jsonb" +
+        ")";
       List<Map<String, Object>> results = jdbcTemplate.queryForList(sql);
       logger.debug("Query returned {} results", results.size());
       return results;
@@ -382,7 +382,7 @@ public class StacRepository {
    * @param id         Database ID of item to be retrieved
    * @param collection Database ID of collection to retrieve items from
    * @return List object containing the item with the given id from the given
-   *         collection
+   * collection
    * @throws RepositoryException if a database error occurs
    */
   public List<Map<String, Object>> getItem(String id, String collection) {
@@ -415,7 +415,7 @@ public class StacRepository {
       jdbcTemplate.execute(sqlDrop);
 
       String sqlInsert = "CREATE VIEW DataLayer AS" +
-          " SELECT geometry FROM pgstac.collections WHERE id = '" + safeCollectionId + "'";
+        " SELECT geometry FROM pgstac.collections WHERE id = '" + safeCollectionId + "'";
 
       jdbcTemplate.execute(sqlInsert);
 
@@ -475,15 +475,15 @@ public class StacRepository {
     logger.debug("Removing all items");
     try {
       String sql = "DO $$ \n" +
-          "DECLARE\n" +
-          "    rec RECORD;\n" +
-          "BEGIN\n" +
-          "    SET search_path = pgstac, public;\n" +
-          "\n" +
-          "    FOR rec IN SELECT id, collection FROM items LOOP\n" +
-          "        PERFORM delete_item(rec.id, rec.collection);\n" +
-          "    END LOOP;\n" +
-          "END $$;\n";
+        "DECLARE\n" +
+        "    rec RECORD;\n" +
+        "BEGIN\n" +
+        "    SET search_path = pgstac, public;\n" +
+        "\n" +
+        "    FOR rec IN SELECT id, collection FROM items LOOP\n" +
+        "        PERFORM delete_item(rec.id, rec.collection);\n" +
+        "    END LOOP;\n" +
+        "END $$;\n";
 
       jdbcTemplate.execute(sql);
       return "Successfully Removed All Items";
@@ -505,16 +505,16 @@ public class StacRepository {
     logger.debug("Removing all items from collection: {}", collectionId);
     try {
       String sql = "DO $$ \n" +
-          "DECLARE\n" +
-          "    rec RECORD;\n" +
-          "    target_collection_id text := '" + collectionId + "';\n" +
-          "BEGIN\n" +
-          "    SET search_path = pgstac, public;\n" +
-          "\n" +
-          "    FOR rec IN SELECT id FROM items WHERE collection = target_collection_id LOOP\n" +
-          "        PERFORM delete_item(rec.id, target_collection_id);\n" +
-          "    END LOOP;\n" +
-          "END $$;\n";
+        "DECLARE\n" +
+        "    rec RECORD;\n" +
+        "    target_collection_id text := '" + collectionId + "';\n" +
+        "BEGIN\n" +
+        "    SET search_path = pgstac, public;\n" +
+        "\n" +
+        "    FOR rec IN SELECT id FROM items WHERE collection = target_collection_id LOOP\n" +
+        "        PERFORM delete_item(rec.id, target_collection_id);\n" +
+        "    END LOOP;\n" +
+        "END $$;\n";
 
       jdbcTemplate.execute(sql);
       return "Successfully Removed All Items From Collection";
@@ -546,47 +546,141 @@ public class StacRepository {
     }
   }
 
+  // BELOW ARE THE METHODS THAT WERE ADDED TO MANAGE GEOSERVER TIFFS
+
   /**
-   * Method responsible for saving a layer URL to the database
+   * Inserts a new asset and marks it as not registered.
    *
-   * @param itemId       Database ID of the item
-   * @param collectionId Database ID of the collection
+   * @param itemId       ID of the item
+   * @param collectionId ID of the collection
    * @param assetName    Name of the asset
    * @param layerUrl     URL of the layer
    */
   public void saveLayer(String itemId, String collectionId, String assetName, String layerUrl) {
-    String sql = """
-            INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url)
-            VALUES (?, ?, ?, ?)
-            ON CONFLICT (item_id, collection_id, asset_name) DO NOTHING;
-        """;
-    jdbcTemplate.update(sql, itemId, collectionId, assetName, layerUrl);
+    // Ensure the collection exists
+    String insertCollection = """
+        INSERT INTO TIFF_Collections (collection_id)
+        VALUES (?)
+        ON CONFLICT (collection_id) DO NOTHING;
+    """;
+    jdbcTemplate.update(insertCollection, collectionId);
+
+    // Ensure the item exists
+    String insertItem = """
+        INSERT INTO TIFF_Items (item_id, collection_id)
+        VALUES (?, ?)
+        ON CONFLICT (item_id) DO NOTHING;
+    """;
+    jdbcTemplate.update(insertItem, itemId, collectionId);
+
+    // Insert asset with default is_registered = FALSE
+    String insertAsset = """
+        INSERT INTO TIFF_Assets (item_id, asset_name, layer_url, is_registered)
+        VALUES (?, ?, ?, FALSE)
+        ON CONFLICT (item_id, asset_name) DO NOTHING;
+    """;
+    jdbcTemplate.update(insertAsset, itemId, assetName, layerUrl);
   }
 
   /**
-   * Method responsible for fetching all loaded layers from the database
+   * Fetches all assets for a given item.
    *
-   * @return List object containing all loaded layers
+   * @param itemId ID of the item
+   * @return List of assets
    */
-  public List<Map<String, Object>> getLoadedLayers() {
-    String sql = "SELECT * FROM ItemAssets";
+  public List<Map<String, Object>> getLoadedLayers(String itemId) {
+    String sql = """
+        SELECT a.id AS asset_id, a.asset_name, a.layer_url, a.is_registered,
+               i.item_id, i.collection_id
+        FROM TIFF_Assets a
+        JOIN TIFF_Items i ON a.item_id = i.item_id
+        WHERE i.item_id = ?
+    """;
+    return jdbcTemplate.queryForList(sql, itemId);
+  }
+
+  /**
+   * Clears all assets and items from the database.
+   */
+  public void clearLayers() {
+    jdbcTemplate.update("DELETE FROM TIFF_Assets");
+    jdbcTemplate.update("DELETE FROM TIFF_Items");
+    jdbcTemplate.update("DELETE FROM TIFF_Collections");
+  }
+
+  /**
+   * Fetches all items and their assets.
+   *
+   * @return List of item-asset mappings
+   */
+  public List<Map<String, Object>> getItemsWithAssets() {
+    String sql = """
+        SELECT i.item_id, a.asset_name, a.layer_url, a.is_registered
+        FROM TIFF_Items i
+        JOIN TIFF_Assets a ON i.item_id = a.item_id
+    """;
     return jdbcTemplate.queryForList(sql);
   }
 
   /**
-   * Method responsible for clearing all layers from the database
+   * Deletes a specific asset from an item.
+   *
+   * @param assetName Name of the asset
+   * @param itemId    ID of the item
    */
-  public void clearLayers() {
-    jdbcTemplate.update("DELETE FROM ItemAssets");
+  public void deleteItemAssetLayer(String assetName, String itemId) {
+    String sql = "DELETE FROM TIFF_Assets WHERE asset_name = ? AND item_id = ?";
+    jdbcTemplate.update(sql, assetName, itemId);
   }
 
   /**
-   * Method responsible for deleting a layer from the database
+   * Marks an asset as registered in GeoServer.
    *
-   * @param layerName Name of the layer to be deleted
+   * @param itemId     ID of the item
+   * @param assetName  Name of the asset
    */
-  public void deleteItemAssetLayer(String layerName) {
-    jdbcTemplate.update("DELETE FROM ItemAssets WHERE asset_name = ?", layerName);
+  public void markAssetAsRegistered(String itemId, String assetName) {
+    String sql = "UPDATE TIFF_Assets SET is_registered = TRUE WHERE item_id = ? AND asset_name = ?";
+    jdbcTemplate.update(sql, itemId, assetName);
   }
+
+  /**
+   * Marks an asset as unregistered in GeoServer.
+   *
+   * @param itemId     ID of the item
+   * @param assetName  Name of the asset
+   */
+  public void markAssetAsUnregistered(String itemId, String assetName) {
+    String sql = "UPDATE TIFF_Assets SET is_registered = FALSE WHERE item_id = ? AND asset_name = ?";
+    jdbcTemplate.update(sql, itemId, assetName);
+  }
+
+  /**
+   * Deletes an item and cascades its assets.
+   *
+   * @param itemId ID of the item
+   */
+  public void deleteItem(String itemId) {
+    String sql = "DELETE FROM TIFF_Items WHERE item_id = ?";
+    jdbcTemplate.update(sql, itemId);
+  }
+
+  /**
+   * Fetches all assets that are currently marked as registered in GeoServer.
+   *
+   * @return List of registered assets
+   */
+  public List<Map<String, Object>> getLoadedLayers() {
+    String sql = """
+        SELECT a.id AS asset_id, a.asset_name, a.layer_url, a.is_registered,
+               i.item_id, i.collection_id
+        FROM TIFF_Assets a
+        JOIN TIFF_Items i ON a.item_id = i.item_id
+        WHERE a.is_registered = TRUE
+    """;
+    return jdbcTemplate.queryForList(sql);
+  }
+
+
 
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -59,7 +59,7 @@ public class DataService {
    *
    * @param collectionId The database id of the collection
    * @return A String object that represents the List of key value pairs from the
-   *         given collection's metadata
+   * given collection's metadata
    * @throws JsonProcessingException Exception thrown when there's an error in the
    *                                 JSON Processing
    */
@@ -214,7 +214,7 @@ public class DataService {
    */
   public List<Map<String, Object>> getCollections(double[] bbox) {
     logger.debug("Fetching collections from database with bbox: {}",
-        bbox != null ? Arrays.toString(bbox) : "No bbox");
+      bbox != null ? Arrays.toString(bbox) : "No bbox");
 
     try {
       // Fetch collections from repository
@@ -223,11 +223,11 @@ public class DataService {
 
       // Transform collections into a structured format
       return collections.stream()
-          .map(collection -> Map.of(
-              "key", collection.get("key") == null ? "" : collection.get("key"),
-              "id", collection.get("id") == null ? "" : collection.get("id"),
-              "bbox", collection.get("bbox") == null ? "[]" : collection.get("bbox")))
-          .collect(Collectors.toList());
+        .map(collection -> Map.of(
+          "key", collection.get("key") == null ? "" : collection.get("key"),
+          "id", collection.get("id") == null ? "" : collection.get("id"),
+          "bbox", collection.get("bbox") == null ? "[]" : collection.get("bbox")))
+        .collect(Collectors.toList());
     } catch (Exception e) {
       logger.error("Error fetching collections: {}", e.getMessage(), e);
       throw new DataException("Failed to fetch collections", e);
@@ -262,8 +262,8 @@ public class DataService {
    * This method queries collections ordered by their name (`id` field) and
    * restructures the response for client consumption.
    *
-   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
-   *                     null, no filter is applied.
+   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                      null, no filter is applied.
    * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections, each containing keys: `key`, `id`, and `bbox`.
    * @throws DataException If an error occurs while fetching collections.
@@ -300,8 +300,8 @@ public class DataService {
    * date and
    * restructures the response for client consumption.
    *
-   * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
-   *             null, no filter is applied.
+   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                      null, no filter is applied.
    * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections, each containing keys: `key`, `id`, and `bbox`.
    * @throws DataException If an error occurs while fetching collections.
@@ -513,7 +513,7 @@ public class DataService {
    * @param id         String object representing the pgSTAC item's id
    * @param collection String object representing the pgSTAC collection's id
    * @return List object that contains the data of the given item relating to the
-   *         given collection
+   * given collection
    */
   public List<Map<String, Object>> getItem(String id, String collection) {
     logger.info("Fetching item from database with id: {} and collection: {}", id, collection);
@@ -535,7 +535,7 @@ public class DataService {
    * Method responsible for removing all items from the database
    *
    * @return String object clarifying whether the removal of all items from the
-   *         database was successful
+   * database was successful
    */
   public String removeAllItems() {
     logger.info("Removing all items from database");
@@ -553,7 +553,7 @@ public class DataService {
    *
    * @param collectionId String object representing the id of the given collection
    * @return String clarifying if the removal of the items from the given
-   *         collection was successful
+   * collection was successful
    */
   public String removeItemsFromCollection(String collectionId) {
     logger.info("Removing items from collection: {}", collectionId);
@@ -601,83 +601,231 @@ public class DataService {
     }
   }
 
-
   /**
-   * Method responsible for processing all assets of a given item
+   * Method responsible for registering all assets for a specific item.
+   * <p>
+   * This fetches the item from the database and registers its GeoTIFF assets one by one.
+   * This is intended to be used when refreshing/re-registering existing assets.
    *
-   * @param collectionId String object representing the id of the collection
-   * @param itemId       String object representing the id of the item
+   * @param itemId ID of the item to process
+   * @return true if all assets were registered successfully, false otherwise
    */
-  @Async
-  public void processItemAssets(String collectionId, String itemId) {
-    List<Map<String, Object>> queryResults = stacRepository.getItem(itemId);
-    if (queryResults.isEmpty()) return;
+  public boolean processItemAssetsRefresh(String itemId) {
+    itemAssetsReset(false);
+    List<Map<String, Object>> items = stacRepository.getItem(itemId);
+    if (items.isEmpty()) {
+      logger.warn("No item found with ID: {}", itemId);
+      return false;
+    }
 
-    fetchProgress.put(itemId, new AtomicInteger(0)); // Initialize progress
-
-    // Extract JSON from `pgstac.get_item()`
-    Object jsonObject = queryResults.get(0).get("get_item");
+    Object jsonObject = items.get(0).get("get_item");
     String itemJson;
     if (jsonObject instanceof PGobject) {
       itemJson = ((PGobject) jsonObject).getValue();
     } else {
-      throw new RuntimeException("Unexpected data type from database");
+      logger.error("Unexpected data type returned for item {}: {}", itemId, jsonObject.getClass().getSimpleName());
+      return false;
     }
 
     try {
       JsonNode jsonNode = objectMapper.readTree(itemJson);
       JsonNode assets = jsonNode.get("assets");
 
-      if (assets == null || assets.isEmpty()) return;
-
-      itemAssetsReset(); // Reset previously registered layers
-
-      // Get total number of assets
-      int totalAssets = assets.size();
-      int counter = 0;
+      if (assets == null || assets.isEmpty()) {
+        logger.info("Item {} has no assets to register", itemId);
+        return false;
+      }
 
       for (Iterator<String> it = assets.fieldNames(); it.hasNext(); ) {
         String assetKey = it.next();
-        JsonNode asset = assets.get(assetKey);
-        String tiffUrl = asset.get("href").asText();
 
-        boolean success = geoTIFFService.processGeoTIFF(itemId, collectionId, assetKey, tiffUrl);
-        counter++;
-        fetchProgress.put(itemId, new AtomicInteger((int) Math.floor(((double) counter / totalAssets) * 100)));
-        if (!success) return;
-      }
-      fetchProgress.put(itemId, new AtomicInteger(100));
-    } catch (Exception e) {
-      logger.error("Error processing item assets: {}", e.getMessage(), e);
-      fetchProgress.put(itemId, new AtomicInteger(-1)); // Set error state
-    }
-  }
-
-  public boolean itemAssetsReset() {
-    try {
-      List<Map<String, Object>> existingLayers = stacRepository.getLoadedLayers();
-
-      for (Map<String, Object> layer : existingLayers) {
-        String layerName = (String) layer.get("asset_name");
-
-        try {
-          geoServerService.unregisterLayer(layerName);
-        } catch (Exception e) {
-          logger.error("Layer not found in GeoServer (likely already deleted): {}", layerName);
+        boolean success = geoTIFFService.registerGeoTIFF(itemId, assetKey);
+        if (!success) {
+          logger.warn("Failed to register asset {} for item {}", assetKey, itemId);
+          return false; // Stop on first failure (optional: allow partial success if needed)
         }
-
-        // Always delete the database trace of the asset, whether unregister succeeds or fails
-        stacRepository.deleteItemAssetLayer(layerName);
       }
 
-      // Finally, clear all registered layers from the database
-      stacRepository.clearLayers();
+      logger.info("Successfully registered all assets for item {}", itemId);
       return true;
+
     } catch (Exception e) {
-      logger.error("Error resetting item assets: {}", e.getMessage(), e);
+      logger.error("Failed to parse or register assets for item {}: {}", itemId, e.getMessage(), e);
       return false;
     }
   }
+
+
+
+  /**
+   * Method responsible for processing all assets for all items in a given collection.
+   * <p>
+   * This fetches all items from the collection and processes their assets one by one.
+   * Layers are reset before processing begins, but data is preserved if unregistering fails.
+   *
+   * @param collectionId ID of the collection
+   */
+  @Async
+  public void processItemAssets(String collectionId) {
+    String collectionProgressKey = collectionId + "_assets";
+    fetchProgress.put(collectionProgressKey, new AtomicInteger(0)); // Initialize progress
+    try {
+      List<Map<String, Object>> results = stacRepository.getAllItems(collectionId);
+
+      if (results.isEmpty()) {
+        logger.warn("No results returned from getAllItems for collection {}", collectionId);
+      }
+
+      // Extract JSON from the first (and only) row of the query
+      Object rawJson = results.get(0).get("search");
+      String json = "";
+      if (rawJson instanceof PGobject) {
+        json = ((PGobject) rawJson).getValue();
+      } else if (rawJson instanceof String) {
+        json = (String) rawJson;
+      } else {
+        logger.error("Unexpected JSON type: {}", rawJson.getClass().getSimpleName());
+      }
+
+      JsonNode root = objectMapper.readTree(json);
+      JsonNode features = root.get("features");
+
+      if (features == null || !features.isArray()) {
+        logger.warn("No features found in FeatureCollection");
+      }
+
+      int totalItems = features.size();
+      logger.info("Processing {} items in collection: {}", totalItems, collectionId);
+
+      int count = 0;
+
+      for (JsonNode feature : features) {
+        String itemId = feature.get("id").asText();
+        String collId = feature.get("collection").asText();  // Prefer the per-feature collection
+
+        JsonNode assets = feature.get("assets");
+        if (assets == null || assets.isEmpty()) {
+          logger.info("No assets found for item {}", itemId);
+          continue;
+        }
+
+        for (Iterator<String> it = assets.fieldNames(); it.hasNext(); ) {
+          String assetKey = it.next();
+          JsonNode asset = assets.get(assetKey);
+          String href = asset.get("href").asText();
+
+          boolean success = geoTIFFService.processGeoTIFF(itemId, collId, assetKey, href);
+          if (!success) {
+            logger.warn("Failed to register asset {} for item {}", assetKey, itemId);
+          }
+        }
+
+        count++;
+        fetchProgress.put(collectionProgressKey, new AtomicInteger((int) Math.floor(((double) count / totalItems) * 100)));
+        logger.info("Processed item {}/{}: {}", count, totalItems, itemId);
+      }
+
+      logger.info("Finished registering all assets in collection {}", collectionId);
+      // Optionally remove progress key or set to -1 or totalItems to indicate completion
+      fetchProgress.put(collectionProgressKey, new AtomicInteger(100));
+
+    } catch (Exception e) {
+      logger.error("Exception while processing assets for collection {}: {}", collectionId, e.getMessage(), e);
+      fetchProgress.put(collectionProgressKey, new AtomicInteger(-1)); // Set error state
+    }
+  }
+
+  /**
+   * Overloaded method to reset item assets with full reset as default.
+   */
+  public boolean itemAssetsReset() {
+    return itemAssetsReset(true); // default fullReset = true
+  }
+
+  /**
+   * Method responsible for unregistering all registered asset layers from GeoServer.
+   * Also updates their registration status in the database.
+   * If all layers are successfully unregistered, clears the entire Assets and Items tables.
+   *
+   * @param fullReset Whether to fully clear the Assets and Items tables after unregistering
+   * @return true if the full reset succeeded, false otherwise
+   */
+  public boolean itemAssetsReset(boolean fullReset) {
+    final int maxAttempts = 3;
+    final long retryDelayMillis = 1000;
+
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      logger.info("Attempt {}/{} to reset item assets...", attempt, maxAttempts);
+      boolean success = tryItemAssetsResetOnce(fullReset);
+
+      if (success) {
+        logger.info("Item assets reset succeeded on attempt {}", attempt);
+        return true;
+      }
+
+      if (attempt < maxAttempts) {
+        try {
+          Thread.sleep(retryDelayMillis);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt(); // Preserve interrupt flag
+          logger.error("Interrupted during retry wait", e);
+          break;
+        }
+      }
+    }
+
+    logger.error("Failed to reset item assets after {} attempts", maxAttempts);
+    return false;
+  }
+
+  /**
+   * Internal helper method that performs the reset logic once.
+   */
+  private boolean tryItemAssetsResetOnce(boolean fullReset) {
+    List<Map<String, Object>> assetsToProcess = fullReset
+      ? stacRepository.getItemsWithAssets()
+      : stacRepository.getLoadedLayers();
+
+    boolean allUnregisteredSuccessfully = true;
+
+    for (Map<String, Object> asset : assetsToProcess) {
+      String itemId = (String) asset.get("item_id");
+      String assetName = (String) asset.get("asset_name");
+      String layerName = itemId + "_" + assetName;
+
+      try {
+        boolean shouldUnregister = !fullReset || Boolean.TRUE.equals(asset.get("is_registered"));
+
+        if (shouldUnregister) {
+          boolean deleted = geoServerService.unregisterLayer(layerName);
+          logger.info("Unregistered layer {}: {}", layerName, deleted);
+          if (deleted) {
+            stacRepository.markAssetAsUnregistered(itemId, assetName);
+          } else {
+            logger.warn("Layer {} could not be unregistered", layerName);
+            allUnregisteredSuccessfully = false;
+          }
+        }
+
+        if (fullReset) {
+          geoServerService.deleteTifFile(layerName);
+        }
+
+      } catch (Exception e) {
+        logger.error("Exception while processing layer {}: {}", layerName, e.getMessage(), e);
+        allUnregisteredSuccessfully = false;
+      }
+    }
+
+    if (allUnregisteredSuccessfully && fullReset) {
+      stacRepository.clearLayers();
+    }
+
+    return allUnregisteredSuccessfully;
+  }
+
+
+
 
   /**
    * Method responsible for retrieving all loaded layers

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -59,7 +59,7 @@ public class DataService {
    *
    * @param collectionId The database id of the collection
    * @return A String object that represents the List of key value pairs from the
-   * given collection's metadata
+   *         given collection's metadata
    * @throws JsonProcessingException Exception thrown when there's an error in the
    *                                 JSON Processing
    */
@@ -214,7 +214,7 @@ public class DataService {
    */
   public List<Map<String, Object>> getCollections(double[] bbox) {
     logger.debug("Fetching collections from database with bbox: {}",
-      bbox != null ? Arrays.toString(bbox) : "No bbox");
+        bbox != null ? Arrays.toString(bbox) : "No bbox");
 
     try {
       // Fetch collections from repository
@@ -223,11 +223,11 @@ public class DataService {
 
       // Transform collections into a structured format
       return collections.stream()
-        .map(collection -> Map.of(
-          "key", collection.get("key") == null ? "" : collection.get("key"),
-          "id", collection.get("id") == null ? "" : collection.get("id"),
-          "bbox", collection.get("bbox") == null ? "[]" : collection.get("bbox")))
-        .collect(Collectors.toList());
+          .map(collection -> Map.of(
+              "key", collection.get("key") == null ? "" : collection.get("key"),
+              "id", collection.get("id") == null ? "" : collection.get("id"),
+              "bbox", collection.get("bbox") == null ? "[]" : collection.get("bbox")))
+          .collect(Collectors.toList());
     } catch (Exception e) {
       logger.error("Error fetching collections: {}", e.getMessage(), e);
       throw new DataException("Failed to fetch collections", e);
@@ -262,8 +262,8 @@ public class DataService {
    * This method queries collections ordered by their name (`id` field) and
    * restructures the response for client consumption.
    *
-   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
-   *                      null, no filter is applied.
+   * @param bbox         An optional bounding box filter (minX, minY, maxX, maxY). If
+   *                     null, no filter is applied.
    * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections, each containing keys: `key`, `id`, and `bbox`.
    * @throws DataException If an error occurs while fetching collections.
@@ -300,8 +300,8 @@ public class DataService {
    * date and
    * restructures the response for client consumption.
    *
-   * @param bbox          An optional bounding box filter (minX, minY, maxX, maxY). If
-   *                      null, no filter is applied.
+   * @param bbox An optional bounding box filter (minX, minY, maxX, maxY). If
+   *             null, no filter is applied.
    * @param sortDirection The direction to sort ("asc" or "desc").
    * @return A list of collections, each containing keys: `key`, `id`, and `bbox`.
    * @throws DataException If an error occurs while fetching collections.
@@ -513,7 +513,7 @@ public class DataService {
    * @param id         String object representing the pgSTAC item's id
    * @param collection String object representing the pgSTAC collection's id
    * @return List object that contains the data of the given item relating to the
-   * given collection
+   *         given collection
    */
   public List<Map<String, Object>> getItem(String id, String collection) {
     logger.info("Fetching item from database with id: {} and collection: {}", id, collection);
@@ -535,7 +535,7 @@ public class DataService {
    * Method responsible for removing all items from the database
    *
    * @return String object clarifying whether the removal of all items from the
-   * database was successful
+   *         database was successful
    */
   public String removeAllItems() {
     logger.info("Removing all items from database");
@@ -553,7 +553,7 @@ public class DataService {
    *
    * @param collectionId String object representing the id of the given collection
    * @return String clarifying if the removal of the items from the given
-   * collection was successful
+   *         collection was successful
    */
   public String removeItemsFromCollection(String collectionId) {
     logger.info("Removing items from collection: {}", collectionId);
@@ -600,6 +600,7 @@ public class DataService {
       return "No internet connection could be established";
     }
   }
+
 
   /**
    * Method responsible for registering all assets for a specific item.
@@ -823,9 +824,6 @@ public class DataService {
 
     return allUnregisteredSuccessfully;
   }
-
-
-
 
   /**
    * Method responsible for retrieving all loaded layers

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -782,7 +782,7 @@ public class DataService {
   /**
    * Internal helper method that performs the reset logic once.
    */
-  private boolean tryItemAssetsResetOnce(boolean fullReset) {
+  public boolean tryItemAssetsResetOnce(boolean fullReset) {
     List<Map<String, Object>> assetsToProcess = fullReset
       ? stacRepository.getItemsWithAssets()
       : stacRepository.getLoadedLayers();

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoServerService.java
@@ -1,15 +1,15 @@
 package wildfire.visualization.backend.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.beans.factory.annotation.Value;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Base64;
 
 @Service
 public class GeoServerService {
@@ -33,6 +33,8 @@ public class GeoServerService {
   private String geoserverDownloadDir;
 
   private final RestTemplate restTemplate = new RestTemplate();
+
+  private static final Logger logger = LoggerFactory.getLogger(GeoServerService.class);
 
   /**
    * Creates and returns HTTP headers with basic authentication for GeoServer interaction.
@@ -109,11 +111,13 @@ public class GeoServerService {
   public boolean unregisterLayer(String layerName) {
     String url = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
 
-    boolean apiSuccess = sendDeleteRequest(url);
-    if (apiSuccess) {
-      deleteTifFile(layerName);
+    try{
+      boolean apiSuccess = sendDeleteRequest(url);
+      return apiSuccess;
+    } catch (Exception e) {
+      logger.error("Error unregistering layer: " + layerName + ". " + e.getMessage());
+      return false;
     }
-    return apiSuccess;
   }
 
   /**
@@ -135,17 +139,17 @@ public class GeoServerService {
    *
    * @param layerName the name of the file to be deleted (without extension)
    */
-  private void deleteTifFile(String layerName) {
+  public void deleteTifFile(String layerName) {
     try {
       Path filePath = Paths.get(geoserverDownloadDir, layerName + ".tif");
       if (Files.exists(filePath)) {
         Files.delete(filePath);
-        System.out.println("Deleted: " + filePath.toAbsolutePath());
+        logger.info("Deleted: " + filePath.toAbsolutePath());
       } else {
-        System.out.println("File not found: " + filePath.toAbsolutePath());
+        logger.error("File not found: " + filePath.toAbsolutePath());
       }
     } catch (Exception e) {
-      System.err.println("Error deleting file: " + layerName + ".tif. " + e.getMessage());
+      logger.error("Error deleting file: " + layerName + ".tif. " + e.getMessage());
     }
   }
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
@@ -33,30 +33,53 @@ public class GeoTIFFService {
   /**
    * Processes a GeoTIFF asset by downloading it, storing it in GeoServer, and saving its layer URL in the database.
    *
-   * @param itemId The ID of the STAC item containing the asset.
+   * @param itemId       The ID of the STAC item containing the asset.
    * @param collectionId The ID of the STAC collection containing the item.
-   * @param assetName The name of the asset to process.
-   * @param tiffUrl The URL of the GeoTIFF asset.
+   * @param assetName    The name of the asset to process.
+   * @param tiffUrl      The URL of the GeoTIFF asset.
    * @return true if the asset was successfully processed, false otherwise.
    */
   public boolean processGeoTIFF(String itemId, String collectionId, String assetName, String tiffUrl) {
     try {
-      String localFilePath = tiffStoragePath + "/" + assetName + ".tif";
-      String layerUrl = geoServerLocalUrl + "/" + workspace + "/wms?service=WMS&request=GetMap&layers=" + workspace + ":" + assetName;
+      String layerName = itemId + "_" + assetName;
+      String localFilePath = tiffStoragePath + "/" + layerName + ".tif";
+      String layerUrl = geoServerLocalUrl + "/" + workspace + "/wms?service=WMS&request=GetMap&layers=" + workspace + ":" + layerName;
+
+      stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
 
       // Download TIFF to GeoServer storage
       downloadFile(tiffUrl, localFilePath);
 
-      // Register in GeoServer
-      boolean storeCreated = geoServerService.registerCoverageStore(assetName);
-      if (!storeCreated) return false;
-
-      boolean layerCreated = geoServerService.registerCoverageLayer(assetName);
-      if (!layerCreated) return false;
-
-      stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
       return true;
     } catch (Exception e) {
+      stacRepository.deleteItemAssetLayer(assetName, itemId);
+      return false;
+    }
+  }
+
+  /**
+   * Registers a GeoTIFF asset in GeoServer.
+   *
+   * @param itemId    The ID of the STAC item containing the asset.
+   * @param assetName The name of the asset to register.
+   * @return true if the asset was successfully registered, false otherwise.
+   */
+  public boolean registerGeoTIFF(String itemId, String assetName) {
+    try {
+      String layerName = itemId + "_" + assetName;
+
+      // Register in GeoServer
+      boolean storeCreated = geoServerService.registerCoverageStore(layerName);
+      if (!storeCreated) return false;
+
+      boolean layerCreated = geoServerService.registerCoverageLayer(layerName);
+      if (!layerCreated) return false;
+
+      stacRepository.markAssetAsRegistered(itemId, assetName);
+
+      return true;
+    } catch (Exception e) {
+      stacRepository.deleteItemAssetLayer(assetName, itemId);
       return false;
     }
   }
@@ -64,7 +87,7 @@ public class GeoTIFFService {
   /**
    * Downloads a file from the specified source URL and saves it to the destination path.
    *
-   * @param sourceUrl The URL of the file to download.
+   * @param sourceUrl       The URL of the file to download.
    * @param destinationPath The local file system path where the file should be saved.
    * @throws IOException If an I/O error occurs during file download or saving.
    */

--- a/apps/backend/src/test/java/wildfire/visualization/backend/config/DatabaseInitializerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/config/DatabaseInitializerTests.java
@@ -29,6 +29,6 @@ class DatabaseInitializerTests {
     databaseInitializer.initializeDatabase();
 
     // Verify that SQL was executed
-    verify(jdbcTemplate, times(1)).execute(anyString());
+    verify(jdbcTemplate, times(3)).execute(anyString());
   }
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/controller/DataControllerTests.java
@@ -728,36 +728,37 @@ class DataControllerTests {
     String itemId = "testItem";
 
     // We can't verify execution due to async, but ensure the method is called
-    doNothing().when(dataService).processItemAssets(anyString(), anyString());
+    doNothing().when(dataService).processItemAssets(anyString());
 
     // Act & Assert
-    mockMvc.perform(get("/api/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+    mockMvc.perform(get("/api/load-assets/{collectionId}", collectionId, itemId))
       .andExpect(status().isOk())
       .andExpect(content().string("Processing started in the background. Check logs for completion."));
 
     // Give async execution a brief moment (useful for debugging)
     Thread.sleep(100);
 
-    verify(dataService, times(1)).processItemAssets(collectionId, itemId);
+    verify(dataService, times(1)).processItemAssets(collectionId);
   }
 
   @Test
   void loadAssets_Failure_ShouldStillReturnSuccess() throws Exception {
     // Arrange
     String collectionId = "testCollection";
-    String itemId = "testItem";
 
-    doThrow(new RuntimeException("Processing error")).when(dataService).processItemAssets(anyString(), anyString());
+    // Simulate an exception during async processing
+    doThrow(new RuntimeException("Processing error")).when(dataService).processItemAssets(anyString());
 
-    // Since the exception is caught in `CompletableFuture.runAsync()`, the API should still return success.
-    mockMvc.perform(get("/api/load-assets/{collectionId}/{itemId}", collectionId, itemId))
-      .andExpect(status().isOk()) // Still returns success because the exception is async
+    // Act & Assert
+    mockMvc.perform(get("/api/load-assets/{collectionId}", collectionId))
+      .andExpect(status().isOk()) // Still returns 200 OK since exception is async
       .andExpect(content().string("Processing started in the background. Check logs for completion."));
 
-    // Give async execution a brief moment
+    // Optional: Give async execution a brief moment
     Thread.sleep(100);
 
-    verify(dataService, times(1)).processItemAssets(collectionId, itemId);
+    // Verify method was still called
+    verify(dataService, times(1)).processItemAssets(collectionId);
   }
 
   @Test
@@ -772,7 +773,7 @@ class DataControllerTests {
         .thenThrow(new RuntimeException("Async processing error"));
 
       // Act & Assert
-      mockMvc.perform(get("/api/load-assets/{collectionId}/{itemId}", collectionId, itemId))
+      mockMvc.perform(get("/api/load-assets/{collectionId}", collectionId, itemId))
         .andExpect(status().isInternalServerError())
         .andExpect(content().string("Failed to start processing."));
     }
@@ -839,6 +840,34 @@ class DataControllerTests {
 
     // Verify interaction
     verify(dataService, times(1)).itemAssetsReset();
+  }
+
+  @Test
+  void loadAssetLayers_shouldReturnOk_whenProcessingStarts() throws Exception {
+    // Given
+    String itemId = "wildfire_item_001";
+
+    // When
+    mockMvc.perform(get("/api/load-asset-layers/{itemId}", itemId)
+        .contentType(MediaType.APPLICATION_JSON))
+      .andExpect(status().isOk())
+      .andExpect(content().string("Processing started in the background. Check logs for completion."));
+
+    // Then
+    verify(dataService).processItemAssetsRefresh(itemId);
+  }
+
+  @Test
+  void loadAssetLayers_shouldReturnServerError_whenExceptionThrown() throws Exception {
+    // Given
+    String itemId = "wildfire_item_001";
+    doThrow(new RuntimeException("Simulated failure")).when(dataService).processItemAssetsRefresh(itemId);
+
+    // When
+    mockMvc.perform(get("/api/load-asset-layers/{itemId}", itemId)
+        .contentType(MediaType.APPLICATION_JSON))
+      .andExpect(status().isInternalServerError())
+      .andExpect(content().string("Failed to start processing."));
   }
 
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -831,103 +831,82 @@ class StacRepositoryTests {
   }
 
   @Test
-  void saveLayer_Success() {
-    // Arrange
-    String itemId = "test-item";
-    String collectionId = "test-collection";
-    String assetName = "test-asset";
-    String layerUrl = "http://test-layer.com";
+  void testSaveLayer_insertsCollectionItemAndAsset() {
+    stacRepository.saveLayer("item1", "col1", "asset1", "url1");
 
-    // Act
-    stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
-
-    // Assert
-    verify(jdbcTemplate, times(1)).update(
-      argThat(query -> query.replaceAll("\\s+", " ").trim().equals(
-        "INSERT INTO ItemAssets (item_id, collection_id, asset_name, layer_url) VALUES (?, ?, ?, ?) ON CONFLICT (item_id, collection_id, asset_name) DO NOTHING;"
-      )),
-      eq(itemId), eq(collectionId), eq(assetName), eq(layerUrl)
-    );
-  }
-
-
-
-  @Test
-  void getLoadedLayers_Success() {
-    // Arrange
-    List<Map<String, Object>> expectedLayers = List.of(
-      Map.of("item_id", "item1", "collection_id", "collection1", "asset_name", "asset1", "layer_url", "http://layer1.com"),
-      Map.of("item_id", "item2", "collection_id", "collection2", "asset_name", "asset2", "layer_url", "http://layer2.com")
-    );
-
-    when(jdbcTemplate.queryForList("SELECT * FROM ItemAssets")).thenReturn(expectedLayers);
-
-    // Act
-    List<Map<String, Object>> actualLayers = stacRepository.getLoadedLayers();
-
-    // Assert
-    assertThat(actualLayers).isEqualTo(expectedLayers);
-    verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
+    verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Collections"), eq("col1"));
+    verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Items"), eq("item1"), eq("col1"));
+    verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Assets"), eq("item1"), eq("asset1"), eq("url1"));
   }
 
   @Test
-  void getLoadedLayers_EmptyResult() {
-    // Arrange
-    when(jdbcTemplate.queryForList("SELECT * FROM ItemAssets")).thenReturn(List.of());
+  void testGetLoadedLayers_returnsList() {
+    List<Map<String, Object>> mockResult = List.of(Map.of("asset_name", "asset1"));
+    when(jdbcTemplate.queryForList(anyString(), eq("item1"))).thenReturn(mockResult);
 
-    // Act
-    List<Map<String, Object>> actualLayers = stacRepository.getLoadedLayers();
+    List<Map<String, Object>> result = stacRepository.getLoadedLayers("item1");
 
-    // Assert
-    assertThat(actualLayers).isEmpty();
-    verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).get("asset_name")).isEqualTo("asset1");
   }
 
   @Test
-  void getLoadedLayers_ThrowsException_WhenDatabaseError() {
-    // Arrange
-    when(jdbcTemplate.queryForList("SELECT * FROM ItemAssets"))
-      .thenThrow(new DataAccessException("Database error") {});
-
-    // Act & Assert
-    assertThatThrownBy(() -> stacRepository.getLoadedLayers())
-      .isInstanceOf(DataAccessException.class)
-      .hasMessageContaining("Database error");
-
-    verify(jdbcTemplate, times(1)).queryForList("SELECT * FROM ItemAssets");
-  }
-
-  @Test
-  void clearLayers_Success() {
-    // Act
+  void testClearLayers_deletesAllTables() {
     stacRepository.clearLayers();
 
-    // Assert
-    verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets");
+    verify(jdbcTemplate).update("DELETE FROM TIFF_Assets");
+    verify(jdbcTemplate).update("DELETE FROM TIFF_Items");
+    verify(jdbcTemplate).update("DELETE FROM TIFF_Collections");
   }
 
   @Test
-  void clearLayers_ThrowsException_WhenDatabaseError() {
-    // Arrange
-    doThrow(new DataAccessException("Database error") {}).when(jdbcTemplate).update("DELETE FROM ItemAssets");
+  void testGetItemsWithAssets_returnsList() {
+    List<Map<String, Object>> mockResult = List.of(Map.of("item_id", "item1"));
+    when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResult);
 
-    // Act & Assert
-    assertThatThrownBy(() -> stacRepository.clearLayers())
-      .isInstanceOf(DataAccessException.class)
-      .hasMessageContaining("Database error");
+    List<Map<String, Object>> result = stacRepository.getItemsWithAssets();
 
-    verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets");
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).get("item_id")).isEqualTo("item1");
   }
 
   @Test
-  void deleteItemAssetLayer_Success() {
-    String layerName = "test-layer";
+  void testDeleteItemAssetLayer_executesDelete() {
+    stacRepository.deleteItemAssetLayer("asset1", "item1");
 
-    // Act
-    stacRepository.deleteItemAssetLayer(layerName);
+    verify(jdbcTemplate).update("DELETE FROM TIFF_Assets WHERE asset_name = ? AND item_id = ?", "asset1", "item1");
+  }
 
-    // Assert
-    verify(jdbcTemplate, times(1)).update("DELETE FROM ItemAssets WHERE asset_name = ?", layerName);
+  @Test
+  void testMarkAssetAsRegistered_executesUpdate() {
+    stacRepository.markAssetAsRegistered("item1", "asset1");
+
+    verify(jdbcTemplate).update("UPDATE TIFF_Assets SET is_registered = TRUE WHERE item_id = ? AND asset_name = ?", "item1", "asset1");
+  }
+
+  @Test
+  void testMarkAssetAsUnregistered_executesUpdate() {
+    stacRepository.markAssetAsUnregistered("item1", "asset1");
+
+    verify(jdbcTemplate).update("UPDATE TIFF_Assets SET is_registered = FALSE WHERE item_id = ? AND asset_name = ?", "item1", "asset1");
+  }
+
+  @Test
+  void testDeleteItem_executesDelete() {
+    stacRepository.deleteItem("item1");
+
+    verify(jdbcTemplate).update("DELETE FROM TIFF_Items WHERE item_id = ?", "item1");
+  }
+
+  @Test
+  void testGetLoadedLayersRegistered_returnsList() {
+    List<Map<String, Object>> mockResult = List.of(Map.of("is_registered", true));
+    when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResult);
+
+    List<Map<String, Object>> result = stacRepository.getLoadedLayers();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).get("is_registered")).isEqualTo(true);
   }
 
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -991,5 +991,40 @@ class DataServiceTests {
     assertThat(result).isTrue();
   }
 
+  @Test
+  void itemAssetsReset_shouldSucceedOnFirstAttempt() {
+    Map<String, Object> asset = Map.of(
+      "item_id", "item1",
+      "asset_name", "a1",
+      "is_registered", true
+    );
+
+    when(stacRepository.getItemsWithAssets()).thenReturn(List.of(asset));
+    when(geoServerService.unregisterLayer("item1_a1")).thenReturn(true);
+
+    boolean result = dataService.itemAssetsReset(true);
+
+    assertThat(result).isTrue();
+    verify(geoServerService).unregisterLayer("item1_a1");
+    verify(stacRepository).markAssetAsUnregistered("item1", "a1");
+    verify(geoServerService).deleteTifFile("item1_a1");
+    verify(stacRepository).clearLayers();
+  }
+
+  @Test
+  void itemAssetsReset_shouldRetryAndFailAfterMaxAttempts() {
+    // Spy on dataService
+    DataService spyService = spy(dataService);
+
+    // Force the internal retry method to fail 3 times
+    doReturn(false).when(spyService).tryItemAssetsResetOnce(true);
+
+    // Execute
+    boolean result = spyService.itemAssetsReset(true);
+
+    // Assert
+    assertThat(result).isFalse();
+    verify(spyService, times(3)).tryItemAssetsResetOnce(true); // Retries 3 times
+  }
 
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -17,7 +17,6 @@ import wildfire.visualization.backend.exception.DataException;
 import wildfire.visualization.backend.exception.RepositoryException;
 import wildfire.visualization.backend.repository.StacRepository;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -925,91 +924,72 @@ class DataServiceTests {
   }
 
   @Test
-  void testProcessItemAssets_Success() throws Exception {
-    // Arrange
-    String collectionId = "testCollection";
-    String itemId = "testItem";
+  void processItemAssetsRefresh_shouldReturnFalse_whenItemNotFound() {
+    when(stacRepository.getItem("item123")).thenReturn(List.of());
 
-    // Mock database query result
-    PGobject pgObject = new PGobject();
-    pgObject.setType("jsonb");
-    pgObject.setValue("""
-        {
-            "assets": {
-                "asset1": {"href": "http://example.com/test1.tif"},
-                "asset2": {"href": "http://example.com/test2.tif"}
-            }
-        }
-    """);
-    List<Map<String, Object>> queryResults = List.of(Map.of("get_item", pgObject));
-    when(stacRepository.getItem(itemId)).thenReturn(queryResults);
+    boolean result = dataService.processItemAssetsRefresh("item123");
 
-    // Mock parsing JSON
-    JsonNode mockJsonNode = new ObjectMapper().readTree(pgObject.getValue());
-    when(objectMapper.readTree(anyString())).thenReturn(mockJsonNode);
-
-    // Mock layers
-    List<Map<String, Object>> existingLayers = List.of(Map.of("asset_name", "oldLayer"));
-    when(stacRepository.getLoadedLayers()).thenReturn(existingLayers);
-
-    // Mock services
-    when(geoServerService.unregisterLayer(anyString())).thenReturn(true);
-    doNothing().when(stacRepository).clearLayers();
-    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), anyString(), anyString())).thenReturn(true);
-
-    // Act
-    dataService.processItemAssets(collectionId, itemId);
-
-    // Allow some time for async execution (optional)
-    Thread.sleep(200);
-
-    // Assert
-    verify(stacRepository, times(1)).getItem(itemId);
-    verify(objectMapper, times(1)).readTree(anyString());
-    verify(stacRepository, times(1)).getLoadedLayers();
-    verify(geoServerService, times(1)).unregisterLayer("oldLayer");
-    verify(stacRepository, times(1)).clearLayers();
-    verify(geoTIFFService, times(2)).processGeoTIFF(eq(itemId), eq(collectionId), anyString(), anyString());
+    assertThat(result).isFalse();
   }
 
   @Test
-  void itemAssetsReset_Success() {
-    // Arrange: Mock database layers
-    List<Map<String, Object>> mockLayers = List.of(
-      Map.of("asset_name", "layer1"),
-      Map.of("asset_name", "layer2")
-    );
-    when(stacRepository.getLoadedLayers()).thenReturn(mockLayers);
+  void processItemAssetsRefresh_shouldReturnFalse_whenUnexpectedDataType() {
+    Map<String, Object> item = Map.of("get_item", 12345); // Not PGobject
+    when(stacRepository.getItem("item123")).thenReturn(List.of(item));
 
-    // Act
-    boolean result = dataService.itemAssetsReset();
+    boolean result = dataService.processItemAssetsRefresh("item123");
 
-    // Assert
-    verify(stacRepository, times(1)).getLoadedLayers();
-    verify(geoServerService, times(1)).unregisterLayer("layer1");
-    verify(geoServerService, times(1)).unregisterLayer("layer2");
-    verify(stacRepository, times(1)).deleteItemAssetLayer("layer1");
-    verify(stacRepository, times(1)).deleteItemAssetLayer("layer2");
-    verify(stacRepository, times(1)).clearLayers();
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void processItemAssetsRefresh_shouldReturnFalse_onJsonParsingException() throws Exception {
+    PGobject pgObject = new PGobject();
+    pgObject.setValue("{invalid json}");
+    Map<String, Object> item = Map.of("get_item", pgObject);
+    when(stacRepository.getItem("item123")).thenReturn(List.of(item));
+    when(objectMapper.readTree(anyString())).thenThrow(JsonProcessingException.class);
+
+    boolean result = dataService.processItemAssetsRefresh("item123");
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void processItemAssetsRefresh_shouldRegisterAssetsSuccessfully() throws Exception {
+    PGobject pgObject = new PGobject();
+    pgObject.setValue("{\"assets\": {\"a1\": {}, \"a2\": {}}}");
+    Map<String, Object> item = Map.of("get_item", pgObject);
+    when(stacRepository.getItem("item123")).thenReturn(List.of(item));
+
+    JsonNode mockRoot = mock(JsonNode.class);
+    JsonNode mockAssets = mock(JsonNode.class);
+
+    when(objectMapper.readTree(anyString())).thenReturn(mockRoot);
+    when(mockRoot.get("assets")).thenReturn(mockAssets);
+    when(mockAssets.fieldNames()).thenReturn(List.of("a1", "a2").iterator());
+    when(geoTIFFService.registerGeoTIFF("item123", "a1")).thenReturn(true);
+    when(geoTIFFService.registerGeoTIFF("item123", "a2")).thenReturn(true);
+
+    boolean result = dataService.processItemAssetsRefresh("item123");
 
     assertThat(result).isTrue();
   }
 
   @Test
-  void itemAssetsReset_TotalFailure_ReturnsFalse() {
-    // Arrange: Simulate an exception when getting loaded layers
-    when(stacRepository.getLoadedLayers()).thenThrow(new RuntimeException("Database error"));
+  void itemAssetsReset_shouldUnregisterAndClear_whenSuccessful() {
+    Map<String, Object> asset = Map.of("item_id", "item1", "asset_name", "a1", "is_registered", true);
+    when(stacRepository.getItemsWithAssets()).thenReturn(List.of(asset));
+    when(geoServerService.unregisterLayer("item1_a1")).thenReturn(true);
 
-    // Act
-    boolean result = dataService.itemAssetsReset();
+    boolean result = dataService.itemAssetsReset(true);
 
-    // Assert
-    verify(stacRepository, times(1)).getLoadedLayers();
-    verify(geoServerService, never()).unregisterLayer(anyString());
-    verify(stacRepository, never()).deleteItemAssetLayer(anyString());
-    verify(stacRepository, never()).clearLayers();
+    verify(stacRepository).markAssetAsUnregistered("item1", "a1");
+    verify(geoServerService).deleteTifFile("item1_a1");
+    verify(stacRepository).clearLayers();
 
-    assertThat(result).isFalse();
+    assertThat(result).isTrue();
   }
+
 
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -1027,4 +1027,117 @@ class DataServiceTests {
     verify(spyService, times(3)).tryItemAssetsResetOnce(true); // Retries 3 times
   }
 
+  @Test
+  void processItemAssets_shouldHandleEmptyResults() {
+    when(stacRepository.getAllItems("empty-collection")).thenReturn(List.of());
+
+    dataService.processItemAssets("empty-collection");
+
+    assertThat(dataService.getProgress("empty-collection_assets")).isEqualTo(-1); // completed without items
+  }
+
+  @Test
+  void processItemAssets_shouldHandleUnexpectedSearchType() {
+    Map<String, Object> mockRow = Map.of("search", 123); // Not PGobject or String
+    when(stacRepository.getAllItems("bad-search")).thenReturn(List.of(mockRow));
+
+    dataService.processItemAssets("bad-search");
+
+    assertThat(dataService.getProgress("bad-search_assets")).isEqualTo(-1); // No crash, handled gracefully
+  }
+
+  @Test
+  void processItemAssets_shouldHandleJsonParsingError() throws Exception {
+    PGobject pgObject = new PGobject();
+    pgObject.setValue("{ invalid json");
+
+    Map<String, Object> mockRow = Map.of("search", pgObject);
+    when(stacRepository.getAllItems("error-case")).thenReturn(List.of(mockRow));
+    when(objectMapper.readTree(anyString())).thenThrow(JsonProcessingException.class);
+
+    dataService.processItemAssets("error-case");
+
+    assertThat(dataService.getProgress("error-case_assets")).isEqualTo(-1); // Error state
+  }
+
+  @Test
+  void processItemAssets_shouldSkipFeaturesWithNoAssets() throws Exception {
+    PGobject pgObject = new PGobject();
+    pgObject.setValue("""
+    {
+      "features": [{
+        "id": "item-no-assets",
+        "collection": "collectionX",
+        "assets": {}
+      }]
+    }
+  """);
+
+    Map<String, Object> mockRow = Map.of("search", pgObject);
+    when(stacRepository.getAllItems("no-assets")).thenReturn(List.of(mockRow));
+
+    dataService.processItemAssets("no-assets");
+
+    assertThat(dataService.getProgress("no-assets_assets")).isEqualTo(-1);
+    verifyNoInteractions(geoTIFFService);
+  }
+
+  @Test
+  void processItemAssets_ShouldProcessAssetsForEachFeature() throws Exception {
+    // Arrange
+    String collectionId = "test-collection";
+    String itemId = "item1";
+    String assetKey = "B01";
+    String href = "https://somehost.com/asset1.tif";
+
+    // Build the JSON string to simulate the "search" PGobject
+    String json = String.format("""
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "id": "%s",
+          "collection": "%s",
+          "assets": {
+            "%s": {
+              "href": "%s"
+            }
+          }
+        }
+      ]
+    }
+    """, itemId, collectionId, assetKey, href);
+
+    PGobject pgObject = new PGobject();
+    pgObject.setType("json");
+    pgObject.setValue(json);
+
+    Map<String, Object> row = Map.of("search", pgObject);
+    when(stacRepository.getAllItems(eq(collectionId))).thenReturn(List.of(row));
+
+    // Mock ObjectMapper to parse the JSON string
+    ObjectMapper realMapper = new ObjectMapper(); // Use real one to parse actual JSON
+    JsonNode rootNode = realMapper.readTree(json);
+    when(objectMapper.readTree(anyString())).thenReturn(rootNode);
+
+    // Ensure GeoTIFFService is mocked properly
+    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href))).thenReturn(true);
+
+    // Act
+    dataService.processItemAssets(collectionId);
+
+    // Allow async execution to complete (adjust if needed)
+    Thread.sleep(150);
+
+    // Assert
+    verify(stacRepository).getAllItems(eq(collectionId));
+    verify(objectMapper).readTree(anyString());
+    verify(geoTIFFService).processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href));
+
+    // Check progress is 100%
+    assertThat(dataService.getProgress(collectionId + "_assets")).isEqualTo(100);
+  }
+
+
+
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
@@ -152,6 +152,27 @@ class GeoServerServiceTests {
   }
 
   @Test
+  void testUnregisterLayer_Failure_Exception() {
+    String expectedUrl = geoserverUrl + "/rest/workspaces/" + workspace + "/coveragestores/" + layerName + "?purge=all&recurse=true";
+
+    // Simulate RestTemplate throwing an exception
+    when(restTemplate.exchange(
+      eq(expectedUrl),
+      eq(HttpMethod.DELETE),
+      any(HttpEntity.class),
+      eq(String.class))
+    ).thenThrow(new RuntimeException("Test exception"));
+
+    // Execute
+    boolean result = geoServerService.unregisterLayer(layerName);
+
+    // Verify
+    verify(restTemplate, times(1)).exchange(eq(expectedUrl), eq(HttpMethod.DELETE), any(HttpEntity.class), eq(String.class));
+    assertThat(result).isFalse();
+  }
+
+
+  @Test
   void deleteTifFile_shouldDeleteFile_ifExists() throws Exception {
     // Arrange
     setField(geoServerService, "geoserverDownloadDir", tempDir.toString());

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoServerServiceTests.java
@@ -3,6 +3,7 @@ package wildfire.visualization.backend.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -10,6 +11,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Base64;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +28,9 @@ class GeoServerServiceTests {
 
   @InjectMocks
   private GeoServerService geoServerService;
+
+  @TempDir
+  Path tempDir;
 
   private final String geoserverUrl = "http://localhost:8090/geoserver";
   private final String workspace = "Default";
@@ -145,6 +151,37 @@ class GeoServerServiceTests {
     assertThat(result).isFalse();
   }
 
+  @Test
+  void deleteTifFile_shouldDeleteFile_ifExists() throws Exception {
+    // Arrange
+    setField(geoServerService, "geoserverDownloadDir", tempDir.toString());
+
+    String testLayer = "delete_test";
+    Path filePath = tempDir.resolve(testLayer + ".tif");
+    Files.write(filePath, "test".getBytes());
+
+    assertThat(Files.exists(filePath)).isTrue();
+
+    // Act
+    geoServerService.deleteTifFile(testLayer);
+
+    // Assert
+    assertThat(Files.exists(filePath)).isFalse();
+  }
+
+  @Test
+  void deleteTifFile_shouldNotFail_ifFileDoesNotExist() {
+    // Arrange
+    setField(geoServerService, "geoserverDownloadDir", tempDir.toString());
+
+    String testLayer = "nonexistent";
+
+    // Act & Assert (no exception should be thrown)
+    assertThatCode(() -> geoServerService.deleteTifFile(testLayer)).doesNotThrowAnyException();
+
+    Path expectedPath = tempDir.resolve(testLayer + ".tif");
+    assertThat(Files.exists(expectedPath)).isFalse();
+  }
 
   // ✅ Utility method to set private fields via reflection
   private void setField(Object target, String fieldName, Object value) {
@@ -156,4 +193,6 @@ class GeoServerServiceTests {
       throw new RuntimeException("Failed to set field: " + fieldName, e);
     }
   }
+
+
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
@@ -44,73 +44,69 @@ class GeoTIFFServiceTests {
   }
 
   @Test
-  void testProcessGeoTIFF_Success() throws Exception {
-    // ✅ Prevent actual file download
+  void processGeoTIFF_shouldReturnTrue_onSuccess() throws Exception {
+    String itemId = "item1", collectionId = "col1", assetName = "a1", url = "http://example.com/file.tif";
+
+    // Mock file download (assume it's a void method)
     doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
 
-    // ✅ Mock GeoServer interactions
-    when(geoServerService.registerCoverageStore(assetName)).thenReturn(true);
-    when(geoServerService.registerCoverageLayer(assetName)).thenReturn(true);
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, url);
 
-    // ✅ Mock database save
-    doNothing().when(stacRepository).saveLayer(anyString(), anyString(), anyString(), anyString());
-
-    // Execute method
-    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
-
-    // Verify interactions
-    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
-    verify(geoServerService, times(1)).registerCoverageStore(assetName);
-    verify(geoServerService, times(1)).registerCoverageLayer(assetName);
-    verify(stacRepository, times(1)).saveLayer(anyString(), anyString(), anyString(), anyString());
-
-    // Assert success
     assertThat(result).isTrue();
+    verify(stacRepository).saveLayer(eq(itemId), eq(collectionId), eq(assetName), contains("GetMap"));
+    verify(geoTIFFService).downloadFile(eq(url), contains(assetName + ".tif"));
   }
 
   @Test
-  void testProcessGeoTIFF_FailureOnDownload() throws Exception {
+  void processGeoTIFF_shouldReturnFalse_onException() throws Exception {
     doThrow(new IOException("Download failed")).when(geoTIFFService).downloadFile(anyString(), anyString());
 
-    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
-
-    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
-    verify(geoServerService, never()).registerCoverageStore(anyString());
-    verify(geoServerService, never()).registerCoverageLayer(anyString());
-    verify(stacRepository, never()).saveLayer(anyString(), anyString(), anyString(), anyString());
+    boolean result = geoTIFFService.processGeoTIFF("item1", "col1", "a1", "url");
 
     assertThat(result).isFalse();
+    verify(stacRepository).deleteItemAssetLayer("a1", "item1");
   }
 
   @Test
-  void testProcessGeoTIFF_FailureOnRegisterStore() throws Exception {
-    doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
-    when(geoServerService.registerCoverageStore(assetName)).thenReturn(false);
+  void registerGeoTIFF_shouldReturnTrue_onSuccess() {
+    when(geoServerService.registerCoverageStore("item1_a1")).thenReturn(true);
+    when(geoServerService.registerCoverageLayer("item1_a1")).thenReturn(true);
 
-    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
+    boolean result = geoTIFFService.registerGeoTIFF("item1", "a1");
 
-    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
-    verify(geoServerService, times(1)).registerCoverageStore(assetName);
-    verify(geoServerService, never()).registerCoverageLayer(anyString());
-    verify(stacRepository, never()).saveLayer(anyString(), anyString(), anyString(), anyString());
-
-    assertThat(result).isFalse();
+    assertThat(result).isTrue();
+    verify(stacRepository).markAssetAsRegistered("item1", "a1");
   }
 
   @Test
-  void testProcessGeoTIFF_FailureOnRegisterLayer() throws Exception {
-    doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
-    when(geoServerService.registerCoverageStore(assetName)).thenReturn(true);
-    when(geoServerService.registerCoverageLayer(assetName)).thenReturn(false);
+  void registerGeoTIFF_shouldReturnFalse_ifStoreFails() {
+    when(geoServerService.registerCoverageStore("item1_a1")).thenReturn(false);
 
-    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, tiffUrl);
-
-    verify(geoTIFFService, times(1)).downloadFile(tiffUrl, localFilePath);
-    verify(geoServerService, times(1)).registerCoverageStore(assetName);
-    verify(geoServerService, times(1)).registerCoverageLayer(assetName);
-    verify(stacRepository, never()).saveLayer(anyString(), anyString(), anyString(), anyString());
+    boolean result = geoTIFFService.registerGeoTIFF("item1", "a1");
 
     assertThat(result).isFalse();
+    verify(stacRepository, never()).markAssetAsRegistered(any(), any());
+  }
+
+  @Test
+  void registerGeoTIFF_shouldReturnFalse_ifLayerFails() {
+    when(geoServerService.registerCoverageStore("item1_a1")).thenReturn(true);
+    when(geoServerService.registerCoverageLayer("item1_a1")).thenReturn(false);
+
+    boolean result = geoTIFFService.registerGeoTIFF("item1", "a1");
+
+    assertThat(result).isFalse();
+    verify(stacRepository, never()).markAssetAsRegistered(any(), any());
+  }
+
+  @Test
+  void registerGeoTIFF_shouldHandleExceptionAndDeleteAsset() {
+    when(geoServerService.registerCoverageStore(any())).thenThrow(new RuntimeException("fail"));
+
+    boolean result = geoTIFFService.registerGeoTIFF("item1", "a1");
+
+    assertThat(result).isFalse();
+    verify(stacRepository).deleteItemAssetLayer("a1", "item1");
   }
 
   @Test


### PR DESCRIPTION
**Related to:** Addition to #251

---

### Description

This PR updates the backend to support preloading and registering wildfire asset GeoTIFFs (humidity, wind force, wind direction) ahead of user interaction. This enables smooth transitions between timestamps by avoiding runtime asset fetching.

---

### Backend Implementation

- **`processGeoTIFF`**: Downloads a TIFF asset, stores it locally, and saves its layer URL to the database.
- **`registerGeoTIFF`**: Registers the asset in GeoServer and updates its registration status.
- **`processItemAssetsRefresh(itemId)`**: Processes and registers all assets for a given item.
- **`processItemAssets(collectionId)`**: Processes all items in a collection with progress tracking.
- **`itemAssetsReset(fullReset)`**: Unregisters layers and optionally clears the database.

---

### New API Endpoint

```
GET /api/load-asset-layers/{itemId}
```

- Starts background processing of all assets for a given item.
- Returns immediately with a success or failure message.

---

### Testing

- Unit tests for `GeoTIFFService` and `DataService` asset handling.
- Controller test for the new `/api/load-asset-layers/{itemId}` endpoint.

---

### Acceptance Criteria Addressed

- Assets are downloaded and registered ahead of selection.
- Duplicate processing is avoided using `is_registered` and conflict checks.
- Progress tracking is implemented for collections.
- API endpoints allow frontend integration for both loading and retrieval.



ALSO DOCUMENTED PROCESS IN ISSUE #307 FOR MORE DETAILS.
