### PR TITLE
#315 - hotfix(backend) - Added `title` parameter to the returned collections

### DIFF
--- a/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/repository/StacRepository.java
@@ -187,7 +187,7 @@ public class StacRepository {
 
       // Validate and apply ordering if provided
       if (!orderBy.isEmpty()) {
-        if (!Arrays.asList("id", "datetime").contains(orderBy)) {
+        if (!Arrays.asList("id", "datetime", "title").contains(orderBy)) {
           throw new RepositoryException("Invalid orderBy column: " + orderBy);
         }
         sql += " ORDER BY " + orderBy + " " + direction;
@@ -305,7 +305,7 @@ public class StacRepository {
    * @throws RepositoryException if a database error occurs
    */
   public List<Map<String, Object>> getAllCollectionsByName(double[] bbox, String sortDirection) {
-    return fetchCollections(bbox, "id", sortDirection);
+    return fetchCollections(bbox, "title", sortDirection);
   }
 
   /**

--- a/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
+++ b/apps/backend/src/main/java/wildfire/visualization/backend/service/DataService.java
@@ -290,6 +290,7 @@ public class DataService {
         .map(collection -> Map.of(
           "key", collection.get("key"),
           "id", collection.get("id"),
+          "title", collection.get("title") == null ? "" : collection.get("title"),
           "bbox", collection.getOrDefault("bbox", "[]") // Default empty bbox if null
         ))
         .collect(Collectors.toList());
@@ -328,6 +329,7 @@ public class DataService {
         .map(collection -> Map.of(
           "key", collection.get("key"),
           "id", collection.get("id"),
+          "title", collection.get("title") == null ? "" : collection.get("title"),
           "bbox", collection.getOrDefault("bbox", "[]") // Default empty bbox if null
         ))
         .collect(Collectors.toList());

--- a/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
+++ b/apps/backend/src/test/java/wildfire/visualization/backend/repository/StacRepositoryTests.java
@@ -303,15 +303,15 @@ class StacRepositoryTests {
   @Test
   void getAllCollectionsByName_Success_NoBbox() {
     List<Map<String, Object>> mockResults = List.of(
-        Map.of("id", "collection1"),
-        Map.of("id", "collection2"));
+        Map.of("title", "collection1"),
+        Map.of("title", "collection2"));
 
     when(jdbcTemplate.queryForList(anyString())).thenReturn(mockResults);
 
     List<Map<String, Object>> results = stacRepository.getAllCollectionsByName(null, "asc");
 
     assertThat(results).hasSize(2);
-    assertThat(results.get(0)).containsEntry("id", "collection1");
+    assertThat(results.get(0)).containsEntry("title", "collection1");
     verify(jdbcTemplate).queryForList(anyString());
   }
 
@@ -319,8 +319,8 @@ class StacRepositoryTests {
   void getAllCollectionsByName_Success_WithBbox() {
     double[] bbox = { 10.0, 20.0, 30.0, 40.0 };
     List<Map<String, Object>> mockResults = List.of(
-        Map.of("id", "collection1"),
-        Map.of("id", "collection2"));
+        Map.of("title", "collection1"),
+        Map.of("title", "collection2"));
 
     when(jdbcTemplate.queryForList(anyString(), eq(bbox[0]), eq(bbox[1]), eq(bbox[2]), eq(bbox[3])))
         .thenReturn(mockResults);
@@ -328,7 +328,7 @@ class StacRepositoryTests {
     List<Map<String, Object>> results = stacRepository.getAllCollectionsByName(bbox, "asc");
 
     assertThat(results).hasSize(2);
-    assertThat(results.get(0)).containsEntry("id", "collection1");
+    assertThat(results.get(0)).containsEntry("title", "collection1");
     verify(jdbcTemplate).queryForList(anyString(), eq(bbox[0]), eq(bbox[1]), eq(bbox[2]), eq(bbox[3]));
   }
 


### PR DESCRIPTION
Related to issue #315 

### Summary
- Fixed Bug where the dataset name would not appear if we filter them.

**Changes Made**

- Backend: Added title parameter to the returned collection

**Testing Instructions**
- Build and run the app
- Select an endpoint
- Filter based on name or date
- See the names of the datasets are displayed

**Screenshots**
![image](https://github.com/user-attachments/assets/74ea5629-5a56-4af4-9195-2a6e66254e2c)
