### PR TITLE
#311 - feat(frontend): Dynamically Create Asset Heatmaps

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
@@ -38,14 +38,19 @@ public class DatabaseInitializer {
               asset_name TEXT NOT NULL,
               layer_url TEXT NOT NULL,
               is_registered BOOLEAN DEFAULT FALSE,
-              min INT NOT NULL,
-              max INT NOT NULL,
               UNIQUE (item_id, asset_name)
           );
+      """;
+
+    String alterAssets = """
+          ALTER TABLE TIFF_Assets
+          ADD COLUMN IF NOT EXISTS min INT NOT NULL,
+          ADD COLUMN IF NOT EXISTS max INT NOT NULL;
       """;
 
     jdbcTemplate.execute(createCollections);
     jdbcTemplate.execute(createItems);      // Must be before Assets
     jdbcTemplate.execute(createAssets);     // Must be after Items
+    jdbcTemplate.execute(alterAssets);      // Alter exisiting table since it is already present in the db
   }
 }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/config/DatabaseInitializer.java
@@ -3,6 +3,7 @@ package wildfire.visualization.backend.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+
 import jakarta.annotation.PostConstruct;
 
 @Component
@@ -37,6 +38,8 @@ public class DatabaseInitializer {
               asset_name TEXT NOT NULL,
               layer_url TEXT NOT NULL,
               is_registered BOOLEAN DEFAULT FALSE,
+              min INT NOT NULL,
+              max INT NOT NULL,
               UNIQUE (item_id, asset_name)
           );
       """;

--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -1,17 +1,18 @@
 package wildfire.visualization.backend.repository;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
-import wildfire.visualization.backend.exception.RepositoryException;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
+import wildfire.visualization.backend.exception.RepositoryException;
 
 /**
  * Repository responsible for directly communicating with the pgSTAC database
@@ -584,7 +585,7 @@ public class StacRepository {
    * @param assetName    Name of the asset
    * @param layerUrl     URL of the layer
    */
-  public void saveLayer(String itemId, String collectionId, String assetName, String layerUrl) {
+  public void saveLayer(String itemId, String collectionId, String assetName, String layerUrl, int min, int max) {
     // Ensure the collection exists
     String insertCollection = """
             INSERT INTO TIFF_Collections (collection_id)
@@ -603,11 +604,11 @@ public class StacRepository {
 
     // Insert asset with default is_registered = FALSE
     String insertAsset = """
-            INSERT INTO TIFF_Assets (item_id, asset_name, layer_url, is_registered)
-            VALUES (?, ?, ?, FALSE)
+            INSERT INTO TIFF_Assets (item_id, asset_name, layer_url, is_registered, min, max)
+            VALUES (?, ?, ?, FALSE, ?, ?)
             ON CONFLICT (item_id, asset_name) DO NOTHING;
         """;
-    jdbcTemplate.update(insertAsset, itemId, assetName, layerUrl);
+    jdbcTemplate.update(insertAsset, itemId, assetName, layerUrl, min, max);
   }
 
   /**
@@ -618,7 +619,7 @@ public class StacRepository {
    */
   public List<Map<String, Object>> getLoadedLayers(String itemId) {
     String sql = """
-            SELECT a.id AS asset_id, a.asset_name, a.layer_url, a.is_registered,
+            SELECT a.id AS asset_id, a.asset_name, a.layer_url, a.is_registered, a.min, a.max,
                    i.item_id, i.collection_id
             FROM TIFF_Assets a
             JOIN TIFF_Items i ON a.item_id = i.item_id
@@ -700,7 +701,7 @@ public class StacRepository {
    */
   public List<Map<String, Object>> getLoadedLayers() {
     String sql = """
-            SELECT a.id AS asset_id, a.asset_name, a.layer_url, a.is_registered,
+            SELECT a.id AS asset_id, a.asset_name, a.layer_url, a.is_registered, a.min, a.max,
                    i.item_id, i.collection_id
             FROM TIFF_Assets a
             JOIN TIFF_Items i ON a.item_id = i.item_id

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -1,8 +1,17 @@
 package wildfire.visualization.backend.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,18 +19,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.postgresql.util.PGobject;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import wildfire.visualization.backend.controller.ConfigController;
 import wildfire.visualization.backend.exception.DataException;
 import wildfire.visualization.backend.helper.UtilHelper;
 import wildfire.visualization.backend.repository.StacRepository;
-
-import java.time.LocalDateTime;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 /**
  * The service responsible for the business logic of data retrieval from the
@@ -728,8 +734,11 @@ public class DataService {
           String assetKey = it.next();
           JsonNode asset = assets.get(assetKey);
           String href = asset.get("href").asText();
+          JsonNode valueRange = asset.get("value_range");
+          int min = valueRange.get(0).asInt();
+          int max = valueRange.get(1).asInt();
 
-          boolean success = geoTIFFService.processGeoTIFF(itemId, collId, assetKey, href);
+          boolean success = geoTIFFService.processGeoTIFF(itemId, collId, assetKey, href, min, max);
           if (!success) {
             logger.warn("Failed to register asset {} for item {}", assetKey, itemId);
           }

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/GeoTIFFService.java
@@ -1,13 +1,18 @@
 package wildfire.visualization.backend.service;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import wildfire.visualization.backend.repository.StacRepository;
 
-import java.io.*;
-import java.net.URL;
-import java.nio.file.*;
+import wildfire.visualization.backend.repository.StacRepository;
 
 @Service
 public class GeoTIFFService {
@@ -39,13 +44,13 @@ public class GeoTIFFService {
    * @param tiffUrl      The URL of the GeoTIFF asset.
    * @return true if the asset was successfully processed, false otherwise.
    */
-  public boolean processGeoTIFF(String itemId, String collectionId, String assetName, String tiffUrl) {
+  public boolean processGeoTIFF(String itemId, String collectionId, String assetName, String tiffUrl, int min, int max) {
     try {
       String layerName = itemId + "_" + assetName;
       String localFilePath = tiffStoragePath + "/" + layerName + ".tif";
       String layerUrl = geoServerLocalUrl + "/" + workspace + "/wms?service=WMS&request=GetMap&layers=" + workspace + ":" + layerName;
 
-      stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl);
+      stacRepository.saveLayer(itemId, collectionId, assetName, layerUrl, min, max);
 
       // Download TIFF to GeoServer storage
       downloadFile(tiffUrl, localFilePath);

--- a/apps/backend/src/test/java/wildfire/visualization/backend/config/DatabaseInitializerTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/config/DatabaseInitializerTests.java
@@ -3,12 +3,14 @@ package wildfire.visualization.backend.config;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
-
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class) // Enables Mockito
 class DatabaseInitializerTests {
@@ -29,6 +31,6 @@ class DatabaseInitializerTests {
     databaseInitializer.initializeDatabase();
 
     // Verify that SQL was executed
-    verify(jdbcTemplate, times(3)).execute(anyString());
+    verify(jdbcTemplate, times(4)).execute(anyString());
   }
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -836,7 +836,7 @@ class StacRepositoryTests {
 
   @Test
   void testSaveLayer_insertsCollectionItemAndAsset() {
-    stacRepository.saveLayer("item1", "col1", "asset1", "url1", 0, 100);//FIXTEST -> done?
+    stacRepository.saveLayer("item1", "col1", "asset1", "url1", 0, 100);
 
     verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Collections"), eq("col1"));
     verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Items"), eq("item1"), eq("col1"));

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -1,17 +1,5 @@
 package wildfire.visualization.backend.repository;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.jdbc.core.JdbcTemplate;
-
-import wildfire.visualization.backend.exception.RepositoryException;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,11 +7,26 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import wildfire.visualization.backend.exception.RepositoryException;
 
 @ExtendWith(MockitoExtension.class)
 class StacRepositoryTests {
@@ -833,11 +836,11 @@ class StacRepositoryTests {
 
   @Test
   void testSaveLayer_insertsCollectionItemAndAsset() {
-    stacRepository.saveLayer("item1", "col1", "asset1", "url1");
+    stacRepository.saveLayer("item1", "col1", "asset1", "url1", 0, 100);//FIXTEST -> done?
 
     verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Collections"), eq("col1"));
     verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Items"), eq("item1"), eq("col1"));
-    verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Assets"), eq("item1"), eq("asset1"), eq("url1"));
+    verify(jdbcTemplate).update(contains("INSERT INTO TIFF_Assets"), eq("item1"), eq("asset1"), eq("url1"), eq(0), eq(100));
   }
 
   @Test

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -1,22 +1,5 @@
 package wildfire.visualization.backend.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.postgresql.util.PGobject;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
-import wildfire.visualization.backend.controller.ConfigController;
-import wildfire.visualization.backend.exception.DataException;
-import wildfire.visualization.backend.exception.RepositoryException;
-import wildfire.visualization.backend.repository.StacRepository;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,8 +8,38 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.postgresql.util.PGobject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import wildfire.visualization.backend.controller.ConfigController;
+import wildfire.visualization.backend.exception.DataException;
+import wildfire.visualization.backend.exception.RepositoryException;
+import wildfire.visualization.backend.repository.StacRepository;
 
 @ExtendWith(MockitoExtension.class)
 class DataServiceTests {
@@ -1088,6 +1101,8 @@ class DataServiceTests {
     String itemId = "item1";
     String assetKey = "B01";
     String href = "https://somehost.com/asset1.tif";
+    int min = 0;
+    int max = 100;
 
     // Build the JSON string to simulate the "search" PGobject
     String json = String.format("""
@@ -1099,13 +1114,17 @@ class DataServiceTests {
               "collection": "%s",
               "assets": {
                 "%s": {
-                  "href": "%s"
+                  "href": "%s",
+                  "value_range": [
+                    %d,
+                    %d
+                  ]
                 }
               }
             }
           ]
         }
-        """, itemId, collectionId, assetKey, href);
+        """, itemId, collectionId, assetKey, href, min, max);
 
     PGobject pgObject = new PGobject();
     pgObject.setType("json");
@@ -1120,7 +1139,7 @@ class DataServiceTests {
     when(objectMapper.readTree(anyString())).thenReturn(rootNode);
 
     // Ensure GeoTIFFService is mocked properly
-    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href))).thenReturn(true);
+    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max))).thenReturn(true);//FIXTEST -> done?
 
     // Act
     dataService.processItemAssets(collectionId);
@@ -1131,7 +1150,7 @@ class DataServiceTests {
     // Assert
     verify(stacRepository).getAllItems(eq(collectionId));
     verify(objectMapper).readTree(anyString());
-    verify(geoTIFFService).processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href));
+    verify(geoTIFFService).processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max));//FIXTEST -> done?
 
     // Check progress is 100%
     assertThat(dataService.getProgress(collectionId + "_assets")).isEqualTo(100);

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -1139,7 +1139,7 @@ class DataServiceTests {
     when(objectMapper.readTree(anyString())).thenReturn(rootNode);
 
     // Ensure GeoTIFFService is mocked properly
-    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max))).thenReturn(true);//FIXTEST -> done?
+    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max))).thenReturn(true);
 
     // Act
     dataService.processItemAssets(collectionId);
@@ -1150,7 +1150,7 @@ class DataServiceTests {
     // Assert
     verify(stacRepository).getAllItems(eq(collectionId));
     verify(objectMapper).readTree(anyString());
-    verify(geoTIFFService).processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max));//FIXTEST -> done?
+    verify(geoTIFFService).processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max));
 
     // Check progress is 100%
     assertThat(dataService.getProgress(collectionId + "_assets")).isEqualTo(100);

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
@@ -59,10 +59,10 @@ class GeoTIFFServiceTests {
     // Mock file download (assume it's a void method)
     doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
 
-    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, url, min, max);//FIXTEST -> done
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, url, min, max);
 
     assertThat(result).isTrue();
-    verify(stacRepository).saveLayer(eq(itemId), eq(collectionId), eq(assetName), contains("GetMap"), eq(min), eq(max));//FIXTEST -> done
+    verify(stacRepository).saveLayer(eq(itemId), eq(collectionId), eq(assetName), contains("GetMap"), eq(min), eq(max));
     verify(geoTIFFService).downloadFile(eq(url), contains(assetName + ".tif"));
   }
 
@@ -70,7 +70,7 @@ class GeoTIFFServiceTests {
   void processGeoTIFF_shouldReturnFalse_onException() throws Exception {
     doThrow(new IOException("Download failed")).when(geoTIFFService).downloadFile(anyString(), anyString());
 
-    boolean result = geoTIFFService.processGeoTIFF("item1", "col1", "a1", "url", 0, 100);//FIXTEST -> done?
+    boolean result = geoTIFFService.processGeoTIFF("item1", "col1", "a1", "url", 0, 100);
 
     assertThat(result).isFalse();
     verify(stacRepository).deleteItemAssetLayer("a1", "item1");

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/GeoTIFFServiceTests.java
@@ -1,20 +1,28 @@
 package wildfire.visualization.backend.service;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.jupiter.MockitoExtension;
-import wildfire.visualization.backend.repository.StacRepository;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import wildfire.visualization.backend.repository.StacRepository;
 
 @ExtendWith(MockitoExtension.class)
 class GeoTIFFServiceTests {
@@ -46,14 +54,15 @@ class GeoTIFFServiceTests {
   @Test
   void processGeoTIFF_shouldReturnTrue_onSuccess() throws Exception {
     String itemId = "item1", collectionId = "col1", assetName = "a1", url = "http://example.com/file.tif";
+    int min = 0, max = 100;
 
     // Mock file download (assume it's a void method)
     doNothing().when(geoTIFFService).downloadFile(anyString(), anyString());
 
-    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, url);
+    boolean result = geoTIFFService.processGeoTIFF(itemId, collectionId, assetName, url, min, max);//FIXTEST -> done
 
     assertThat(result).isTrue();
-    verify(stacRepository).saveLayer(eq(itemId), eq(collectionId), eq(assetName), contains("GetMap"));
+    verify(stacRepository).saveLayer(eq(itemId), eq(collectionId), eq(assetName), contains("GetMap"), eq(min), eq(max));//FIXTEST -> done
     verify(geoTIFFService).downloadFile(eq(url), contains(assetName + ".tif"));
   }
 
@@ -61,7 +70,7 @@ class GeoTIFFServiceTests {
   void processGeoTIFF_shouldReturnFalse_onException() throws Exception {
     doThrow(new IOException("Download failed")).when(geoTIFFService).downloadFile(anyString(), anyString());
 
-    boolean result = geoTIFFService.processGeoTIFF("item1", "col1", "a1", "url");
+    boolean result = geoTIFFService.processGeoTIFF("item1", "col1", "a1", "url", 0, 100);//FIXTEST -> done?
 
     assertThat(result).isFalse();
     verify(stacRepository).deleteItemAssetLayer("a1", "item1");

--- a/apps/frontend/__tests__/TestAsssetsDropdown.spec.tsx
+++ b/apps/frontend/__tests__/TestAsssetsDropdown.spec.tsx
@@ -33,8 +33,8 @@ describe('AssetsDropdown component', () => {
   const mockContext = {
     mapRef: { current: mockMap },
     loadedLayers: [
-      { asset_name: 'humidity', layer_url: 'humidity-url' },
-      { asset_name: 'wind_force', layer_url: 'wind-url' },
+      { asset_name: 'humidity', layer_url: 'humidity-url', min: 0, max: 100 },
+      { asset_name: 'wind_force', layer_url: 'wind-url', min: 0, max: 100 },
     ],
     selectedAssetLayers: [],
     setSelectedAssetLayers: jest.fn(),
@@ -86,6 +86,8 @@ describe('AssetsDropdown component', () => {
       'humidity',
       'humidity-url',
       true,
+      0,
+      100
     );
     expect(setSelectedAssetLayers).toHaveBeenCalledWith(
       expect.any(Function),
@@ -111,6 +113,8 @@ describe('AssetsDropdown component', () => {
       'humidity',
       'humidity-url',
       false,
+      0,
+      100
     );
     expect(setSelectedAssetLayers).toHaveBeenCalledWith(expect.any(Function));
   });

--- a/apps/frontend/src/app/components/AssetsDropdown.tsx
+++ b/apps/frontend/src/app/components/AssetsDropdown.tsx
@@ -71,12 +71,12 @@ const AssetsDropdown = () => {
         prev.filter((name) => name !== layerName),
       );
       // Remove from map
-      toggleAssetLayer(map, layerName, layerData.layer_url, false);
+      toggleAssetLayer(map, layerName, layerData.layer_url, false, layerData.min, layerData.max);
     } else {
       // Add to selected layers
       setSelectedAssetLayers((prev) => [...prev, layerName]);
       // Add to map
-      toggleAssetLayer(map, layerName, layerData.layer_url, true);
+      toggleAssetLayer(map, layerName, layerData.layer_url, true, layerData.min, layerData.max);
     }
   };
 

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -55,8 +55,8 @@ const Footer = () => {
                 const layerData = response.find(
                   (obj: { asset_name: string, item_id: string }) => obj.asset_name === layer && obj.item_id === itemId,
                 );
-                toggleAssetLayer(map, layer, '', false);
-                toggleAssetLayer(map, layer, layerData.layer_url, true); // You need to define this function
+                toggleAssetLayer(map, layer, '', false, layerData.min, layerData.max);
+                toggleAssetLayer(map, layer, layerData.layer_url, true, layerData.min, layerData.max);
               }
             });
           }

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -17,6 +17,7 @@ import { GeoJSON } from 'ol/format';
 import { Style, Stroke, Fill } from 'ol/style';
 import ImageLayer from 'ol/layer/Image';
 import { ImageWMS } from 'ol/source';
+import { createItemAssetStyle } from '../styles/ItemAssetSyle';
 
 // Attributions
 const attribution = '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
@@ -292,17 +293,25 @@ export const toggleAssetLayer = (
   layerName: string,
   layerUrl: string,
   add: boolean,
+  min: number,
+  max: number
 ): void => {
   // First check if layer already exists
   const layers = map.getLayers().getArray();
   const existingLayer = layers.find((layer) => layer.get('name') === layerName);
+
+  const result = /layers=(.*)/.exec(layerUrl);
+    let geoServerLayerName = ''
+    if(result){
+      geoServerLayerName = result[1];
+    }
 
   if (add && !existingLayer) {
     // Add the layer
     const newLayer = new ImageLayer({
       source: new ImageWMS({
         url: layerUrl,
-        params: { STYLES: layerName },
+        params: { SLD_BODY: createItemAssetStyle(geoServerLayerName, min, max) },
         // Add crossOrigin to handle potential CORS issues
         crossOrigin: 'anonymous',
       }),

--- a/apps/frontend/src/app/styles/ItemAssetSyle.tsx
+++ b/apps/frontend/src/app/styles/ItemAssetSyle.tsx
@@ -1,0 +1,30 @@
+export const createItemAssetStyle = (layerName: string, min: number, max: number) => {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+    <StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd" version="1.0.0">
+      <NamedLayer>
+        <Name>${layerName}</Name>
+        <UserStyle>
+          <Name>raster</Name>
+          <Title>Opaque Raster</Title>
+          <Abstract>A sample style for rasters</Abstract>
+          <FeatureTypeStyle>
+            <FeatureTypeName>Feature</FeatureTypeName>
+            <Rule>
+              <RasterSymbolizer>
+                <Opacity>0.5</Opacity>
+                <ChannelSelection>
+                  <GrayChannel>
+                    <SourceChannelName>1</SourceChannelName>
+                  </GrayChannel>
+                </ChannelSelection>
+                <ColorMap type="ramp">
+                  <ColorMapEntry color="#0000ff" quantity="${min}"/>
+                  <ColorMapEntry color="#ff0000" quantity="${max}"/>
+                </ColorMap>
+              </RasterSymbolizer>
+            </Rule>
+          </FeatureTypeStyle>
+        </UserStyle>
+      </NamedLayer>
+    </StyledLayerDescriptor>`;
+  }


### PR DESCRIPTION
### Summary
Added a way to dynamically create item asset heatmaps based on their min and max values

### Changes Made
- Added a style template to pass in the layer, min and max values
- Altered a table to add min and max values
- Retrieved the min and max values from the endpoint
- Stored the values in the table
- Passed the values to the frontend so that they could be used with the style template

### Testing Instructions
1. Build and run the app
2. Load a dataset
3. Select an asset in the asset dropdown once they have laoded
4. Verify that the style is correct

### Screenshots
![image](https://github.com/user-attachments/assets/d8647c39-f197-45ed-ad76-04231c7c61d3)