### PR TITLE
#316 - fix(frontend): Loading Bar Changes Position

### DIFF
--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -204,14 +204,14 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
           onClick={onLoadDataset}
           data-testid="load-dataset-button"
         >
-          <LoadingModule
-            progress={progress}
-            isVisible={loading}
-            datasetBeingLoaded={name}
-            data-testid="loading-module"
-          />
           {t('load_dataset')}
         </button>
+        <LoadingModule
+          progress={progress}
+          isVisible={loading}
+          datasetBeingLoaded={name}
+          data-testid="loading-module"
+        />
       </div>
     </div>
   );

--- a/apps/frontend/src/app/styles/LoadingModule.css
+++ b/apps/frontend/src/app/styles/LoadingModule.css
@@ -5,7 +5,7 @@
   width: 530px;
   height: 50px;
   position: fixed;
-  top: calc(var(--datasets-bottom) + 10px); /* Use datasets-container's bottom + 10px */
+  top: 68%;
   right: 20px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
   border: 1px solid #ddd;
@@ -32,8 +32,9 @@
 }
 
 .progress-text {
-  font-size: 0.9em;
-  color: #666;
+  font-size: 1em;
+  font-weight: bold;
+  color: #666;         
   text-align: center;
   margin-top: 10px;
 }


### PR DESCRIPTION
### Summary

Fixed Bug where the loading bar would change positions when clicking on the loading bar or hovering over the load dataset button in map metadata.

**Changes Made**

- Moved the loading module outside of the <button> tag in the MapMetaData.tsx file
- Updated CSS to match what was done previously

**Testing Instructions**

- Build and run the app
- Click on a dataset and load it
- Try clicking on the loading bar or hovering over load dataset button, nothing should happen.

**Screenshots**

https://github.com/user-attachments/assets/3af2ad07-0314-4366-9157-ab46b0c4d559