### PR TITLE
#333 - fix(backend): Fix asset processing logic to handle real results from `pgstac.items`

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -256,9 +256,9 @@ public class StacRepository {
   }
 
   /**
-   * 
+   *
    * Retrieves item IDs from the database, ordered by datetime ascending (UTC).*
-   * 
+   *
    * @return List of item IDs
    * @throws RepositoryException if a database error occurs
    */
@@ -383,6 +383,26 @@ public class StacRepository {
       throw new RepositoryException("Error fetching items for collection: " + collectionId, e);
     }
   }
+
+  /**
+   * Retrieves all items from the database
+   *
+   * @return List of maps containing item data
+   * @throws RepositoryException if a database error occurs
+   */
+  public List<Map<String, Object>> getAllItemsFromCollection(String collectionId) {
+    logger.debug("Fetching items for collection: {}", collectionId);
+    try {
+      String sql = "SELECT * FROM pgstac.items WHERE collection = ?";
+      List<Map<String, Object>> results = jdbcTemplate.queryForList(sql, collectionId);
+      logger.debug("Query returned {} results", results.size());
+      return results;
+    } catch (DataAccessException e) {
+      logger.error("Error fetching items: {}", e.getMessage(), e);
+      throw new RepositoryException("Error fetching items for collection: " + collectionId, e);
+    }
+  }
+
 
   /**
    * Method responsible for retrieving an item from the database

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -687,52 +687,59 @@ public class DataService {
   @Async
   public void processItemAssets(String collectionId) {
     String collectionProgressKey = collectionId + "_assets";
-    fetchProgress.put(collectionProgressKey, new AtomicInteger(0)); // Initialize progress
+    fetchProgress.put(collectionProgressKey, new AtomicInteger(0));
+
     try {
-      List<Map<String, Object>> results = stacRepository.getAllItems(collectionId);
-
+      List<Map<String, Object>> results = stacRepository.getAllItemsFromCollection(collectionId);
       if (results.isEmpty()) {
-        logger.warn("No results returned from getAllItems for collection {}", collectionId);
+        logger.warn("No items returned from getAllItems for collection {}", collectionId);
       }
 
-      // Extract JSON from the first (and only) row of the query
-      Object rawJson = results.get(0).get("search");
-      String json = "";
-      if (rawJson instanceof PGobject) {
-        json = ((PGobject) rawJson).getValue();
-      } else if (rawJson instanceof String) {
-        json = (String) rawJson;
-      } else {
-        logger.error("Unexpected JSON type: {}", rawJson.getClass().getSimpleName());
-      }
-
-      JsonNode root = objectMapper.readTree(json);
-      JsonNode features = root.get("features");
-
-      if (features == null || !features.isArray()) {
-        logger.warn("No features found in FeatureCollection");
-      }
-
-      int totalItems = features.size();
+      int totalItems = results.size();
       logger.info("Processing {} items in collection: {}", totalItems, collectionId);
 
       int count = 0;
+      for (Map<String, Object> row : results) {
+        String itemId = (String) row.get("id");
+        String collId = (String) row.get("collection");
+        String contentStr = null;
+        Object contentObj = row.get("content");
+        if (contentObj instanceof PGobject) {
+          contentStr = ((PGobject) contentObj).getValue();
+        } else if (contentObj instanceof String) {
+          // If the driver already gave you a string, just cast it
+          contentStr = (String) contentObj;
+        } else if (contentObj != null) {
+          // Fallback: you can do contentObj.toString(), or throw an error
+          logger.warn("Unexpected type for content column: {}", contentObj.getClass());
+          contentStr = contentObj.toString();
+        } else {
+          // Handle null
+          logger.warn("Null content column for item in collection {}", collectionId);
+          continue;
+        }
 
-      for (JsonNode feature : features) {
-        String itemId = feature.get("id").asText();
-        String collId = feature.get("collection").asText();  // Prefer the per-feature collection
+        // Now parse that as JSON
+        JsonNode contentNode = objectMapper.readTree(contentStr);
+        JsonNode assetsNode = contentNode.get("assets");
 
-        JsonNode assets = feature.get("assets");
-        if (assets == null || assets.isEmpty()) {
+        if (assetsNode == null || assetsNode.isEmpty()) {
           logger.info("No assets found for item {}", itemId);
           continue;
         }
 
-        for (Iterator<String> it = assets.fieldNames(); it.hasNext(); ) {
-          String assetKey = it.next();
-          JsonNode asset = assets.get(assetKey);
+        Iterator<String> fieldNames = assetsNode.fieldNames();
+        while (fieldNames.hasNext()) {
+          String assetKey = fieldNames.next();
+          JsonNode asset = assetsNode.get(assetKey);
           String href = asset.get("href").asText();
+
           JsonNode valueRange = asset.get("value_range");
+          if (valueRange == null || !valueRange.isArray() || valueRange.size() < 2) {
+            logger.warn("Invalid or missing value_range for asset {} of item {}", assetKey, itemId);
+            continue;
+          }
+
           int min = valueRange.get(0).asInt();
           int max = valueRange.get(1).asInt();
 
@@ -743,19 +750,19 @@ public class DataService {
         }
 
         count++;
-        fetchProgress.put(collectionProgressKey, new AtomicInteger((int) Math.floor(((double) count / totalItems) * 100)));
+        int progress = (int) (((double) count / totalItems) * 100);
+        fetchProgress.get(collectionProgressKey).set(progress);
         logger.info("Processed item {}/{}: {}", count, totalItems, itemId);
       }
 
       logger.info("Finished registering all assets in collection {}", collectionId);
-      // Optionally remove progress key or set to -1 or totalItems to indicate completion
-      fetchProgress.put(collectionProgressKey, new AtomicInteger(100));
-
+      fetchProgress.get(collectionProgressKey).set(100);
     } catch (Exception e) {
       logger.error("Exception while processing assets for collection {}: {}", collectionId, e.getMessage(), e);
-      fetchProgress.put(collectionProgressKey, new AtomicInteger(-1)); // Set error state
+      fetchProgress.put(collectionProgressKey, new AtomicInteger(-1));
     }
   }
+
 
   /**
    * Overloaded method to reset item assets with full reset as default.

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -1,9 +1,6 @@
 package wildfire.visualization.backend.repository;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -955,10 +952,10 @@ class StacRepositoryTests {
     );
     List<Map<String, Object>> mockResults = List.of(item);
 
-    when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
+    when(jdbcTemplate.queryForList(anyString(), eq(collectionId))).thenReturn(mockResults);
 
     // Act
-    List<Map<String, Object>> result = stacRepository.getAllItems(collectionId);
+    List<Map<String, Object>> result = stacRepository.getAllItemsFromCollection(collectionId);
 
     // Assert
     assertThat(result).hasSize(1);
@@ -969,13 +966,14 @@ class StacRepositoryTests {
   @Test
   void getAllItems_throwsRepositoryException_onJdbcError() {
     // Arrange
-    when(jdbcTemplate.queryForList(anyString()))
+    when(jdbcTemplate.queryForList(anyString(), Optional.ofNullable(any())))
       .thenThrow(new DataAccessException("Simulated DB error") {});
 
     // Act & Assert
-    assertThatThrownBy(() -> stacRepository.getAllItems("any_collection"))
+    assertThatThrownBy(() -> stacRepository.getAllItemsFromCollection("any_collection"))
       .isInstanceOf(RepositoryException.class)
       .hasMessageContaining("Error fetching items");
   }
+
 
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -945,4 +945,37 @@ class StacRepositoryTests {
     verify(jdbcTemplate).queryForList(anyString(), eq(String.class));
   }
 
+  @Test
+  void getAllItems_returnsItemsForCollection() {
+    // Arrange
+    String collectionId = "montreal_2023";
+    Map<String, Object> item = Map.of(
+      "id", "wildfire_timestamp_2023_08_30_12_00_00",
+      "collection", collectionId
+    );
+    List<Map<String, Object>> mockResults = List.of(item);
+
+    when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
+
+    // Act
+    List<Map<String, Object>> result = stacRepository.getAllItems(collectionId);
+
+    // Assert
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).get("id")).isEqualTo("wildfire_timestamp_2023_08_30_12_00_00");
+    assertThat(result.get(0).get("collection")).isEqualTo(collectionId);
+  }
+
+  @Test
+  void getAllItems_throwsRepositoryException_onJdbcError() {
+    // Arrange
+    when(jdbcTemplate.queryForList(anyString()))
+      .thenThrow(new DataAccessException("Simulated DB error") {});
+
+    // Act & Assert
+    assertThatThrownBy(() -> stacRepository.getAllItems("any_collection"))
+      .isInstanceOf(RepositoryException.class)
+      .hasMessageContaining("Error fetching items");
+  }
+
 }

--- a/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/service/DataServiceTests.java
@@ -1040,123 +1040,6 @@ class DataServiceTests {
   }
 
   @Test
-  void processItemAssets_shouldHandleEmptyResults() {
-    when(stacRepository.getAllItems("empty-collection")).thenReturn(List.of());
-
-    dataService.processItemAssets("empty-collection");
-
-    assertThat(dataService.getProgress("empty-collection_assets")).isEqualTo(-1); // completed without items
-  }
-
-  @Test
-  void processItemAssets_shouldHandleUnexpectedSearchType() {
-    Map<String, Object> mockRow = Map.of("search", 123); // Not PGobject or String
-    when(stacRepository.getAllItems("bad-search")).thenReturn(List.of(mockRow));
-
-    dataService.processItemAssets("bad-search");
-
-    assertThat(dataService.getProgress("bad-search_assets")).isEqualTo(-1); // No crash, handled gracefully
-  }
-
-  @Test
-  void processItemAssets_shouldHandleJsonParsingError() throws Exception {
-    PGobject pgObject = new PGobject();
-    pgObject.setValue("{ invalid json");
-
-    Map<String, Object> mockRow = Map.of("search", pgObject);
-    when(stacRepository.getAllItems("error-case")).thenReturn(List.of(mockRow));
-    when(objectMapper.readTree(anyString())).thenThrow(JsonProcessingException.class);
-
-    dataService.processItemAssets("error-case");
-
-    assertThat(dataService.getProgress("error-case_assets")).isEqualTo(-1); // Error state
-  }
-
-  @Test
-  void processItemAssets_shouldSkipFeaturesWithNoAssets() throws Exception {
-    PGobject pgObject = new PGobject();
-    pgObject.setValue("""
-          {
-            "features": [{
-              "id": "item-no-assets",
-              "collection": "collectionX",
-              "assets": {}
-            }]
-          }
-        """);
-
-    Map<String, Object> mockRow = Map.of("search", pgObject);
-    when(stacRepository.getAllItems("no-assets")).thenReturn(List.of(mockRow));
-
-    dataService.processItemAssets("no-assets");
-
-    assertThat(dataService.getProgress("no-assets_assets")).isEqualTo(-1);
-    verifyNoInteractions(geoTIFFService);
-  }
-
-  @Test
-  void processItemAssets_ShouldProcessAssetsForEachFeature() throws Exception {
-    // Arrange
-    String collectionId = "test-collection";
-    String itemId = "item1";
-    String assetKey = "B01";
-    String href = "https://somehost.com/asset1.tif";
-    int min = 0;
-    int max = 100;
-
-    // Build the JSON string to simulate the "search" PGobject
-    String json = String.format("""
-        {
-          "type": "FeatureCollection",
-          "features": [
-            {
-              "id": "%s",
-              "collection": "%s",
-              "assets": {
-                "%s": {
-                  "href": "%s",
-                  "value_range": [
-                    %d,
-                    %d
-                  ]
-                }
-              }
-            }
-          ]
-        }
-        """, itemId, collectionId, assetKey, href, min, max);
-
-    PGobject pgObject = new PGobject();
-    pgObject.setType("json");
-    pgObject.setValue(json);
-
-    Map<String, Object> row = Map.of("search", pgObject);
-    when(stacRepository.getAllItems(eq(collectionId))).thenReturn(List.of(row));
-
-    // Mock ObjectMapper to parse the JSON string
-    ObjectMapper realMapper = new ObjectMapper(); // Use real one to parse actual JSON
-    JsonNode rootNode = realMapper.readTree(json);
-    when(objectMapper.readTree(anyString())).thenReturn(rootNode);
-
-    // Ensure GeoTIFFService is mocked properly
-    when(geoTIFFService.processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max))).thenReturn(true);
-
-    // Act
-    dataService.processItemAssets(collectionId);
-
-    // Allow async execution to complete (adjust if needed)
-    Thread.sleep(150);
-
-    // Assert
-    verify(stacRepository).getAllItems(eq(collectionId));
-    verify(objectMapper).readTree(anyString());
-    verify(geoTIFFService).processGeoTIFF(eq(itemId), eq(collectionId), eq(assetKey), eq(href), eq(min), eq(max));
-
-    // Check progress is 100%
-    assertThat(dataService.getProgress(collectionId + "_assets")).isEqualTo(100);
-  }
-
-  @Test
   void getItemsIdsOrderedByTimestamp_Success() {
     // Arrange
     List<String> expectedIds = List.of("item1", "item2", "item3");
@@ -1182,6 +1065,96 @@ class DataServiceTests {
         .hasMessageContaining("Failed to fetch item timestamps");
 
     verify(stacRepository, times(1)).getItemsIdsOrderedByTimestamp();
+  }
+
+  @Test
+  void processItemAssets_shouldHandleEmptyResults() {
+    when(stacRepository.getAllItemsFromCollection("empty-collection")).thenReturn(List.of());
+
+    dataService.processItemAssets("empty-collection");
+
+    assertThat(dataService.getProgress("empty-collection_assets")).isEqualTo(100);
+  }
+
+  @Test
+  void processItemAssets_shouldHandleUnexpectedContentType() {
+    Map<String, Object> row = Map.of("id", "item1", "collection", "coll1", "content", 123); // Not PGobject or String
+    when(stacRepository.getAllItemsFromCollection("coll1")).thenReturn(List.of(row));
+
+    dataService.processItemAssets("coll1");
+
+    assertThat(dataService.getProgress("coll1_assets")).isNotEqualTo(100);
+    verifyNoInteractions(geoTIFFService);
+  }
+
+
+  @Test
+  void processItemAssets_shouldHandleJsonParsingError() throws Exception {
+    PGobject pgObject = new PGobject();
+    pgObject.setValue("invalid json");
+
+    Map<String, Object> row = Map.of("id", "item1", "collection", "coll1", "content", pgObject);
+    when(stacRepository.getAllItemsFromCollection("coll1")).thenReturn(List.of(row));
+    when(objectMapper.readTree(anyString())).thenThrow(JsonProcessingException.class);
+
+    dataService.processItemAssets("coll1");
+
+    assertThat(dataService.getProgress("coll1_assets")).isEqualTo(-1);
+  }
+
+  @Test
+  void processItemAssets_shouldSkipItemsWithNoAssets() throws Exception {
+    String json = """
+        {
+          "assets": {}
+        }
+        """;
+
+    PGobject pgObject = new PGobject();
+    pgObject.setValue(json);
+
+    Map<String, Object> row = Map.of("id", "item1", "collection", "coll1", "content", pgObject);
+    when(stacRepository.getAllItemsFromCollection("coll1")).thenReturn(List.of(row));
+    when(objectMapper.readTree(anyString())).thenReturn(new ObjectMapper().readTree(json));
+
+    dataService.processItemAssets("coll1");
+
+    assertThat(dataService.getProgress("coll1_assets")).isEqualTo(100);
+    verifyNoInteractions(geoTIFFService);
+  }
+
+  @Test
+  void processItemAssets_shouldProcessValidAssets() throws Exception {
+    String itemId = "item1";
+    String collId = "coll1";
+    String assetKey = "wind_force";
+    String href = "http://some.url/asset.tif";
+    int min = 0, max = 100;
+
+    String json = String.format("""
+        {
+          "assets": {
+            "%s": {
+              "href": "%s",
+              "value_range": [%d, %d]
+            }
+          }
+        }
+        """, assetKey, href, min, max);
+
+    PGobject pgObject = new PGobject();
+    pgObject.setValue(json);
+
+    Map<String, Object> row = Map.of("id", itemId, "collection", collId, "content", pgObject);
+    when(stacRepository.getAllItemsFromCollection(collId)).thenReturn(List.of(row));
+    when(objectMapper.readTree(anyString())).thenReturn(new ObjectMapper().readTree(json));
+    when(geoTIFFService.processGeoTIFF(itemId, collId, assetKey, href, min, max)).thenReturn(true);
+
+    dataService.processItemAssets(collId);
+    Thread.sleep(200); // Let the async method finish
+
+    assertThat(dataService.getProgress(collId + "_assets")).isEqualTo(100);
+    verify(geoTIFFService).processGeoTIFF(itemId, collId, assetKey, href, min, max);
   }
 
 }


### PR DESCRIPTION
### **Summary**  
This PR refactors the `processItemAssets` method to correctly process each item in a collection using the actual structure returned by `pgstac.items`. Previously, we relied on a wrapper query with a single JSON `search` field, which was inefficient and brittle. Now, we handle each row/item individually, parse the embedded `content` JSON, and extract assets directly.

---

### **Changes Made**

-  Updated `processItemAssets(String collectionId)` to:
  - Use `stacRepository.getAllItemsFromCollection()` which returns one row per item.
  - Parse the `content` field correctly using `PGobject.getValue()` to retrieve raw JSON.
  - Loop through and process each asset per item using existing `geoTIFFService`.
  - Safely extract fields like `href` and `value_range` from the JSON structure.
  - Handle edge cases: missing `value_range`, no assets, malformed JSON, etc.
  - Track and update progress more accurately using `results.size()` as `totalItems`.


---

### **Why?**  
The previous implementation used a nonstandard `pgstac.search` query which returned a single aggregated JSON object. This made it difficult to track progress and introduced parsing complexity. By switching to `pgstac.items`, we now:
- Get one clean row per item.
- Avoid deeply nested parsing.
- Enable simpler and more accurate progress tracking.
- Reduce potential bugs related to JSON structure.

---

### **Test Coverage / Validation**
- Manual run confirms items are parsed correctly.
- Progress bar now reaches 100% accurately.
- Logs show asset processing and fallbacks working as expected.
