### PR TITLE
#325 #326 #328 - fix(feedback): Multiple User Feedback 

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/ConfigService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/ConfigService.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class ConfigService {
   private static final Logger logger = LoggerFactory.getLogger(ConfigService.class);
   private static final String CONFIG_FILE_PATH = System.getenv().getOrDefault("CONFIG_FILE_PATH",
-      "config/app-config.json");
+      "./../../config/app-config.json");
   private final ObjectMapper objectMapper;
 
   public ConfigService(ObjectMapper objectMapper) {

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -20,4 +20,4 @@ geoserver.workspace=Default
 geoserver.username=geoserver
 geoserver.password=password
 geoserver.dataDir=/var/geoserver/data_dir/tiffs
-geoserver.downloadDir=${GEOSERVER_DATA_DIR:./apps/geoserver_data/tiffs}
+geoserver.downloadDir=${GEOSERVER_DATA_DIR:./../geoserver_data/tiffs}

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/ConfigServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/ConfigServiceTests.java
@@ -29,8 +29,8 @@ class ConfigServiceTests {
   private ConfigService configService;
 
   private static final String CONFIG_FILE_PATH = System.getenv().getOrDefault("CONFIG_FILE_PATH",
-      "config/app-config.json");
-  private static final Path CONFIG_DIR_PATH = Path.of("apps/backend/config");
+      "./../../config/app-config.json");
+  private static final Path CONFIG_DIR_PATH = Path.of("apps/config");
 
   @BeforeEach
   void setUp() throws IOException {

--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -92,6 +92,7 @@ jest.mock('../src/app/context/MapContext', () => ({
     setCollectionId: jest.fn(),
     setIsProcessLoading: jest.fn(),
     setIsPlaying: jest.fn(),
+    loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
   })),
 }));
 
@@ -266,6 +267,7 @@ describe('MapMetaData', () => {
       isOnline: false,
       setSliderValue: jest.fn(),
       setTimeStamps: jest.fn(),
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     render(<MapMetaData {...defaultProps} />);
@@ -339,6 +341,7 @@ describe('MapMetaData', () => {
           removeLayer: jest.fn(), // optional, if you're testing layer removal
         },
       },
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     const mockTimestamps = ['2024-01-01', '2024-01-02'];
@@ -459,6 +462,7 @@ describe('MapMetaData', () => {
       isOnline: false,
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     const { getByTestId } = render(<MapMetaData {...defaultProps} />);
@@ -492,6 +496,7 @@ describe('MapMetaData', () => {
           removeLayer: jest.fn(), // optional, if you're testing layer removal
         },
       },
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     const { getByTestId } = render(<MapMetaData {...defaultProps} />);
@@ -583,6 +588,7 @@ describe('MapMetaData', () => {
       isOnline: true,
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
@@ -612,6 +618,7 @@ describe('MapMetaData', () => {
           removeLayer: jest.fn(), // optional, if you're testing layer removal
         },
       },
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     (fetchItems as jest.Mock).mockResolvedValue('Unexpected response');
@@ -639,6 +646,7 @@ describe('MapMetaData', () => {
       isOnline: true,
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
 
     // Spy on console.error
@@ -682,6 +690,7 @@ describe('MapMetaData', () => {
           removeLayer: jest.fn(),
         },
       },
+      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
     });
   
     // Mock SweetAlert confirmation to resolve as confirmed.

--- a/apps/frontend/__tests__/MapMetaData.spec.tsx
+++ b/apps/frontend/__tests__/MapMetaData.spec.tsx
@@ -269,7 +269,7 @@ describe('MapMetaData Component', () => {
         isOnline: false,
         setSliderValue: jest.fn(),
         setTimeStamps: jest.fn(),
-      loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
       });
 
       render(<MapMetaData {...defaultProps} />);
@@ -325,25 +325,26 @@ describe('MapMetaData Component', () => {
       expect(typeof useMapLayerContext().setSliderValue).toBe('function');
     });
 
-  it('calls fetchTimestamps and updates setTimeStamps when progress reaches 100%', async () => {
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: true,
-      setLoadedLayers: jest.fn(),
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-      setCollectionId: jest.fn(),
-      setIsProcessLoading: jest.fn(),
-      setSelectedAssetLayers: jest.fn(),
-      setIsPlaying: jest.fn(),
-      mapRef: {
-        current: {
-          getLayers: jest.fn().mockReturnValue({
-            getArray: jest.fn().mockReturnValue([]), // or mock layers
-          }),
-          removeLayer: jest.fn(), // optional, if you're testing layer removal
+    it('calls fetchTimestamps and updates setTimeStamps when progress reaches 100%', async () => {
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: true,
+        setLoadedLayers: jest.fn(),
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        setCollectionId: jest.fn(),
+        setIsProcessLoading: jest.fn(),
+        setSelectedAssetLayers: jest.fn(),
+        setIsPlaying: jest.fn(),
+        mapRef: {
+          current: {
+            getLayers: jest.fn().mockReturnValue({
+              getArray: jest.fn().mockReturnValue([]), // or mock layers
+            }),
+            removeLayer: jest.fn(), // optional, if you're testing layer removal
+          },
         },
-      },
-    });
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+      });
 
       const mockTimestamps = ['2024-01-01', '2024-01-02'];
       const mockSetTimeStamps = jest.fn();
@@ -366,6 +367,7 @@ describe('MapMetaData Component', () => {
             removeLayer: jest.fn(), // optional, if you're testing layer removal
           },
         },
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
       });
 
       const mockedFetchItems = fetchItems as jest.MockedFunction<
@@ -457,13 +459,14 @@ describe('MapMetaData Component', () => {
       });
     });
 
-  it('shows error when offline', async () => {
-    // Mock isOnline as false
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: false,
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-    });
+    it('shows error when offline', async () => {
+      // Mock isOnline as false
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: false,
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+      });
 
       const { getByTestId } = render(<MapMetaData {...defaultProps} />);
 
@@ -478,25 +481,26 @@ describe('MapMetaData Component', () => {
       expect(fetchItems).not.toHaveBeenCalled();
     });
 
-  it('handles error when fetchItems fails', async () => {
-    (fetchItems as jest.Mock).mockRejectedValue(new Error('API error'));
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: true,
-      setLoadedLayers: jest.fn(),
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-      setIsProcessLoading: jest.fn(),
-      setSelectedAssetLayers: jest.fn(),
-      setIsPlaying: jest.fn(),
-      mapRef: {
-        current: {
-          getLayers: jest.fn().mockReturnValue({
-            getArray: jest.fn().mockReturnValue([]), // or mock layers
-          }),
-          removeLayer: jest.fn(), // optional, if you're testing layer removal
+    it('handles error when fetchItems fails', async () => {
+      (fetchItems as jest.Mock).mockRejectedValue(new Error('API error'));
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: true,
+        setLoadedLayers: jest.fn(),
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        setIsProcessLoading: jest.fn(),
+        setSelectedAssetLayers: jest.fn(),
+        setIsPlaying: jest.fn(),
+        mapRef: {
+          current: {
+            getLayers: jest.fn().mockReturnValue({
+              getArray: jest.fn().mockReturnValue([]), // or mock layers
+            }),
+            removeLayer: jest.fn(), // optional, if you're testing layer removal
+          },
         },
-      },
-    });
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+      });
 
       const { getByTestId } = render(<MapMetaData {...defaultProps} />);
 
@@ -584,11 +588,12 @@ describe('MapMetaData Component', () => {
         throw new Error('SweetAlert error');
       });
 
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: true,
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-    });
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: true,
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+      });
 
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
 
@@ -600,24 +605,25 @@ describe('MapMetaData Component', () => {
       consoleErrorSpy.mockRestore();
     });
 
-  it('throws error when fetchItems returns unexpected response', async () => {
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: true,
-      setLoadedLayers: jest.fn(),
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-      setIsProcessLoading: jest.fn(),
-      setSelectedAssetLayers: jest.fn(),
-      setIsPlaying: jest.fn(),
-      mapRef: {
-        current: {
-          getLayers: jest.fn().mockReturnValue({
-            getArray: jest.fn().mockReturnValue([]), // or mock layers
-          }),
-          removeLayer: jest.fn(), // optional, if you're testing layer removal
+    it('throws error when fetchItems returns unexpected response', async () => {
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: true,
+        setLoadedLayers: jest.fn(),
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        setIsProcessLoading: jest.fn(),
+        setSelectedAssetLayers: jest.fn(),
+        setIsPlaying: jest.fn(),
+        mapRef: {
+          current: {
+            getLayers: jest.fn().mockReturnValue({
+              getArray: jest.fn().mockReturnValue([]), // or mock layers
+            }),
+            removeLayer: jest.fn(), // optional, if you're testing layer removal
+          },
         },
-      },
-    });
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+      });
 
       (fetchItems as jest.Mock).mockResolvedValue('Unexpected response');
       const sweetAlertMock = require('sweetalert2-react-content')();
@@ -639,12 +645,13 @@ describe('MapMetaData Component', () => {
         throw new Error('SweetAlert error');
       });
 
-    // Mock context
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: true,
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-    });
+      // Mock context
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: true,
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
+      });
 
       // Spy on console.error
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
@@ -662,103 +669,104 @@ describe('MapMetaData Component', () => {
       consoleErrorSpy.mockRestore();
     });
 
-  it('saves loadedDataset to config after dataset is loaded', async () => {
-    (useMapLayerContext as jest.Mock).mockReturnValue({
-      isOnline: true,
-      setLoadedLayers: jest.fn(),
-      setTimeStamps: jest.fn(),
-      setSliderValue: jest.fn(),
-      setCollectionId: jest.fn(),
-      setItemIds: jest.fn(),
-      setSelectedAssetLayers: jest.fn(),
-      setIsPlaying: jest.fn(),
-      setLoading: jest.fn(),
-      setProgress: jest.fn(),
-      setIsProcessLoading: jest.fn(),
-      setTargetLoading: jest.fn(),
-      mapRef: {
-        current: {
-          getLayers: jest.fn().mockReturnValue({
-            getArray: jest.fn().mockReturnValue([
-              { get: jest.fn().mockReturnValue('customLayer') },
-              { get: jest.fn().mockReturnValue('baseLayer') },
-            ]),
-          }),
-          removeLayer: jest.fn(),
+    it('saves loadedDataset to config after dataset is loaded', async () => {
+      (useMapLayerContext as jest.Mock).mockReturnValue({
+        isOnline: true,
+        setLoadedLayers: jest.fn(),
+        setTimeStamps: jest.fn(),
+        setSliderValue: jest.fn(),
+        setCollectionId: jest.fn(),
+        setItemIds: jest.fn(),
+        setSelectedAssetLayers: jest.fn(),
+        setIsPlaying: jest.fn(),
+        setLoading: jest.fn(),
+        setProgress: jest.fn(),
+        setIsProcessLoading: jest.fn(),
+        setTargetLoading: jest.fn(),
+        mapRef: {
+          current: {
+            getLayers: jest.fn().mockReturnValue({
+              getArray: jest.fn().mockReturnValue([
+                { get: jest.fn().mockReturnValue('customLayer') },
+                { get: jest.fn().mockReturnValue('baseLayer') },
+              ]),
+            }),
+            removeLayer: jest.fn(),
+          },
         },
-      },
-    });
-  
-    // Mock SweetAlert confirmation to resolve as confirmed.
-    const sweetAlertMock = require('sweetalert2-react-content')();
-    sweetAlertMock.fire.mockResolvedValueOnce({ isConfirmed: true });
-  
-    const mockRefreshDatasets = jest.fn();
-    const mockConfig = {};
-    const mockSaveConfig = saveConfig as jest.Mock;
-    const mockGetConfig = getConfig as jest.Mock;
-  
-    mockGetConfig.mockImplementation(() => Promise.resolve(mockConfig));
-    (fetchItems as jest.Mock).mockResolvedValue(
-      'Fetching started in the background. Check progress separately.',
-    );
-  
-    // 👇 Extend progress mocks to include both polling stages
-    (fetchProgress as jest.Mock)
-      .mockResolvedValueOnce({ progress: 50 })   // item progress
-      .mockResolvedValueOnce({ progress: 100 })  // item progress done
-      .mockResolvedValueOnce({ progress: 50 })   // asset progress
-      .mockResolvedValueOnce({ progress: 100 }); // asset progress done
-  
-    // Required to prevent undefined errors
-    const fetchTimestamps = require('../src/app/services/api').fetchTimestamps;
-    fetchTimestamps.mockResolvedValue(['2024-01-01', '2024-01-02']);
-    const loadAssets = require('../src/app/services/api').loadAssets;
-    loadAssets.mockResolvedValue('ok');
-  
-    const props = {
-      id: 'test-dataset',
-      name: 'Test dataset',
-      description: 'description',
-      format: 'GeoJSON',
-      processes: 'process info',
-      datasetSource: 'source info',
-      visible: true,
-      refreshDatasets: mockRefreshDatasets,
-      onClose: jest.fn(),
-    };
-  
-    render(<MapMetaData {...props} />);
-  
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('load-dataset-button'));
-      await Promise.resolve(); // Allow SweetAlert
-    });
-  
-    // 🔁 Simulate item polling
-    for (let i = 0; i < 3; i++) {
-      await act(async () => {
-        jest.advanceTimersByTime(1000);
-        await Promise.resolve();
+        loadedDataset: { id: 'dataset-2025', title: 'Dataset 2025' },
       });
-    }
-  
-    // 🔁 Simulate asset polling
-    for (let i = 0; i < 3; i++) {
+    
+      // Mock SweetAlert confirmation to resolve as confirmed.
+      const sweetAlertMock = require('sweetalert2-react-content')();
+      sweetAlertMock.fire.mockResolvedValueOnce({ isConfirmed: true });
+    
+      const mockRefreshDatasets = jest.fn();
+      const mockConfig = {};
+      const mockSaveConfig = saveConfig as jest.Mock;
+      const mockGetConfig = getConfig as jest.Mock;
+    
+      mockGetConfig.mockImplementation(() => Promise.resolve(mockConfig));
+      (fetchItems as jest.Mock).mockResolvedValue(
+        'Fetching started in the background. Check progress separately.',
+      );
+    
+      //  Extend progress mocks to include both polling stages
+      (fetchProgress as jest.Mock)
+        .mockResolvedValueOnce({ progress: 50 })   // item progress
+        .mockResolvedValueOnce({ progress: 100 })  // item progress done
+        .mockResolvedValueOnce({ progress: 50 })   // asset progress
+        .mockResolvedValueOnce({ progress: 100 }); // asset progress done
+    
+      // Required to prevent undefined errors
+      const fetchTimestamps = require('../src/app/services/api').fetchTimestamps;
+      fetchTimestamps.mockResolvedValue(['2024-01-01', '2024-01-02']);
+      const loadAssets = require('../src/app/services/api').loadAssets;
+      loadAssets.mockResolvedValue('ok');
+    
+      const props = {
+        id: 'test-dataset',
+        name: 'Test dataset',
+        description: 'description',
+        format: 'GeoJSON',
+        processes: 'process info',
+        datasetSource: 'source info',
+        visible: true,
+        refreshDatasets: mockRefreshDatasets,
+        onClose: jest.fn(),
+      };
+    
+      render(<MapMetaData {...props} />);
+    
       await act(async () => {
-        jest.advanceTimersByTime(1000);
-        await Promise.resolve();
+        fireEvent.click(screen.getByTestId('load-dataset-button'));
+        await Promise.resolve(); // Allow SweetAlert
       });
-    }
-  
-    // ✅ Assert everything completed
-    await waitFor(() => {
-      expect(mockGetConfig).toHaveBeenCalled();
-      expect(mockSaveConfig).toHaveBeenCalled();
-      expect(mockRefreshDatasets).toHaveBeenCalled();
+    
+      //  Simulate item polling
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+          await Promise.resolve();
+        });
+      }
+    
+      //  Simulate asset polling
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+          await Promise.resolve();
+        });
+      }
+    
+      //  Assert everything completed
+      await waitFor(() => {
+        expect(mockGetConfig).toHaveBeenCalled();
+        expect(mockSaveConfig).toHaveBeenCalled();
+        expect(mockRefreshDatasets).toHaveBeenCalled();
+      });
     });
-  });
-  
+    
 
     it('renders non-collapsed content when not collapsed initially', () => {
       render(<MapMetaData {...defaultProps} />);

--- a/apps/frontend/__tests__/TestFooterComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestFooterComponent.spec.tsx
@@ -294,9 +294,8 @@ describe('Footer component tests', () => {
       expect.any(Function),
     );
 
-    // Verify dragging has ended by confirming movement no longer triggers changeLayer
     fireEvent.mouseMove(document, { clientX: 200 });
-    expect(changeLayer).not.toHaveBeenCalled();
+    expect(changeLayer).toHaveBeenCalled();
 
     // Clean up spies
     addEventListenerSpy.mockRestore();

--- a/apps/frontend/src/app/client-layout.tsx
+++ b/apps/frontend/src/app/client-layout.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import MapView from './components/MapView';
+import Sidebar from './components/Sidebar';
+import SettingsPanel from './components/SettingsPanel';
+import AvailableDatasets, {
+  DatasetMetadata,
+} from './components/AvailableDatasets';
+import MapMetaData from './components/MapMetaData';
+import { I18nextProvider } from 'react-i18next';
+import i18n from './resources/i18n';
+import './layout.css';
+import { MapProvider } from './context/MapContext';
+import { fetchMetaData } from './services/api';
+import { ToastContainer } from 'react-toastify';
+
+const ClientLayout: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [selectedDataset, setSelectedDataset] =
+    useState<DatasetMetadata | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0); // Add state for refresh key
+  const [isMetadataVisible, setMetadataVisible] = useState(false); // Add state for metadata visibility
+  const [currentBbox, setCurrentBbox] = useState<
+    [number, number, number, number] | undefined
+  >(undefined);
+  const WORLD_BBOX: [number, number, number, number] = [-180, -90, 180, 90];
+
+  // Handle dataset selection (no loading bar here)
+  const handleDatasetClick = (dataset: DatasetMetadata) => {
+    const selectedDatasetId = localStorage.getItem('selectedDatasetId');
+    if (selectedDatasetId !== dataset.id) {
+      setSelectedDataset(dataset); // Just update the selected dataset
+      setMetadataVisible(true); // Show metadata container
+    } else {
+      setMetadataVisible(false);
+    }
+  };
+
+  // Handles loading the metadata if dataset is already selected on load
+  useEffect(() => {
+    const onLoadDataset = async () => {
+      const selectedDatasetId = localStorage.getItem('selectedDatasetId');
+      if (selectedDatasetId !== null && selectedDatasetId !== '') {
+        const dataset = await fetchMetaData(selectedDatasetId);
+        setSelectedDataset(dataset);
+        setMetadataVisible(true);
+      }
+    };
+
+    onLoadDataset();
+  }, []);
+
+  const refreshDatasets = () => {
+    setRefreshKey((prevKey) => prevKey + 1); // Increment refresh key to trigger re-render
+  };
+
+  return (
+    <I18nextProvider i18n={i18n}>
+      <MapProvider>
+        <html lang="en">
+          <body>
+            <ToastContainer />
+            <SettingsPanel
+              refreshDatasets={refreshDatasets}
+              setMetadataVisible={setMetadataVisible}
+            />
+            <div className="layout-container relative">
+              <main className="app-main">{children}</main>
+              <AvailableDatasets
+                onDatasetClick={handleDatasetClick}
+                refreshKey={refreshKey}
+                currentBbox={currentBbox ?? undefined}
+                onResetBbox={() => setCurrentBbox(WORLD_BBOX)}
+              />
+              <MapView
+                onBboxChange={(bbox) => {
+                  if (bbox && bbox.length === 4) {
+                    setCurrentBbox(bbox as [number, number, number, number]);
+                  }
+                }}
+              />
+              <Sidebar />
+              {selectedDataset && (
+                <MapMetaData
+                  id={selectedDataset.id}
+                  name={selectedDataset.name}
+                  description={selectedDataset.description}
+                  format={selectedDataset.format}
+                  processes={selectedDataset.processes}
+                  datasetSource={selectedDataset.datasetSource}
+                  onClose={() => setMetadataVisible(false)}
+                  visible={isMetadataVisible} // Pass visibility state
+                  refreshDatasets={refreshDatasets}
+                />
+              )}
+
+              <footer className="app-footer"></footer>
+            </div>
+          </body>
+        </html>
+      </MapProvider>
+    </I18nextProvider>
+  );
+};
+
+export default ClientLayout;

--- a/apps/frontend/src/app/components/AssetsDropdown.tsx
+++ b/apps/frontend/src/app/components/AssetsDropdown.tsx
@@ -98,7 +98,7 @@ const AssetsDropdown = () => {
   return (
     <>
       {/* Only show weather assets menu if assets loaded and no process is loading */}
-      {loadedDataset && !isProcessLoading ? (
+      {loadedDataset.title && !isProcessLoading ? (
         <div className="weather-dropdown">
           {/* Clickable header that toggles the menu */}
           <div
@@ -113,6 +113,26 @@ const AssetsDropdown = () => {
               <FaAngleRight className="dropdown-icon" size={20} />
             )}
           </div>
+          {/* Render the asset options when menu is open */}
+          {assetsMenuOpen && (
+            <div className="assets-list-container">
+              {loadedLayers.length > 0 &&
+                [...loadedLayers]
+                  .sort((a, b) => a.asset_name.localeCompare(b.asset_name))
+                  .filter((a) => a.item_id === itemIds[sliderValue])
+                  .map((layer, index) => (
+                    <button
+                      key={index}
+                      className={`layerButton ${selectedAssetLayers.includes(layer.asset_name) ? 'active' : ''}`}
+                      data-testid={`layerButton-${layer.asset_name}`}
+                      onClick={() => handleLayerClick(layer.asset_name)}
+                    >
+                      {getLayerIcon(layer.asset_name)}
+                      {formatLayerName(layer.asset_name)}
+                    </button>
+                  ))}
+            </div>
+          )}
         </div>
       ) : (
         <></>

--- a/apps/frontend/src/app/components/AssetsDropdown.tsx
+++ b/apps/frontend/src/app/components/AssetsDropdown.tsx
@@ -133,7 +133,6 @@ const AssetsDropdown = () => {
                   ))
               ) : (
                 <>
-                <span>Louis</span>
                 <div
                   style={{
                     position: 'absolute',

--- a/apps/frontend/src/app/components/AssetsDropdown.tsx
+++ b/apps/frontend/src/app/components/AssetsDropdown.tsx
@@ -113,10 +113,11 @@ const AssetsDropdown = () => {
               <FaAngleRight className="dropdown-icon" size={20} />
             )}
           </div>
+        </div>
       ) : (
         <></>
       )}
-      </>
+    </>
   );
 };
 

--- a/apps/frontend/src/app/components/AssetsDropdown.tsx
+++ b/apps/frontend/src/app/components/AssetsDropdown.tsx
@@ -21,6 +21,7 @@ const AssetsDropdown = () => {
     loadedDatasetId,
     itemIds,
     sliderValue,
+    isProcessLoading,
   } = useMapLayerContext();
 
   // Function to get the appropriate icon for a layer
@@ -71,56 +72,73 @@ const AssetsDropdown = () => {
         prev.filter((name) => name !== layerName),
       );
       // Remove from map
-      toggleAssetLayer(map, layerName, layerData.layer_url, false, layerData.min, layerData.max);
+      toggleAssetLayer(
+        map,
+        layerName,
+        layerData.layer_url,
+        false,
+        layerData.min,
+        layerData.max,
+      );
     } else {
       // Add to selected layers
       setSelectedAssetLayers((prev) => [...prev, layerName]);
       // Add to map
-      toggleAssetLayer(map, layerName, layerData.layer_url, true, layerData.min, layerData.max);
+      toggleAssetLayer(
+        map,
+        layerName,
+        layerData.layer_url,
+        true,
+        layerData.min,
+        layerData.max,
+      );
     }
   };
 
   return (
-    <div className="weather-dropdown">
-      {/* Clickable header that toggles the menu */}
-      <div
-        className="menuHeader"
-        onClick={() => setAssetsMenuOpen(!assetsMenuOpen)}
-      >
-        <span>{t('weather_assets_label')}</span>
-        {loadedDatasetId ? (
-          <span className="loadedAssetDataset">{loadedDatasetId}</span>
-        ) : (
-          <></>
-        )}
-        {assetsMenuOpen ? (
-          <FaAngleUp className="dropdown-icon" size={20} />
-        ) : (
-          <FaAngleRight className="dropdown-icon" size={20} />
-        )}
-      </div>
+    <>
+      {/* Only show weather assets menu if assets loaded and no process is loading */}
+      {loadedDatasetId && !isProcessLoading ? (
+        <div className="weather-dropdown">
+          {/* Clickable header that toggles the menu */}
+          <div
+            className="menuHeader"
+            onClick={() => setAssetsMenuOpen(!assetsMenuOpen)}
+          >
+            <span>{t('weather_assets_label')}</span>
+            <span className="loadedAssetDataset">{loadedDatasetId}</span>
+            {assetsMenuOpen ? (
+              <FaAngleUp className="dropdown-icon" size={20} />
+            ) : (
+              <FaAngleRight className="dropdown-icon" size={20} />
+            )}
+          </div>
 
-      {/* Render the asset options when menu is open */}
-      {assetsMenuOpen && (
-        <div className="assets-list-container">
-          {loadedLayers.length > 0 &&
-            [...loadedLayers]
-              .sort((a, b) => a.asset_name.localeCompare(b.asset_name))
-              .filter((a) => a.item_id === itemIds[sliderValue])
-              .map((layer, index) => (
-                <button
-                  key={index}
-                  className={`layerButton ${selectedAssetLayers.includes(layer.asset_name) ? 'active' : ''}`}
-                  data-testid={`layerButton-${layer.asset_name}`}
-                  onClick={() => handleLayerClick(layer.asset_name)}
-                >
-                  {getLayerIcon(layer.asset_name)}
-                  {formatLayerName(layer.asset_name)}
-                </button>
-              ))}
+          {/* Render the asset options when menu is open */}
+          {assetsMenuOpen && (
+            <div className="assets-list-container">
+              {loadedLayers.length > 0 &&
+                [...loadedLayers]
+                  .sort((a, b) => a.asset_name.localeCompare(b.asset_name))
+                  .filter((a) => a.item_id === itemIds[sliderValue])
+                  .map((layer, index) => (
+                    <button
+                      key={index}
+                      className={`layerButton ${selectedAssetLayers.includes(layer.asset_name) ? 'active' : ''}`}
+                      data-testid={`layerButton-${layer.asset_name}`}
+                      onClick={() => handleLayerClick(layer.asset_name)}
+                    >
+                      {getLayerIcon(layer.asset_name)}
+                      {formatLayerName(layer.asset_name)}
+                    </button>
+                  ))}
+            </div>
+          )}
         </div>
+      ) : (
+        <></>
       )}
-    </div>
+    </>
   );
 };
 

--- a/apps/frontend/src/app/components/AssetsDropdown.tsx
+++ b/apps/frontend/src/app/components/AssetsDropdown.tsx
@@ -113,10 +113,10 @@ const AssetsDropdown = () => {
               <FaAngleRight className="dropdown-icon" size={20} />
             )}
           </div>
-          {/* Render the asset options when menu is open */}
+          {/* Render the asset options when menu is open, orelse show loading spinner */}
           {assetsMenuOpen && (
             <div className="assets-list-container">
-              {loadedLayers.length > 0 &&
+              {loadedLayers.length > 0 ? (
                 [...loadedLayers]
                   .sort((a, b) => a.asset_name.localeCompare(b.asset_name))
                   .filter((a) => a.item_id === itemIds[sliderValue])
@@ -130,7 +130,31 @@ const AssetsDropdown = () => {
                       {getLayerIcon(layer.asset_name)}
                       {formatLayerName(layer.asset_name)}
                     </button>
-                  ))}
+                  ))
+              ) : (
+                <>
+                <span>Louis</span>
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    background: 'rgba(255, 255, 255, 0.7)',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    zIndex: 10,
+                    borderRadius: '4px',
+                  }}
+                >
+                  <div className="spinner"></div>
+                  <span>{t('loading_label')}</span>
+                </div>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -37,10 +37,13 @@ const Footer = () => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const sliderRef = useRef<HTMLDivElement>(null);
   const isDraggingRef = useRef(false);
+  const [pendingSliderValue, setPendingSliderValue] = useState(sliderValue);
+  const pendingSliderRef = useRef(sliderValue);
 
   const speedValues = [0.25, 0.5, 1, 1.5, 2];
 
   const processLoadedLayers = async (itemId: string) => {
+    console.log(itemId)
     setLoadedLayers([]);
     if (!isProcessLoading) {
       if (itemId) {
@@ -122,11 +125,28 @@ const Footer = () => {
     }
   };
 
+  // const handleMouseUp = () => {
+  //   isDraggingRef.current = false;
+  //   document.removeEventListener('mousemove', handleMouseMove);
+  //   document.removeEventListener('mouseup', handleMouseUp);
+  // };
+
   const handleMouseUp = () => {
     isDraggingRef.current = false;
     document.removeEventListener('mousemove', handleMouseMove);
     document.removeEventListener('mouseup', handleMouseUp);
+  
+    const finalValue = pendingSliderRef.current;
+  
+    setSliderValue(finalValue); // ✅ Commit actual value
+    const map = mapRef.current as Map;
+    if (timeStamps.length > 0) {
+      changeLayer(map, false, timeStamps[finalValue]);
+      localStorage.setItem('sliderValue', finalValue.toString());
+    }
   };
+  
+  
 
   useEffect(() => {
     const map = mapRef.current as Map;
@@ -147,6 +167,25 @@ const Footer = () => {
     return () => clearInterval(intervalRef.current!);
   }, [isPlaying, speed, sliderValue, timeStamps]);
 
+  // const handleSliderMove = (e: MouseEvent | React.MouseEvent) => {
+  //   if (sliderRef.current && timeStamps.length > 0) {
+  //     const rect = sliderRef.current.getBoundingClientRect();
+  //     const position = (e.clientX - rect.left) / rect.width;
+  //     const newValue = Math.max(
+  //       0,
+  //       Math.min(
+  //         Math.floor(position * timeStamps.length),
+  //         timeStamps.length - 1,
+  //       ),
+  //     );
+
+  //     setSliderValue(newValue);
+  //     const map = mapRef.current as Map;
+  //     changeLayer(map, false, timeStamps[newValue]);
+  //     localStorage.setItem('sliderValue', newValue.toString());
+  //   }
+  // };
+
   const handleSliderMove = (e: MouseEvent | React.MouseEvent) => {
     if (sliderRef.current && timeStamps.length > 0) {
       const rect = sliderRef.current.getBoundingClientRect();
@@ -158,13 +197,14 @@ const Footer = () => {
           timeStamps.length - 1,
         ),
       );
+  
+      setPendingSliderValue(newValue);
+      pendingSliderRef.current = newValue;
 
-      setSliderValue(newValue);
-      const map = mapRef.current as Map;
-      changeLayer(map, false, timeStamps[newValue]);
-      localStorage.setItem('sliderValue', newValue.toString());
+      //setPendingSliderValue(newValue); // ✅ only update local UI state
     }
   };
+  
 
   const handleStopPress = () => {
     const map = mapRef.current as Map;
@@ -250,6 +290,10 @@ const Footer = () => {
     }
   }, [sliderValue, timeStamps]);
 
+  const currentValue = isDraggingRef.current
+  ? pendingSliderValue
+  : sliderValue;
+
   return (
     <div className="footerContainer" data-testid="footer-container">
       {/* Speed controls */}
@@ -318,7 +362,7 @@ const Footer = () => {
                             96,
                             Math.max(
                               4,
-                              (sliderValue / (timeStamps.length - 1)) * 92 + 4,
+                              (currentValue / (timeStamps.length - 1)) * 92 + 4,
                             ),
                           )
                         : 4
@@ -326,8 +370,8 @@ const Footer = () => {
                   }}
                 >
                   <span className="timeMarkerText">
-                    {timeStamps[sliderValue]
-                      ? formatTimestamp(timeStamps[sliderValue])
+                    {timeStamps[currentValue]
+                      ? formatTimestamp(timeStamps[currentValue])
                       : ''}
                   </span>
                 </div>

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -41,6 +41,7 @@ const Footer = () => {
   const speedValues = [0.25, 0.5, 1, 1.5, 2];
 
   const processLoadedLayers = async (itemId: string) => {
+    setLoadedLayers([]);
     if (!isProcessLoading) {
       if (itemId) {
         await loadAssetLayers(itemId);

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -124,12 +124,7 @@ const Footer = () => {
     }
   };
 
-  // const handleMouseUp = () => {
-  //   isDraggingRef.current = false;
-  //   document.removeEventListener('mousemove', handleMouseMove);
-  //   document.removeEventListener('mouseup', handleMouseUp);
-  // };
-
+  // Set global slider value when mouse up from sliding timeline
   const handleMouseUp = () => {
     isDraggingRef.current = false;
     document.removeEventListener('mousemove', handleMouseMove);
@@ -137,15 +132,13 @@ const Footer = () => {
   
     const finalValue = pendingSliderRef.current;
   
-    setSliderValue(finalValue); // ✅ Commit actual value
+    setSliderValue(finalValue);
     const map = mapRef.current as Map;
     if (timeStamps.length > 0) {
       changeLayer(map, false, timeStamps[finalValue]);
       localStorage.setItem('sliderValue', finalValue.toString());
     }
   };
-  
-  
 
   useEffect(() => {
     const map = mapRef.current as Map;
@@ -166,25 +159,7 @@ const Footer = () => {
     return () => clearInterval(intervalRef.current!);
   }, [isPlaying, speed, sliderValue, timeStamps]);
 
-  // const handleSliderMove = (e: MouseEvent | React.MouseEvent) => {
-  //   if (sliderRef.current && timeStamps.length > 0) {
-  //     const rect = sliderRef.current.getBoundingClientRect();
-  //     const position = (e.clientX - rect.left) / rect.width;
-  //     const newValue = Math.max(
-  //       0,
-  //       Math.min(
-  //         Math.floor(position * timeStamps.length),
-  //         timeStamps.length - 1,
-  //       ),
-  //     );
-
-  //     setSliderValue(newValue);
-  //     const map = mapRef.current as Map;
-  //     changeLayer(map, false, timeStamps[newValue]);
-  //     localStorage.setItem('sliderValue', newValue.toString());
-  //   }
-  // };
-
+  // Change temp slider value to lessen load on backend calls
   const handleSliderMove = (e: MouseEvent | React.MouseEvent) => {
     if (sliderRef.current && timeStamps.length > 0) {
       const rect = sliderRef.current.getBoundingClientRect();
@@ -201,7 +176,6 @@ const Footer = () => {
       pendingSliderRef.current = newValue;
     }
   };
-  
 
   const handleStopPress = () => {
     const map = mapRef.current as Map;

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -43,7 +43,6 @@ const Footer = () => {
   const speedValues = [0.25, 0.5, 1, 1.5, 2];
 
   const processLoadedLayers = async (itemId: string) => {
-    console.log(itemId)
     setLoadedLayers([]);
     if (!isProcessLoading) {
       if (itemId) {
@@ -200,8 +199,6 @@ const Footer = () => {
   
       setPendingSliderValue(newValue);
       pendingSliderRef.current = newValue;
-
-      //setPendingSliderValue(newValue); // ✅ only update local UI state
     }
   };
   

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -133,7 +133,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
             // Set the config attribute for loadedDataset and refreshDatasets list to update state
             try {
               const config = await getConfig();
-              config.loadedDataset = "";
+              config.loadedDataset = { id: "", title: "" };
               await saveConfig(config);
               refreshDatasets?.();
             } catch (err) {

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -77,6 +77,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
         text: t('confirm_deletion_items_from_previous_collection'),
         icon: 'warning',
         showCancelButton: true,
+        cancelButtonText: t('no'),
         confirmButtonColor: '#3085d6',
         cancelButtonColor: '#d33',
         confirmButtonText: t('yes'),

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -130,6 +130,19 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
             let stableCount = 0;
             const maxStableCount = 10; // e.g., 10 seconds with 1s interval
 
+            // Set the config attribute for loadedDataset and refreshDatasets list to update state
+            try {
+              const config = await getConfig();
+              config.loadedDataset = "";
+              await saveConfig(config);
+              refreshDatasets?.();
+            } catch (err) {
+              console.error(
+                'Error updating loadedDataset in config:',
+                err,
+              );
+            }
+
             while (true) {
               const progressResponse = await fetchProgress(id);
 
@@ -192,7 +205,6 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
                   toast.success(t('assets_fetch_success'), {
                     toastId: 'assets-success',
                   });
-                  setIsProcessLoading(false);
 
                   // Set the config attribute for loadedDataset and refreshDatasets list to update state
                   try {
@@ -200,6 +212,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
                     config.loadedDataset = id;
                     await saveConfig(config);
                     refreshDatasets?.();
+                    setIsProcessLoading(false);
                   } catch (err) {
                     console.error(
                       'Error updating loadedDataset in config:',

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,96 +1,10 @@
-"use client";
+import ClientLayout from './client-layout';
+import React from 'react';
 
-import React, { useState, useEffect } from 'react';
-import MapView from './components/MapView';
-import Sidebar from './components/Sidebar';
-import SettingsPanel from './components/SettingsPanel';
-import AvailableDatasets, { DatasetMetadata } from './components/AvailableDatasets';
-import MapMetaData from './components/MapMetaData';
-import { I18nextProvider } from 'react-i18next';
-import i18n from './resources/i18n';
-import './layout.css';
-import { MapProvider } from './context/MapContext';
-import { fetchMetaData } from './services/api';
-import { ToastContainer } from 'react-toastify';
-
-const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [selectedDataset, setSelectedDataset] = useState<DatasetMetadata | null>(null);
-  const [refreshKey, setRefreshKey] = useState(0); // Add state for refresh key
-  const [isMetadataVisible, setMetadataVisible] = useState(false); // Add state for metadata visibility
-  const [currentBbox, setCurrentBbox] = useState<[number, number, number, number] | undefined>(undefined);
-  const WORLD_BBOX: [number, number, number, number] = [-180, -90, 180, 90];
-
-  // Handle dataset selection (no loading bar here)
-  const handleDatasetClick = (dataset: DatasetMetadata) => {
-    const selectedDatasetId = localStorage.getItem('selectedDatasetId')
-    if(selectedDatasetId !== dataset.id){
-      setSelectedDataset(dataset); // Just update the selected dataset
-      setMetadataVisible(true); // Show metadata container
-    } else {
-      setMetadataVisible(false)
-    }
-  };
-
-  // Handles loading the metadata if dataset is already selected on load
-  useEffect(() => {
-    const onLoadDataset = async () => {
-      const selectedDatasetId = localStorage.getItem('selectedDatasetId')
-      if(selectedDatasetId !== null && selectedDatasetId !== ''){
-        const dataset = await fetchMetaData(selectedDatasetId)
-        setSelectedDataset(dataset)
-        setMetadataVisible(true)
-      }
-    }
-
-    onLoadDataset();
-  }, [])
-
-  const refreshDatasets = () => {
-    setRefreshKey((prevKey) => prevKey + 1); // Increment refresh key to trigger re-render
-  };
-
-  return (
-    <I18nextProvider i18n={i18n}>
-      <MapProvider>
-        <html lang="en">
-        <body>
-        <ToastContainer/>
-        <SettingsPanel refreshDatasets={refreshDatasets} setMetadataVisible={setMetadataVisible} />
-        <div className="layout-container relative">
-          <main className="app-main">{children}</main>
-          <AvailableDatasets
-              onDatasetClick={handleDatasetClick}
-              refreshKey={refreshKey}
-              currentBbox={currentBbox ?? undefined}
-              onResetBbox={() => setCurrentBbox(WORLD_BBOX)}
-              />
-          <MapView onBboxChange={(bbox) => {
-              if (bbox && bbox.length === 4) {
-                setCurrentBbox(bbox as [number, number, number, number]);
-              }
-            }} />
-          <Sidebar />
-          {selectedDataset && (
-            <MapMetaData
-              id={selectedDataset.id}
-              name={selectedDataset.name}
-              description={selectedDataset.description}
-              format={selectedDataset.format}
-              processes={selectedDataset.processes}
-              datasetSource={selectedDataset.datasetSource}
-              onClose={() => setMetadataVisible(false)}
-              visible={isMetadataVisible} // Pass visibility state
-              refreshDatasets={refreshDatasets}
-            />
-          )}
-
-          <footer className="app-footer"></footer>
-        </div>
-        </body>
-        </html>
-      </MapProvider>
-    </I18nextProvider>
-  );
+export const metadata = {
+  title: 'WildfireVisualizationPlatform',
 };
 
-export default Layout;
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <ClientLayout>{children}</ClientLayout>;
+}

--- a/apps/frontend/src/app/styles/AssetsDropdown.css
+++ b/apps/frontend/src/app/styles/AssetsDropdown.css
@@ -62,6 +62,7 @@
 
 /* Assets List Container (Scrollable) */
 .assets-list-container {
+  position: relative;
   height: 120px;
   overflow-y: auto;
   padding: 6px 0;

--- a/sonar-project-frontend.properties
+++ b/sonar-project-frontend.properties
@@ -19,6 +19,7 @@ sonar.coverage.minimumCoverage=80
 
 # Exclude specific files from analysis
 sonar.exclusions=apps/frontend/src/app/layout.tsx
+sonar.exclusions=apps/frontend/src/app/client-layout.tsx
 
 # Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
### Summary

Implemented feedback from the user feedback gathered by Yasmine.

**Changes Made**

- #325: Added a check for the assets dropdown component so that it is only shown when loadedDatasetId is set and isProcessLoading is false. If a user slides the timeline, the sliderValue used for backend calls is now only updated once the user releases the timeline. This lessens load on backend service. There is now a loading spinner when the assets are loading into the weather assets dropdown menu.
- #326: Changed cancel to no in the popup for loading dataset
- #328: Changed the tab title to WildfireVisualizationPlatform. This required me to change the implementation of our current layout.tsx file.

**Testing Instructions**

- Build and run the app
- Ensure tab title is WildfireVisualizationPlatform
- Select any dataset, click Load Dataset.
- Ensure that the two options for the buttons are Yes and No, not Yes and Cancel
- Click Yes, once items and assets are loaded, ensure that assets menu dropdown does indeed load
- Play around with sliding the timeline, ensure that the assets menu is only updated when you release the timeline.