### PR TITLE
#248 - feature(frontend) - Move to area of selected dataset

### DIFF
--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -68,7 +68,24 @@ jest.mock('ol/control.js', () => ({
   defaults: jest.fn(() => ({ extend: jest.fn() })),
 }));
 
-jest.mock('ol/source/Vector', () => jest.fn().mockImplementation(() => ({})));
+jest.mock('ol/source/Vector', () => {
+  return jest.fn().mockImplementation(() => {
+    const properties: Record<string, any> = {};
+    return {
+      set: jest.fn((key: string, value: any) => {
+        properties[key] = value;
+      }),
+      get: jest.fn((key: string) => properties[key]),
+      once: jest.fn((event: string, callback: () => void) => {
+        // Simulate the event being triggered immediately
+        if (event === 'featuresloadend') {
+          callback();
+        }
+      }),
+      getExtent: jest.fn(() => [-120, 30, -110, 40]), // Mock extent
+    };
+  });
+});
 
 jest.mock('ol/layer/Vector', () =>
   jest.fn().mockImplementation(() => {
@@ -111,6 +128,9 @@ jest.mock('ol/Map', () => {
       trigger: (event: string) => {
         (eventListeners[event] || []).forEach((callback) => callback());
       },
+      getResolutionForExtent: jest.fn(() => 1), // Mock resolution
+      getZoomForResolution: jest.fn(() => 5), // Mock zoom level
+      animate: jest.fn(), // Mock animate method
     };
 
     return {
@@ -267,6 +287,12 @@ describe(MapView, () => {
 
   it('calls changeLayer without errors', () => {
     const mockMapInstance = {
+      getView: jest.fn(() => ({
+        getResolutionForExtent: jest.fn(),
+        getZoomForResolution: jest.fn(),
+        animate: jest.fn(),
+      })),
+      getSize: jest.fn(() => [800, 600]),
       getLayers: jest.fn(() => ({
         getArray: jest.fn(() => []),
       })),
@@ -290,6 +316,12 @@ describe(MapView, () => {
 
   it('refreshes the map layer correctly', () => {
     const mockMap = {
+      getView: jest.fn(() => ({
+        getResolutionForExtent: jest.fn(),
+        getZoomForResolution: jest.fn(),
+        animate: jest.fn(),
+      })),
+      getSize: jest.fn(() => [800, 600]),
       getLayers: jest.fn(() => ({
         getArray: jest.fn(() => [
           { get: jest.fn(() => 'dataLayer'), set: jest.fn() },

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -26,7 +26,6 @@ const OFFLINE_LAYER_URL = `${tileserverUrl}/{z}/{x}/{y}.jpg`;
 const SATELLITE_LAYER_URL = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
 const TOPOGRAPHIC_LAYER_URL = 'https://tile.opentopomap.org/{z}/{x}/{y}.png';
 
-
 // Offline fallback layer for cases with no internet connection
 const offlineLayer = new TileLayer({
   source: new XYZ({
@@ -66,7 +65,7 @@ const topographicLayer = new TileLayer({
  *
  * @returns {VectorLayer} The generated collection data layer for the map.
  */
-const createCollectionDataLayer = (): VectorLayer => {
+const createCollectionDataLayer = (map: Map): VectorLayer => {
   const geoserverUrl = process.env.NEXT_PUBLIC_GEOSERVER_URL;
 
   const vectorSource = new VectorSource({
@@ -83,6 +82,20 @@ const createCollectionDataLayer = (): VectorLayer => {
   });
 
   newLayer.set('id', 'dataLayer');
+  vectorSource.once('featuresloadend', () => {
+    const extent = vectorSource.getExtent();
+    if (extent) {
+      const view = map.getView();
+      const resolution = view.getResolutionForExtent(extent, map.getSize());
+      const zoom = view.getZoomForResolution(resolution);
+      view.animate({
+        center: [(extent[0] + extent[2]) / 2, (extent[1] + extent[3]) / 2],
+        zoom: zoom ? zoom - 1 : 1, 
+        duration: 1000 
+      });
+    }
+  });
+
   return newLayer;
 };
 
@@ -126,7 +139,7 @@ export const refreshLayer = (map: Map, collection: boolean, timestamp?: string) 
     if (dataLayer) {
       map.removeLayer(dataLayer);
     }
-    const newLayer = createCollectionDataLayer()
+    const newLayer = createCollectionDataLayer(map);
     map.addLayer(newLayer);
   }
 
@@ -185,7 +198,7 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
       mapRef.current = new Map({
         target: mapElement.current as unknown as HTMLElement,
         controls: defaultControls().extend([new FullScreen()]),
-        layers: [getLayer(), createCollectionDataLayer()],
+        layers: mapRef.current ? [getLayer(), createCollectionDataLayer(mapRef.current)] : [getLayer()],
         view: new View({
           center: [-75.6972, 45.4215], // Ottawa
           zoom: 1,


### PR DESCRIPTION
Related to #248 

### Description

This PR updates the frontend to move the map view to the corresponding area of the selected toggled dataset.


### Frontend Implementation

`createCollectionDataLayer = (map: Map)` Added a map parameter to pull the new location of the layer, and set the center of the map at these coordinates.

### Testing

- Unit tests for `TestMapView`, mocked the new functions used.

### Acceptance criteria Addressed

Automatically adjust the map's viewport to focus on the dataset's geographic bounding box when clicked.