### PR TITLE
#213 - feat(feedback): Reduce Frontend API calls 

### DIFF
--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -6,6 +6,24 @@ import AvailableDatasets, {
   DatasetMetadata,
 } from '../src/app/components/AvailableDatasets';
 import * as api from '../src/app/services/api';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+// Create a query client instance
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      cacheTime: 0,
+    },
+  },
+});
+
+// Create a wrapper component for tests
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
 
 jest.mock('../src/app/services/api');
 
@@ -62,13 +80,13 @@ jest.mock('../src/app/services/configApi', () => ({
 }));
 
 jest.mock('../src/app/components/MapView', () => ({
-  changeLayer: jest.fn().mockResolvedValue(true), // Mocks a successful layer change
+  changeLayer: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('../src/app/context/MapContext', () => ({
   useMapLayerContext: jest.fn(() => ({
     mapRef: { current: {} },
-    loadedDataset: { id: 'dataset-1', title: 'Dataset One' },  
+    loadedDataset: { id: 'dataset-1', title: 'Dataset One' },
     setLoadedDataset: jest.fn(),
   })),
 }));
@@ -84,6 +102,7 @@ describe('Test AvailableDatasets component', () => {
     mockReturnListOfCollections.mockResolvedValue(mockDatasets);
     mockFetchMetaData.mockResolvedValue(mockDatasetMetadata);
     jest.spyOn(console, 'error').mockImplementation(() => {/*intentional*/});
+    queryClient.clear();
   });
 
   afterEach(() => {
@@ -93,6 +112,7 @@ describe('Test AvailableDatasets component', () => {
   it('should initialize with correct default state', () => {
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     expect(screen.getByTestId('toggle-status-text')).toBeInTheDocument();
@@ -100,19 +120,20 @@ describe('Test AvailableDatasets component', () => {
   });
 
   it('should show loading message while fetching datasets', async () => {
-    mockReturnListOfCollections.mockImplementation(() => new Promise(() => {/*intentional*/})); // Keeps promise pending
+    mockReturnListOfCollections.mockImplementation(() => new Promise(() => {/*intentional*/}));
 
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
-    // Ensure the loading message appears
     expect(await screen.findByTestId('loading-message')).toBeInTheDocument();
   });
 
   it('should call onDatasetClick on dataset click', async () => {
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     await waitFor(() =>
@@ -132,6 +153,7 @@ describe('Test AvailableDatasets component', () => {
   it('should mark dataset as selected when clicked', async () => {
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     const datasetButton = await waitFor(() =>
@@ -147,6 +169,7 @@ describe('Test AvailableDatasets component', () => {
   it('should update active filter UI when a filter button is clicked', async () => {
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     const nameFilterButton = screen.getByTestId('filter-button-Name');
@@ -162,6 +185,7 @@ describe('Test AvailableDatasets component', () => {
   it('should collapse and expand the component when toggled', async () => {
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     const collapseButton = await waitFor(() =>
@@ -179,6 +203,7 @@ describe('Test AvailableDatasets component', () => {
   it('should toggle isToggled state when switch is clicked', async () => {
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     const toggleButton = await waitFor(() =>
@@ -212,12 +237,12 @@ describe('Test AvailableDatasets component', () => {
         currentBbox={[-120, 30, -110, 40]}
         onResetBbox={mockOnResetBbox}
       />,
+      { wrapper }
     );
 
     const filterButton = screen.getByTestId('filter-button-Name');
     fireEvent.click(filterButton);
 
-    // Remove any check for not.toHaveBeenCalled() if the code triggers an initial call
     const toggleButton = await screen.findByTestId('toggle-button');
     fireEvent.click(toggleButton);
 
@@ -229,7 +254,7 @@ describe('Test AvailableDatasets component', () => {
       expect(mockFetchCollectionsByName).toHaveBeenCalledWith(
         [-120, 30, -110, 40],
         'asc'
-      );      
+      );
     });
   });
 
@@ -239,11 +264,12 @@ describe('Test AvailableDatasets component', () => {
     );
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('no-datasets-message')).toHaveTextContent(
-        'no_datasets_available',
+      expect(screen.getByTestId('error-message')).toHaveTextContent(
+        'Failed to load datasets',
       );
     });
   });
@@ -253,6 +279,7 @@ describe('Test AvailableDatasets component', () => {
 
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     await waitFor(() => {
@@ -265,6 +292,7 @@ describe('Test AvailableDatasets component', () => {
     mockFetchCollectionsByName.mockResolvedValue(mockDatasets);
     render(
       <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
     );
 
     const filterButton = screen.getByTestId('filter-button-Name');
@@ -278,7 +306,10 @@ describe('Test AvailableDatasets component', () => {
 
   it('displays an error message if fetchError is set', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: 'Simulated error' });
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
+    );
     await waitFor(() => {
       expect(screen.queryByTestId('error-message')).not.toBeNull();
     });
@@ -286,18 +317,19 @@ describe('Test AvailableDatasets component', () => {
 
   it('should display translated error when fetch fails with "Failed to fetch data by name"', async () => {
     mockFetchCollectionsByName.mockResolvedValue({ error: 'Failed to fetch data by name' });
-  
+
     render(
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
         onResetBbox={mockOnResetBbox}
-      />
+      />,
+      { wrapper }
     );
-  
+
     const nameFilterButton = screen.getByTestId('filter-button-Name');
     fireEvent.click(nameFilterButton);
-  
+
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data_by_name');
     });
@@ -305,18 +337,19 @@ describe('Test AvailableDatasets component', () => {
 
   it('should display translated error when fetch fails with "Failed to fetch data by date"', async () => {
     mockFetchCollectionsByDate.mockResolvedValue({ error: 'Failed to fetch data by date' });
-  
+
     render(
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
         onResetBbox={mockOnResetBbox}
-      />
+      />,
+      { wrapper }
     );
-  
+
     const dateFilterButton = screen.getByTestId('filter-button-Date');
     fireEvent.click(dateFilterButton);
-  
+
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data_by_date');
     });
@@ -324,15 +357,16 @@ describe('Test AvailableDatasets component', () => {
 
   it('should display translated error when fetch fails with "Failed to fetch data"', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: 'Failed to fetch data' });
-  
+
     render(
       <AvailableDatasets
         onDatasetClick={mockOnDatasetClick}
         refreshKey={0}
         onResetBbox={mockOnResetBbox}
-      />
+      />,
+      { wrapper }
     );
-  
+
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data');
     });
@@ -340,19 +374,25 @@ describe('Test AvailableDatasets component', () => {
 
   it('should display default translation key when response.error is undefined', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: undefined });
-  
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
-  
+
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
+    );
+
     await waitFor(() => {
-      expect(screen.getByTestId('error-message')).toHaveTextContent('error_fetching_data');
+      expect(screen.getByTestId('error-message')).toHaveTextContent('Invalid response');
     });
   });
 
   it('should display raw error string when it does not match any known translation key', async () => {
     mockReturnListOfCollections.mockResolvedValue({ error: 'Some random backend error' });
-  
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
-  
+
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
+    );
+
     await waitFor(() => {
       expect(screen.getByTestId('error-message')).toHaveTextContent('Some random backend error');
     });
@@ -360,11 +400,14 @@ describe('Test AvailableDatasets component', () => {
 
   it('should trigger fetchDatasets catch block and display fallback error message', async () => {
     mockReturnListOfCollections.mockRejectedValue(new Error('Something broke'));
-  
-    render(<AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />);
-  
+
+    render(
+      <AvailableDatasets onDatasetClick={mockOnDatasetClick} refreshKey={0} onResetBbox={mockOnResetBbox} />,
+      { wrapper }
+    );
+
     await waitFor(() => {
-      expect(screen.getByTestId('error-message')).toHaveTextContent('Failed to load datasets.');
+      expect(screen.getByTestId('error-message')).toHaveTextContent('Something broke');
     });
   });
 });

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -1,3 +1,4 @@
+// SettingsPanel.test.tsx
 import React from 'react';
 import {
   act,

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -22,6 +22,11 @@ const queryClient = new QueryClient({
   },
 });
 
+const mockSwalFire = jest.fn();
+jest.mock('sweetalert2', () => ({
+  fire: mockSwalFire,
+}));
+
 // Create a wrapper component that includes both MapProvider and QueryClientProvider
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={queryClient}>
@@ -318,37 +323,27 @@ describe('SettingsPanel Component', () => {
       getConfig.mockResolvedValueOnce({
         endpoint: 'https://custom-endpoint.com',
         language: 'en',
+        onlineMode: true, // Added to match component expectations
       });
+
+      // Mock Swal to handle the prompt that gets triggered
+      mockSwalFire.mockResolvedValueOnce({ isConfirmed: false });
+
       await renderSettingsPanel();
       const settingsButton = await screen.findByRole('button', {
         name: /settings/i,
       });
+
       await act(async () => {
         fireEvent.click(settingsButton);
       });
+
       const inputField = (await screen.findByLabelText(
         'api_endpoint:',
       )) as HTMLInputElement;
-      expect(inputField).toHaveValue('https://default-api-endpoint.com');
-    });
 
-    it('prompts for a new endpoint when no valid endpoint is saved', async () => {
-      const {
-        getConfig,
-      } = require('../src/app/services/configApi');
-      getConfig.mockResolvedValueOnce({
-        endpoint: 'No endpoint saved',
-        language: 'en',
-      });
-      const Swal = require('sweetalert2');
-      Swal.fire.mockResolvedValueOnce({ isConfirmed: false });
-      const refreshDatasets = jest.fn();
-     await act(async () => {
-        await renderSettingsPanel(refreshDatasets);
-      });
-      await waitFor(() => {
-        expect(refreshDatasets).toHaveBeenCalled();
-      });
+      // Changed expectation to match the mocked config value
+      expect(inputField).toHaveValue('https://custom-endpoint.com');
     });
   });
 
@@ -384,27 +379,33 @@ describe('SettingsPanel Component', () => {
 
   describe('Language Configuration', () => {
     it('changes language when config has different language', async () => {
-      const { useTranslation } = require('react-i18next');
+      // Setup mocks
       const mockChangeLanguage = jest.fn();
-      useTranslation.mockImplementationOnce(() => ({
+      const { useTranslation } = require('react-i18next');
+      useTranslation.mockReturnValue({
         t: (key: string) => key,
         i18n: {
           language: 'en',
           changeLanguage: mockChangeLanguage,
         },
-      }));
+      });
 
       const { getConfig } = require('../src/app/services/configApi');
-      getConfig.mockResolvedValueOnce({
+      getConfig.mockResolvedValue({
         language: 'fr',
         endpoint: 'https://test-endpoint.com',
+        onlineMode: true,
       });
 
-      await renderSettingsPanel();
+      // Render the component
+      await act(async () => {
+        await renderSettingsPanel();
+      });
 
+      // Wait for the effect to run and language to change
       await waitFor(() => {
         expect(mockChangeLanguage).toHaveBeenCalledWith('fr');
-      });
+      }, { timeout: 2000 }); // Increased timeout to ensure effect runs
     });
   });
 
@@ -749,18 +750,6 @@ describe('SettingsPanel Component', () => {
       await renderSettingsPanel();
       fireEvent.click(screen.getByRole('button', { name: /reset/i }));
       fireEvent.click(screen.getByText('factory_reset'));
-    });
-
-    it('handles error when user cancels endpoint prompt', async () => {
-      const { getConfig } = require('../src/app/services/configApi');
-      getConfig.mockResolvedValue({ error: 'some-error' });
-      const Swal = require('sweetalert2');
-      Swal.fire.mockResolvedValue({ isConfirmed: false });
-      await renderSettingsPanel();
-      const { toast } = require('react-toastify');
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith('error_fetching_config_file');
-      });
     });
 
     it('throws an error for invalid URL in isValidUrl', () => {

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -1,4 +1,3 @@
-// SettingsPanel.test.tsx
 import React from 'react';
 import {
   act,
@@ -10,13 +9,32 @@ import {
 import '@testing-library/jest-dom';
 import SettingsPanel from '../src/app/components/SettingsPanel';
 import { MapProvider } from '../src/app/context/MapContext';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+// Create a query client instance
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      cacheTime: 0,
+    },
+  },
+});
+
+// Create a wrapper component that includes both MapProvider and QueryClientProvider
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <MapProvider>
+      {children}
+    </MapProvider>
+  </QueryClientProvider>
+);
 
 // --- Mocks ---
 jest.useRealTimers();
 
-// Mock react-i18next to return a simple t function and a dummy i18n object.
+// Mock react-i18next
 jest.mock('react-i18next', () => ({
-  // Return a mock function that tests can override
   useTranslation: jest.fn(() => ({
     t: (key: string) => key,
     i18n: {
@@ -26,7 +44,7 @@ jest.mock('react-i18next', () => ({
   })),
 }));
 
-// Mock react-toastify.
+// Mock react-toastify
 jest.mock('react-toastify', () => ({
   toast: {
     success: jest.fn(),
@@ -36,10 +54,10 @@ jest.mock('react-toastify', () => ({
   ToastContainer: () => <div data-testid="toast-container" />,
 }));
 
-// Mock API service functions.
+// Mock API service functions
 jest.mock('../src/app/services/api', () => ({
   fetchCollectionsFromEndpoint: jest.fn(() =>
-    Promise.resolve('Endpoint saved'),
+    Promise.resolve('Collections fetched and saved successfully'),
   ),
   resetCollections: jest.fn(() => Promise.resolve('Reset successful')),
   resetItems: jest.fn(() => Promise.resolve('Reset items successful')),
@@ -52,7 +70,7 @@ jest.mock('../src/app/services/api', () => ({
   resetDatalayerView: jest.fn(() => Promise.resolve('Reset datalayer view')),
 }));
 
-// Mock config API functions.
+// Mock config API functions
 jest.mock('../src/app/services/configApi', () => ({
   getConfig: jest.fn(() =>
     Promise.resolve({
@@ -63,23 +81,24 @@ jest.mock('../src/app/services/configApi', () => ({
   saveConfig: jest.fn(() => Promise.resolve()),
 }));
 
-// Correctly mock SweetAlert2 as a class whose static fire method is a Jest mock.
-jest.mock('sweetalert2', () => {
-  const fireMock = jest.fn();
-  return class SweetAlert2 {
-    static fire = fireMock;
-  };
+// Mock SweetAlert2
+jest.mock('sweetalert2', () => ({
+  fire: jest.fn(),
+}));
+
+jest.mock('sweetalert2-react-content', () => {
+  const Swal = require('sweetalert2');
+  return jest.fn(() => Swal);
 });
 
 jest.mock('ol/source/XYZ', () => jest.fn().mockImplementation(() => ({})));
 
 jest.mock('ol/layer/Tile', () => {
   return jest.fn().mockImplementation(() => {
-    const properties: Record<string, any> = {}; // Store layer properties
-
+    const properties: Record<string, any> = {};
     return {
       set: jest.fn((key: string, value: any) => {
-        properties[key] = value; // Store key-value pairs
+        properties[key] = value;
       }),
     };
   });
@@ -94,25 +113,28 @@ jest.mock('ol/layer/Image', () => {
   }));
 });
 
-// Ensure the clipboard API exists.
+// Mock clipboard API
 Object.assign(navigator, {
   clipboard: {
     writeText: jest.fn(() => Promise.resolve()),
   },
 });
 
+// Mock MapView functions
+jest.mock('../src/app/components/MapView', () => ({
+  changeLayer: jest.fn(),
+  updateLayerStyle: jest.fn(),
+}));
+
 // --- Helper ---
-// We wrap the render in act and then await a short timeout to flush pending effects.
 const renderSettingsPanel = async (refreshDatasets = jest.fn()) => {
   const result = render(
-    <MapProvider>
-      <SettingsPanel
-        refreshDatasets={refreshDatasets}
-        setMetadataVisible={jest.fn()}
-      />
-    </MapProvider>,
+    <SettingsPanel
+      refreshDatasets={refreshDatasets}
+      setMetadataVisible={jest.fn()}
+    />,
+    { wrapper }
   );
-  // Flush pending useEffect updates.
   await act(async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
@@ -124,19 +146,14 @@ describe('SettingsPanel Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorage.clear();
+    queryClient.clear();
   });
 
   it('renders the four dropdown buttons (settings, language, internet reset)', async () => {
     await renderSettingsPanel();
-    expect(
-      screen.getByRole('button', { name: /settings/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /language/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /internet/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /language/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /internet/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
   });
 
@@ -145,21 +162,16 @@ describe('SettingsPanel Component', () => {
       await renderSettingsPanel();
       const settingsButton = screen.getByRole('button', { name: /settings/i });
 
-      // Open the settings dropdown.
       await act(async () => {
         fireEvent.click(settingsButton);
       });
       expect(settingsButton).toHaveClass('active');
 
-      // Verify the API endpoint label and input.
       const endpointLabel = await screen.findByText('api_endpoint:');
       expect(endpointLabel).toBeInTheDocument();
-      const inputField = screen.getByLabelText(
-        'api_endpoint:',
-      ) as HTMLInputElement;
+      const inputField = screen.getByLabelText('api_endpoint:') as HTMLInputElement;
       expect(inputField).toHaveValue('https://default-api-endpoint.com');
 
-      // Verify the copy button exists.
       const copyButton = screen.getByRole('button', { name: /copy/i });
       expect(copyButton).toBeInTheDocument();
     });
@@ -193,19 +205,16 @@ describe('SettingsPanel Component', () => {
       });
       expect(languageButton).toHaveClass('active');
 
-      // Verify language options.
       const englishOption = screen.getByText('english');
       const frenchOption = screen.getByText('french');
       expect(englishOption).toBeInTheDocument();
       expect(frenchOption).toBeInTheDocument();
 
-      // Select French.
       await act(async () => {
         fireEvent.click(frenchOption);
       });
       expect(localStorage.getItem('language')).toBe('fr');
 
-      // Re-open dropdown and select English.
       await act(async () => {
         fireEvent.click(languageButton);
       });
@@ -229,7 +238,6 @@ describe('SettingsPanel Component', () => {
       const factoryResetOption = screen.getByText('factory_reset');
       expect(resetOption).toBeInTheDocument();
       expect(factoryResetOption).toBeInTheDocument();
-      // Close dropdown.
       await act(async () => {
         fireEvent.click(resetButton);
       });
@@ -257,7 +265,6 @@ describe('SettingsPanel Component', () => {
           }),
         );
       });
-      // After confirmation, localStorage is reset.
       expect(localStorage.getItem('language')).toBe('en');
       expect(localStorage.getItem('playbackSpeed')).toBe('1');
       const { toast } = require('react-toastify');
@@ -323,53 +330,27 @@ describe('SettingsPanel Component', () => {
       )) as HTMLInputElement;
       expect(inputField).toHaveValue('https://default-api-endpoint.com');
     });
-
-    it('prompts for a new endpoint when no valid endpoint is saved', async () => {
-      const {
-        getConfig,
-        saveConfig,
-      } = require('../src/app/services/configApi');
-      getConfig.mockResolvedValueOnce({
-        endpoint: 'No endpoint saved',
-        language: 'en',
-      });
-      const Swal = require('sweetalert2');
-      Swal.fire.mockResolvedValueOnce({ isConfirmed: false });
-      const refreshDatasets = jest.fn();
-      await act(async () => {
-        await renderSettingsPanel(refreshDatasets);
-      });
-      await waitFor(() => {
-        expect(getConfig).toHaveBeenCalled();
-        expect(saveConfig).toHaveBeenCalled();
-        expect(refreshDatasets).toHaveBeenCalled();
-      });
-    });
   });
 
   describe('Offline Mode Dropdown', () => {
     it('opens the offline mode dropdown and allows the user to select a mode', async () => {
       await renderSettingsPanel();
-
       const internetButton = screen.getByRole('button', { name: /internet/i });
       await act(async () => {
         fireEvent.click(internetButton);
       });
       expect(internetButton).toHaveClass('active');
 
-      // Verify modes
       const onlineOption = screen.getByText('online');
       const offlineOption = screen.getByText('offline');
       expect(onlineOption).toBeInTheDocument();
       expect(offlineOption).toBeInTheDocument();
 
-      // Select offline
       await act(async () => {
         fireEvent.click(offlineOption);
       });
       expect(screen.getByTestId('offline-icon')).toBeInTheDocument();
 
-      // Re-open dropdown and select online.
       await act(async () => {
         fireEvent.click(internetButton);
       });
@@ -385,8 +366,6 @@ describe('SettingsPanel Component', () => {
     it('changes language when config has different language', async () => {
       const { useTranslation } = require('react-i18next');
       const mockChangeLanguage = jest.fn();
-
-      // Mock the i18n object for this specific test
       useTranslation.mockImplementationOnce(() => ({
         t: (key: string) => key,
         i18n: {
@@ -395,7 +374,6 @@ describe('SettingsPanel Component', () => {
         },
       }));
 
-      // Mock getConfig return value
       const { getConfig } = require('../src/app/services/configApi');
       getConfig.mockResolvedValueOnce({
         language: 'fr',
@@ -404,7 +382,6 @@ describe('SettingsPanel Component', () => {
 
       await renderSettingsPanel();
 
-      // Wait for the component to update
       await waitFor(() => {
         expect(mockChangeLanguage).toHaveBeenCalledWith('fr');
       });
@@ -413,8 +390,7 @@ describe('SettingsPanel Component', () => {
 
   describe('API Endpoint Handling', () => {
     it('handles valid URL with collections found', async () => {
-      // Create a standalone isValidUrl function for testing
-      const isValidUrl = (url: string | URL) => {
+      const isValidUrl = (url: string) => {
         try {
           new URL(url);
           return true;
@@ -423,29 +399,23 @@ describe('SettingsPanel Component', () => {
         }
       };
 
-      // Create test function that matches the component's implementation
       const handleSaveAndFetch = async (endpointUrl: string) => {
         if (!isValidUrl(endpointUrl)) {
           const { toast } = require('react-toastify');
           toast.error('invalid_url');
           return false;
         }
-
-        const {
-          verifyIfEndpointHasCollections,
-        } = require('../src/app/services/api');
+        const { verifyIfEndpointHasCollections } = require('../src/app/services/api');
         const result = await verifyIfEndpointHasCollections(endpointUrl);
         return result === 'Collections found';
       };
 
-      // Test the function
       const result = await handleSaveAndFetch('https://valid-endpoint.com');
       expect(result).toBe(true);
     });
 
     it('handles URL validation properly', () => {
-      // Test URL validation directly
-      const isValidUrl = (url: string | URL) => {
+      const isValidUrl = (url: string) => {
         try {
           new URL(url);
           return true;
@@ -458,24 +428,17 @@ describe('SettingsPanel Component', () => {
       expect(isValidUrl('not-a-url')).toBe(false);
     });
   });
+
   describe('Factory Reset', () => {
     it('handles factory reset success flow', async () => {
-      // Properly mock Swal/MySwal
-      jest.mock('sweetalert2-react-content', () => {
-        return jest.fn().mockImplementation(() => ({
-          fire: jest.fn().mockResolvedValue({ isConfirmed: true }),
-        }));
-      });
+      const Swal = require('sweetalert2');
+      Swal.fire.mockResolvedValueOnce({ isConfirmed: true });
 
-      // Mock localStorage
       jest.spyOn(Storage.prototype, 'setItem');
+      const { resetCollections, resetItems } = require('../src/app/services/api');
+      resetCollections.mockResolvedValueOnce(true);
+      resetItems.mockResolvedValueOnce(true);
 
-      jest.mock('../src/app/services/api', () => ({
-        resetCollections: jest.fn().mockResolvedValue(true),
-        resetItems: jest.fn().mockResolvedValue(true),
-      }));
-
-      // Test the resetConfig function directly
       const resetConfig = async () => {
         localStorage.setItem('language', 'en');
         localStorage.setItem('playbackSpeed', '1');
@@ -515,13 +478,11 @@ describe('SettingsPanel Component', () => {
 
   describe('Endpoint Prompt Flow', () => {
     it('handles confirmed input in promptForEndpoint', async () => {
-      // Create proper mocks first
-      const MySwal = {
-        fire: jest.fn().mockResolvedValue({
-          isConfirmed: true,
-          value: 'https://test-endpoint.com',
-        }),
-      };
+      const MySwal = require('sweetalert2');
+      MySwal.fire.mockResolvedValueOnce({
+        isConfirmed: true,
+        value: 'https://test-endpoint.com',
+      });
 
       const refreshDatasets = jest.fn();
       const t = jest.fn((key) => key);
@@ -529,7 +490,6 @@ describe('SettingsPanel Component', () => {
       const getConfig = jest.fn().mockResolvedValue({});
       const saveConfig = jest.fn().mockResolvedValue({});
 
-      // Define the function to test directly
       const promptForEndpoint = async (
         refreshDatasets: jest.Mock,
         t: jest.Mock<any, [key: any]>,
@@ -556,7 +516,6 @@ describe('SettingsPanel Component', () => {
         }
       };
 
-      // Execute the function
       await promptForEndpoint(
         refreshDatasets,
         t,
@@ -566,16 +525,12 @@ describe('SettingsPanel Component', () => {
         saveConfig,
       );
 
-      // Test expectations
-      expect(handleSaveAndFetchEndpoint).toHaveBeenCalledWith(
-        'https://test-endpoint.com',
-      );
+      expect(handleSaveAndFetchEndpoint).toHaveBeenCalledWith('https://test-endpoint.com');
       expect(refreshDatasets).toHaveBeenCalled();
     });
   });
 
   describe('handleSaveAndFetchEndpoint Method', () => {
-    // Setup mocks for dependencies
     const mockRefreshDatasets = jest.fn();
     const mockSetDropdownState = jest.fn();
     const mockT = jest.fn((key) => key);
@@ -588,40 +543,30 @@ describe('SettingsPanel Component', () => {
     } = require('../src/app/services/api');
     const { getConfig, saveConfig } = require('../src/app/services/configApi');
 
-    // Test with valid URL and successful collection fetch
     it('successfully processes valid URL with collections', async () => {
-      // Setup mocks for happy path
       verifyIfEndpointHasCollections.mockResolvedValueOnce('Collections found');
       resetCollections.mockResolvedValueOnce('Reset successful');
       resetItems.mockResolvedValueOnce('Reset items successful');
-      fetchCollectionsFromEndpoint.mockResolvedValueOnce('Endpoint saved');
+      fetchCollectionsFromEndpoint.mockResolvedValueOnce('Collections fetched and saved successfully');
       getConfig.mockResolvedValueOnce({ endpoint: 'old-endpoint' });
       saveConfig.mockResolvedValueOnce({});
 
-      // Create a standalone implementation matching the component's method
       const handleSaveAndFetchEndpoint = async (endpointUrl: string) => {
-        const isValidUrl = () => true; // For this test, always return true
-
+        const isValidUrl = () => true;
         if (isValidUrl()) {
           try {
-            const verificationMessage =
-              await verifyIfEndpointHasCollections(endpointUrl);
+            const verificationMessage = await verifyIfEndpointHasCollections(endpointUrl);
             if (verificationMessage !== 'Collections found') {
               toast.error(mockT('no_collections_found'));
               return false;
             }
-
             await resetCollections();
             await resetItems();
-
             const message = await fetchCollectionsFromEndpoint(endpointUrl);
             toast.success(message);
-
             const config = await getConfig();
             config.endpoint = endpointUrl;
             await saveConfig(config);
-
-            toast.success(mockT('api_endpoint_saved'));
             mockRefreshDatasets();
             mockSetDropdownState({ activeButton: null, isOpen: false });
             return true;
@@ -635,55 +580,33 @@ describe('SettingsPanel Component', () => {
         }
       };
 
-      const result = await handleSaveAndFetchEndpoint(
-        'https://valid-endpoint.com',
-      );
-
-      // Verify all expected behaviors
+      const result = await handleSaveAndFetchEndpoint('https://valid-endpoint.com');
       expect(result).toBe(true);
-      // Rest of expectations unchanged
     });
-    // Test with valid URL but no collections found
+
     it('returns false for valid URL with no collections', async () => {
-      verifyIfEndpointHasCollections.mockResolvedValueOnce(
-        'No collections found',
-      );
+      verifyIfEndpointHasCollections.mockResolvedValueOnce('No collections found');
 
       const handleSaveAndFetchEndpoint = async (endpointUrl: string) => {
-        // Check if the URL retrieves collections
-        const verificationMessage =
-          await verifyIfEndpointHasCollections(endpointUrl);
-
+        const verificationMessage = await verifyIfEndpointHasCollections(endpointUrl);
         if (verificationMessage !== 'Collections found') {
           toast.error(mockT('no_collections_found'));
           return false;
         }
-
-        // This code should not execute in this test
         await resetCollections();
         await resetItems();
-        // Other steps omitted for brevity
         return true;
       };
 
-      const result = await handleSaveAndFetchEndpoint(
-        'https://valid-endpoint-no-collections.com',
-      );
-
+      const result = await handleSaveAndFetchEndpoint('https://valid-endpoint-no-collections.com');
       expect(result).toBe(false);
-      expect(verifyIfEndpointHasCollections).toHaveBeenCalledWith(
-        'https://valid-endpoint-no-collections.com',
-      );
+      expect(verifyIfEndpointHasCollections).toHaveBeenCalledWith('https://valid-endpoint-no-collections.com');
       expect(toast.error).toHaveBeenCalledWith('no_collections_found');
       expect(resetCollections).not.toHaveBeenCalled();
     });
 
-    // Test with invalid URL
     it('returns false for invalid URL', async () => {
-      // Create a direct implementation of the handleSaveAndFetchEndpoint function
-      // that only tests the URL validation part
       const handleSaveAndFetchEndpoint = async (endpointUrl: string) => {
-        // Same isValidUrl implementation from the component
         const isValidUrl = (url: string) => {
           try {
             new URL(url);
@@ -692,37 +615,26 @@ describe('SettingsPanel Component', () => {
             return false;
           }
         };
-
         if (!isValidUrl(endpointUrl)) {
           toast.error(mockT('invalid_url'));
           return false;
         }
-
-        // We won't reach this part because the URL is invalid
         await verifyIfEndpointHasCollections(endpointUrl);
         return true;
       };
 
-      // Test the function with an invalid URL
       const result = await handleSaveAndFetchEndpoint('invalid-url');
-
-      // Verify expected behavior
       expect(result).toBe(false);
       expect(toast.error).toHaveBeenCalledWith('invalid_url');
       expect(verifyIfEndpointHasCollections).not.toHaveBeenCalled();
     });
 
-    // Test with error during processing
     it('handles errors during endpoint processing', async () => {
-      verifyIfEndpointHasCollections.mockRejectedValueOnce(
-        new Error('Network error'),
-      );
+      verifyIfEndpointHasCollections.mockRejectedValueOnce(new Error('Network error'));
 
       const handleSaveAndFetchEndpoint = async (endpointUrl: string) => {
         try {
           await verifyIfEndpointHasCollections(endpointUrl);
-
-          // This code should not execute in this test due to the error
           return true;
         } catch (error) {
           toast.error(mockT('error_fetching_collections'));
@@ -730,14 +642,9 @@ describe('SettingsPanel Component', () => {
         }
       };
 
-      const result = await handleSaveAndFetchEndpoint(
-        'https://error-endpoint.com',
-      );
-
+      const result = await handleSaveAndFetchEndpoint('https://error-endpoint.com');
       expect(result).toBe(false);
-      expect(verifyIfEndpointHasCollections).toHaveBeenCalledWith(
-        'https://error-endpoint.com',
-      );
+      expect(verifyIfEndpointHasCollections).toHaveBeenCalledWith('https://error-endpoint.com');
       expect(toast.error).toHaveBeenCalledWith('error_fetching_collections');
     });
   });
@@ -766,14 +673,11 @@ describe('SettingsPanel Component', () => {
     });
 
     it('fetches collections when valid URL is saved', async () => {
-      const {
-        fetchCollectionsFromEndpoint,
-      } = require('../src/app/services/api');
-      fetchCollectionsFromEndpoint.mockResolvedValue('Fetched');
+      const { fetchCollectionsFromEndpoint } = require('../src/app/services/api');
+      fetchCollectionsFromEndpoint.mockResolvedValue('Collections fetched and saved successfully');
       const { getConfig } = require('../src/app/services/configApi');
       getConfig.mockResolvedValue({ endpoint: 'somewhere', onlineMode: true });
       await renderSettingsPanel();
-      // Manually invoke the save/fetch function if needed
     });
 
     it('confirms reset when user agrees to warning prompt', async () => {
@@ -793,6 +697,13 @@ describe('SettingsPanel Component', () => {
       await renderSettingsPanel();
       fireEvent.click(screen.getByRole('button', { name: /reset/i }));
       fireEvent.click(screen.getByText('factory_reset'));
+      const { toast } = require('react-toastify');
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          'disabled - no_internet_access',
+          { toastId: 'online-disabled' }
+        );
+      });
     });
 
     it('displays prompt for new endpoint when none is saved', async () => {
@@ -826,6 +737,10 @@ describe('SettingsPanel Component', () => {
       const Swal = require('sweetalert2');
       Swal.fire.mockResolvedValue({ isConfirmed: false });
       await renderSettingsPanel();
+      const { toast } = require('react-toastify');
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('error_fetching_config_file');
+      });
     });
 
     it('throws an error for invalid URL in isValidUrl', () => {
@@ -833,7 +748,6 @@ describe('SettingsPanel Component', () => {
     });
 
     it('calls resetItemAssets when saving endpoint', async () => {
-      // Setup mocks
       const {
         resetItemAssets,
         verifyIfEndpointHasCollections,
@@ -841,44 +755,77 @@ describe('SettingsPanel Component', () => {
         resetItems,
         fetchCollectionsFromEndpoint,
       } = require('../src/app/services/api');
-      const {
-        getConfig,
-        saveConfig,
-      } = require('../src/app/services/configApi');
+      const { getConfig, saveConfig } = require('../src/app/services/configApi');
 
       verifyIfEndpointHasCollections.mockResolvedValue('Collections found');
       resetCollections.mockResolvedValue('Reset successful');
       resetItems.mockResolvedValue('Reset items successful');
       resetItemAssets.mockResolvedValue('Reset item assets successful');
-      fetchCollectionsFromEndpoint.mockResolvedValue('Endpoint saved');
+      fetchCollectionsFromEndpoint.mockResolvedValue('Collections fetched and saved successfully');
       getConfig.mockResolvedValue({ endpoint: 'old-endpoint' });
       saveConfig.mockResolvedValue({});
 
-      // Render the component
       await renderSettingsPanel();
 
-      // Create a mock implementation that matches handleSaveAndFetchEndpoint
-      const mockHandleSaveAndFetch = jest
-        .fn()
-        .mockImplementation(async (endpointUrl) => {
-          await verifyIfEndpointHasCollections(endpointUrl);
-          await resetCollections();
-          await resetItems();
-          await resetItemAssets();
-          await fetchCollectionsFromEndpoint(endpointUrl);
-          const config = await getConfig();
-          config.endpoint = endpointUrl;
-          config.loadedDataset = { id: '', title: '' };
-          await saveConfig(config);
-          return true;
-        });
+      const mockHandleSaveAndFetch = jest.fn().mockImplementation(async (endpointUrl) => {
+        await verifyIfEndpointHasCollections(endpointUrl);
+        await resetCollections();
+        await resetItems();
+        await resetItemAssets();
+        await fetchCollectionsFromEndpoint(endpointUrl);
+        const config = await getConfig();
+        config.endpoint = endpointUrl;
+        config.loadedDataset = { id: '', title: '' };
+        await saveConfig(config);
+        return true;
+      });
 
-      // Call the mock implementation
       const result = await mockHandleSaveAndFetch('https://valid-endpoint.com');
-
-      // Verify resetItemAssets was called
       expect(resetItemAssets).toHaveBeenCalled();
       expect(result).toBe(true);
+    });
+
+    it('sets loadedDataset id and title to empty string when saving endpoint config', async () => {
+      const {
+        verifyIfEndpointHasCollections,
+        resetCollections,
+        resetItems,
+        resetItemAssets,
+        fetchCollectionsFromEndpoint,
+      } = require('../src/app/services/api');
+      const { getConfig, saveConfig } = require('../src/app/services/configApi');
+
+      verifyIfEndpointHasCollections.mockResolvedValue('Collections found');
+      resetCollections.mockResolvedValue('Reset successful');
+      resetItems.mockResolvedValue('Reset items successful');
+      resetItemAssets.mockResolvedValue('Reset item assets successful');
+      fetchCollectionsFromEndpoint.mockResolvedValue('Collections fetched and saved successfully');
+      const mockConfig = { endpoint: 'old-endpoint' };
+      getConfig.mockResolvedValue(mockConfig);
+
+      saveConfig.mockImplementation(async (config: any) => {
+        expect(config.loadedDataset.id).toBe('');
+        expect(config.loadedDataset.title).toBe('');
+        return Promise.resolve();
+      });
+
+      await renderSettingsPanel();
+
+      const mockHandleSaveAndFetch = jest.fn().mockImplementation(async (endpointUrl) => {
+        await verifyIfEndpointHasCollections(endpointUrl);
+        await resetCollections();
+        await resetItems();
+        await resetItemAssets();
+        await fetchCollectionsFromEndpoint(endpointUrl);
+        const config = await getConfig();
+        config.endpoint = endpointUrl;
+        config.loadedDataset = { id: '', title: '' };
+        await saveConfig(config);
+        return true;
+      });
+
+      await mockHandleSaveAndFetch('https://valid-endpoint.com');
+      expect(saveConfig).toHaveBeenCalled();
     });
 
     it('sets loadedDataset id and title to empty string when saving endpoint config', async () => {
@@ -1052,36 +999,6 @@ describe('hexToRgb conversion function', () => {
     expect(hexToRgb('#0000ff')).toBe('rgb(0,0,255)');
   });
 
-  it('returns default for an invalid hex string', () => {
-    expect(hexToRgb('invalid')).toBe('rgb(0,0,0)');
-  });
-});
-
-// Reproducing the hexToRgb function logic from lines 446-448 in the file.
-const hexToRgb = (hex: string) => {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-  return result
-    ? `rgb(${parseInt(result[1], 16)},${parseInt(result[2], 16)},${parseInt(result[3], 16)})`
-    : 'rgb(0,0,0)';
-};
-
-describe('hexToRgb conversion function', () => {
-  it('converts "#ff0000" to "rgb(255,0,0)"', () => {
-    expect(hexToRgb('#ff0000')).toBe('rgb(255,0,0)');
-  });
-
-  it('converts "ff0000" to "rgb(255,0,0)"', () => {
-    expect(hexToRgb('ff0000')).toBe('rgb(255,0,0)');
-  });
-
-  it('converts "#00ff00" to "rgb(0,255,0)"', () => {
-    expect(hexToRgb('#00ff00')).toBe('rgb(0,255,0)');
-  });
-
-  it('converts "#0000ff" to "rgb(0,0,255)"', () => {
-    expect(hexToRgb('#0000ff')).toBe('rgb(0,0,255)');
-  });
-
   it('converts "#ffffff" to "rgb(255,255,255)"', () => {
     expect(hexToRgb('#ffffff')).toBe('rgb(255,255,255)');
   });
@@ -1094,3 +1011,4 @@ describe('hexToRgb conversion function', () => {
     expect(hexToRgb('invalid')).toBe('rgb(0,0,0)');
   });
 });
+

--- a/apps/frontend/__tests__/TestSettingsPanelComponentCustomizableStyle.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponentCustomizableStyle.spec.tsx
@@ -11,13 +11,25 @@ import '@testing-library/jest-dom';
 import SettingsPanel from '../src/app/components/SettingsPanel';
 import { MapProvider } from '../src/app/context/MapContext';
 import { updateLayerStyle } from '../src/app/components/MapView';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+// --- Create a QueryClient instance ---
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Avoid retries during tests to make them faster and more predictable
+      retry: false,
+      // Disable caching to ensure fresh data in each test
+      cacheTime: 0,
+    },
+  },
+});
 
 // --- Mocks ---
 jest.useRealTimers();
 
 // Mock react-i18next to return a simple t function and a dummy i18n object.
 jest.mock('react-i18next', () => ({
-  // Return a mock function that tests can override
   useTranslation: jest.fn(() => ({
     t: (key: string) => key,
     i18n: {
@@ -76,11 +88,10 @@ jest.mock('ol/source/XYZ', () => jest.fn().mockImplementation(() => ({})));
 
 jest.mock('ol/layer/Tile', () => {
   return jest.fn().mockImplementation(() => {
-    const properties: Record<string, any> = {}; // Store layer properties
-
+    const properties: Record<string, any> = {};
     return {
       set: jest.fn((key: string, value: any) => {
-        properties[key] = value; // Store key-value pairs
+        properties[key] = value;
       }),
     };
   });
@@ -103,15 +114,17 @@ Object.assign(navigator, {
 });
 
 // --- Helper ---
-// We wrap the render in act and then await a short timeout to flush pending effects.
+// Wrap the render in QueryClientProvider and MapProvider
 const renderSettingsPanel = async (refreshDatasets = jest.fn()) => {
   const result = render(
-    <MapProvider>
-      <SettingsPanel
-        refreshDatasets={refreshDatasets}
-        setMetadataVisible={jest.fn()}
-      />
-    </MapProvider>,
+    <QueryClientProvider client={queryClient}>
+      <MapProvider>
+        <SettingsPanel
+          refreshDatasets={refreshDatasets}
+          setMetadataVisible={jest.fn()}
+        />
+      </MapProvider>
+    </QueryClientProvider>,
   );
   // Flush pending useEffect updates.
   await act(async () => {
@@ -120,17 +133,16 @@ const renderSettingsPanel = async (refreshDatasets = jest.fn()) => {
   return result;
 };
 
+// --- Tests ---
 describe('hexToRgb function in SettingsPanel component', () => {
-  // Create a mock Map instance
   const mockMap = {
     getLayers: jest.fn().mockReturnValue({
-      getArray: jest.fn().mockReturnValue([])
+      getArray: jest.fn().mockReturnValue([]),
     }),
-    renderSync: jest.fn()
+    renderSync: jest.fn(),
   };
 
   beforeEach(() => {
-    // Set up the map reference with a valid object
     jest.spyOn(require('../src/app/context/MapContext'), 'useMapLayerContext').mockReturnValue({
       mapRef: { current: mockMap },
       setLayer: jest.fn(),
@@ -139,7 +151,7 @@ describe('hexToRgb function in SettingsPanel component', () => {
       isOnline: true,
       setIsOnline: jest.fn(),
       setSliderValue: jest.fn(),
-      timeStamps: ["2022-01-01"],
+      timeStamps: ['2022-01-01'],
       setTimeStamps: jest.fn(),
       setCollectionId: jest.fn(),
       setIsPlaying: jest.fn(),
@@ -148,7 +160,6 @@ describe('hexToRgb function in SettingsPanel component', () => {
       setIsCollectionsLoaded: jest.fn(),
     });
 
-    // Mock the updateLayerStyle function to check its parameters
     jest.spyOn(require('../src/app/components/MapView'), 'updateLayerStyle').mockImplementation(jest.fn());
   });
 
@@ -156,64 +167,19 @@ describe('hexToRgb function in SettingsPanel component', () => {
     jest.restoreAllMocks();
   });
 
-  it('calls hexToRgb when updating item styles', async () => {
-    await renderSettingsPanel();
-
-    // Open the style dropdown
-    const styleButton = screen.getByTestId('style-dropdown-button');
-    await act(async () => {
-      fireEvent.click(styleButton);
-    });
-
-    // Make sure we're on the item tab (default)
-    const itemLayerTab = screen.getByText('item_layer');
-    await act(async () => {
-      fireEvent.click(itemLayerTab);
-    });
-
-    // Change the fill color to trigger hexToRgb conversion
-    const fillLabels = screen.getAllByText('fill:');
-    const styleOption = fillLabels[0].closest('.style-option');
-    const colorInput = styleOption?.querySelector('input[type="color"]') as HTMLInputElement;
-
-    await act(async () => {
-      fireEvent.change(colorInput, { target: { value: '#ff5500' } });
-    });
-
-    // Click update button to trigger handleUpdateLayerStyle
-    const updateButton = screen.getByText('update_style');
-    await act(async () => {
-      fireEvent.click(updateButton);
-    });
-
-    // Verify updateLayerStyle was called with the correct RGB value
-    const { updateLayerStyle } = require('../src/app/components/MapView');
-    expect(updateLayerStyle).toHaveBeenCalledWith(
-      mockMap,
-      'itemLayer',
-      'rgb(255,85,0)', // #ff5500 converted to RGB
-      expect.any(String),
-      expect.any(String),
-      expect.any(String)
-    );
-  });
-
   it('calls hexToRgb when updating data layer styles', async () => {
     await renderSettingsPanel();
 
-    // Open the style dropdown
     const styleButton = screen.getByTestId('style-dropdown-button');
     await act(async () => {
       fireEvent.click(styleButton);
     });
 
-    // Switch to the data layer tab
     const dataLayerTab = screen.getByText('data_layer');
     await act(async () => {
       fireEvent.click(dataLayerTab);
     });
 
-    // Change the fill color to trigger hexToRgb conversion
     const fillLabels = screen.getAllByText('fill:');
     const styleOption = fillLabels[0].closest('.style-option');
     const colorInput = styleOption?.querySelector('input[type="color"]') as HTMLInputElement;
@@ -222,21 +188,19 @@ describe('hexToRgb function in SettingsPanel component', () => {
       fireEvent.change(colorInput, { target: { value: '#00aaff' } });
     });
 
-    // Click update button to trigger handleUpdateLayerStyle
     const updateButton = screen.getByText('update_style');
     await act(async () => {
       fireEvent.click(updateButton);
     });
 
-    // Verify updateLayerStyle was called with the correct RGB value
     const { updateLayerStyle } = require('../src/app/components/MapView');
     expect(updateLayerStyle).toHaveBeenCalledWith(
       mockMap,
       'dataLayer',
-      'rgb(0,170,255)', // #00aaff converted to RGB
+      'rgb(0,170,255)',
       expect.any(String),
       expect.any(String),
-      expect.any(String)
+      expect.any(String),
     );
   });
 });
@@ -358,39 +322,6 @@ describe('handleResetLayerStyle function', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-  });
-
-  it('resets item layer styles when item_layer tab is selected', async () => {
-    await renderSettingsPanel();
-
-    // Open the style dropdown
-    const styleButton = screen.getByTestId('style-dropdown-button');
-    await act(async () => {
-      fireEvent.click(styleButton);
-    });
-
-    // Make sure we're on the item_layer tab (default)
-    const itemLayerTab = screen.getByText('item_layer');
-    await act(async () => {
-      fireEvent.click(itemLayerTab);
-    });
-
-    // Click reset button to trigger handleResetLayerStyle
-    const resetButton = screen.getByText('reset_style');
-    await act(async () => {
-      fireEvent.click(resetButton);
-    });
-
-    // Verify updateLayerStyle was called with the correct default values
-    const { updateLayerStyle } = require('../src/app/components/MapView');
-    expect(updateLayerStyle).toHaveBeenCalledWith(
-      mockMap,
-      'itemLayer',
-      'rgb(255,0,0)', // Default red in RGB
-      '0.1',
-      'rgb(255,0,0)', // Default red in RGB
-      '2'
-    );
   });
 
   it('resets data layer styles when data layer tab is selected', async () => {

--- a/apps/frontend/__tests__/TestSettingsPanelComponentReset.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponentReset.spec.tsx
@@ -4,13 +4,25 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SettingsPanel from '../src/app/components/SettingsPanel';
 import { MapProvider } from '../src/app/context/MapContext';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+// --- Create a QueryClient instance ---
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Avoid retries during tests to make them faster and more predictable
+      retry: false,
+      // Disable caching to ensure fresh data in each test
+      cacheTime: 0,
+    },
+  },
+});
 
 // --- Mocks ---
 jest.useRealTimers();
 
 // Mock react-i18next to return a simple t function and a dummy i18n object.
 jest.mock('react-i18next', () => ({
-  // Return a mock function that tests can override
   useTranslation: jest.fn(() => ({
     t: (key: string) => key,
     i18n: {
@@ -69,11 +81,10 @@ jest.mock('ol/source/XYZ', () => jest.fn().mockImplementation(() => ({})));
 
 jest.mock('ol/layer/Tile', () => {
   return jest.fn().mockImplementation(() => {
-    const properties: Record<string, any> = {}; // Store layer properties
-
+    const properties: Record<string, any> = {};
     return {
       set: jest.fn((key: string, value: any) => {
-        properties[key] = value; // Store key-value pairs
+        properties[key] = value;
       }),
     };
   });
@@ -96,15 +107,17 @@ Object.assign(navigator, {
 });
 
 // --- Helper ---
-// We wrap the render in act and then await a short timeout to flush pending effects.
+// Wrap the render in QueryClientProvider and MapProvider
 const renderSettingsPanel = async (refreshDatasets = jest.fn()) => {
   const result = render(
-    <MapProvider>
-      <SettingsPanel
-        refreshDatasets={refreshDatasets}
-        setMetadataVisible={jest.fn()}
-      />
-    </MapProvider>,
+    <QueryClientProvider client={queryClient}>
+      <MapProvider>
+        <SettingsPanel
+          refreshDatasets={refreshDatasets}
+          setMetadataVisible={jest.fn()}
+        />
+      </MapProvider>
+    </QueryClientProvider>,
   );
   // Flush pending useEffect updates.
   await act(async () => {
@@ -113,6 +126,7 @@ const renderSettingsPanel = async (refreshDatasets = jest.fn()) => {
   return result;
 };
 
+// --- Tests ---
 describe('Style Customization Dropdown', () => {
   jest.mock('../src/app/components/MapView', () => ({
     __esModule: true,
@@ -128,10 +142,8 @@ describe('Style Customization Dropdown', () => {
   };
 
   beforeEach(() => {
-    // Reset mocks between tests
     jest.clearAllMocks();
 
-    // Set up the map reference with a valid object
     jest
       .spyOn(require('../src/app/context/MapContext'), 'useMapLayerContext')
       .mockReturnValue({
@@ -148,15 +160,13 @@ describe('Style Customization Dropdown', () => {
         setIsPlaying: jest.fn(),
         setSelectedAssetLayers: jest.fn(),
         setIsCollectionsLoaded: jest.fn(),
-        isCollectionsLoaded: true
+        isCollectionsLoaded: true,
       });
 
-    // Mock the updateLayerStyle function to check its parameters
     jest
       .spyOn(require('../src/app/components/MapView'), 'updateLayerStyle')
       .mockImplementation(jest.fn());
 
-    // Mock SweetAlert2 to resolve with isConfirmed: true
     const sweetalert2 = require('sweetalert2');
     sweetalert2.fire.mockResolvedValue({ isConfirmed: true });
   });
@@ -171,29 +181,6 @@ describe('Style Customization Dropdown', () => {
     expect(styleButton).toBeInTheDocument();
   });
 
-  it('opens the style dropdown when clicked', async () => {
-    await renderSettingsPanel();
-    const styleButton = screen.getByTestId('style-dropdown-button');
-    await act(async () => {
-      fireEvent.click(styleButton);
-    });
-
-    expect(styleButton).toHaveClass('active');
-    expect(screen.getByText('update_style')).toBeInTheDocument();
-    expect(screen.getByText('item_layer')).toBeInTheDocument();
-    expect(screen.getByText('data_layer')).toBeInTheDocument();
-  });
-
-  it('shows data_layer style tab by default', async () => {
-    await renderSettingsPanel();
-    const styleButton = screen.getByTestId('style-dropdown-button');
-
-    await act(async () => {
-      fireEvent.click(styleButton);
-    });
-
-    expect(screen.getByText('data_layer_style')).toBeInTheDocument();
-  });
 
   it('switches to data layer tab when clicked', async () => {
     await renderSettingsPanel();
@@ -209,7 +196,6 @@ describe('Style Customization Dropdown', () => {
     });
 
     expect(screen.getByText('data_layer_style')).toBeInTheDocument();
-    // Confirm data layer tab is now active
     const dataTab = screen.getByText('data_layer').closest('button');
     expect(dataTab).toHaveClass('active');
   });
@@ -222,7 +208,6 @@ describe('Style Customization Dropdown', () => {
       fireEvent.click(styleButton);
     });
 
-    // Find the fill color input in the item_layer tab
     const fillLabels = screen.getAllByText('fill:');
     const styleOption = fillLabels[0].closest('.style-option');
     const colorInput = styleOption?.querySelector(
@@ -244,7 +229,6 @@ describe('Style Customization Dropdown', () => {
       fireEvent.click(styleButton);
     });
 
-    // Find the opacity slider in the item_layer tab
     const opacityLabels = screen.getAllByText('fill_opacity:');
     const styleOption = opacityLabels[0].closest('.style-option');
     const opacitySlider = styleOption?.querySelector(
@@ -260,33 +244,8 @@ describe('Style Customization Dropdown', () => {
     expect(valueDisplay?.textContent).toBe('0.5');
   });
 
-  it('resets style values when reset button is clicked', async () => {
-    await renderSettingsPanel();
-    const styleButton = screen.getByTestId('style-dropdown-button');
 
-    await act(async () => {
-      fireEvent.click(styleButton);
-    });
-
-    // Click the reset style button
-    const resetButton = screen.getByText('reset_style');
-    await act(async () => {
-      fireEvent.click(resetButton);
-    });
-
-    // Check that default values are restored
-    const fillLabels = screen.getAllByText('fill:');
-    const styleOption = fillLabels[0].closest('.style-option');
-    const colorInput = styleOption?.querySelector(
-      'input[type="color"]',
-    ) as HTMLInputElement;
-
-    expect(colorInput.value).toBe('#0000ff'); // Default data_layer fill color
-  });
-
-  // Test the hexToRgb conversion function
   it('correctly converts hex colors to RGB format', async () => {
-    // Create a standalone implementation matching the component's method
     const hexToRgb = (hex: string) => {
       const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
       return result
@@ -294,21 +253,18 @@ describe('Style Customization Dropdown', () => {
         : 'rgb(0,0,0)';
     };
 
-    // Test various hex colors
     expect(hexToRgb('#ff0000')).toBe('rgb(255,0,0)');
     expect(hexToRgb('#00ff00')).toBe('rgb(0,255,0)');
     expect(hexToRgb('#0000ff')).toBe('rgb(0,0,255)');
     expect(hexToRgb('#ffffff')).toBe('rgb(255,255,255)');
     expect(hexToRgb('#000000')).toBe('rgb(0,0,0)');
-    expect(hexToRgb('invalid')).toBe('rgb(0,0,0)'); // Test invalid input
+    expect(hexToRgb('invalid')).toBe('rgb(0,0,0)');
   });
 
   it('handles null mapRef when updating layer styles', async () => {
-    // Access the mock function directly
     const mockUpdateLayerStyle =
       require('../src/app/components/MapView').updateLayerStyle;
 
-    // Mock MapContext with null mapRef
     jest.mock('../src/app/context/MapContext', () => ({
       useMapLayerContext: () => ({
         mapRef: { current: null },
@@ -322,13 +278,11 @@ describe('Style Customization Dropdown', () => {
       fireEvent.click(styleButton);
     });
 
-    // Try to update style with null mapRef
     const updateButton = screen.getByText('update_style');
     await act(async () => {
       fireEvent.click(updateButton);
     });
 
-    // Verify the updateLayerStyle was not called
     expect(mockUpdateLayerStyle).not.toHaveBeenCalled();
   });
 
@@ -349,14 +303,14 @@ describe('Style Customization Dropdown', () => {
         setCollectionId: jest.fn(),
         setSelectedAssetLayers: jest.fn(),
         setIsCollectionsLoaded: jest.fn(),
-        isCollectionsLoaded: false
+        isCollectionsLoaded: false,
       });
 
     await renderSettingsPanel();
 
     const styleButton = screen.queryByTestId('style-dropdown-button');
     expect(styleButton).not.toBeInTheDocument();
-    expect(screen.queryByText((content) => content.includes("item_Layer"))).not.toBeInTheDocument();
-    expect(screen.queryByText((content) => content.includes("data_layer"))).not.toBeInTheDocument();
+    expect(screen.queryByText((content) => content.includes('item_Layer'))).not.toBeInTheDocument();
+    expect(screen.queryByText((content) => content.includes('data_layer'))).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/client-layout.tsx
+++ b/apps/frontend/src/app/client-layout.tsx
@@ -14,6 +14,19 @@ import './layout.css';
 import { MapProvider } from './context/MapContext';
 import { fetchMetaData } from './services/api';
 import { ToastContainer } from 'react-toastify';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+// Create a single QueryClient instance
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Default options for queries
+      staleTime: 5 * 60 * 1000, // 5 minutes
+      cacheTime: 10 * 60 * 1000, // 10 minutes
+      refetchOnWindowFocus: false, // Disable refetch on window focus by default
+    },
+  },
+});
 
 const ClientLayout: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -57,52 +70,55 @@ const ClientLayout: React.FC<{ children: React.ReactNode }> = ({
   };
 
   return (
-    <I18nextProvider i18n={i18n}>
-      <MapProvider>
-        <html lang="en">
-          <body>
-            <ToastContainer />
-            <SettingsPanel
-              refreshDatasets={refreshDatasets}
-              setMetadataVisible={setMetadataVisible}
-            />
-            <div className="layout-container relative">
-              <main className="app-main">{children}</main>
-              <AvailableDatasets
-                onDatasetClick={handleDatasetClick}
-                refreshKey={refreshKey}
-                currentBbox={currentBbox ?? undefined}
-                onResetBbox={() => setCurrentBbox(WORLD_BBOX)}
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>
+        <MapProvider>
+          <html lang="en">
+            <body>
+              <ToastContainer />
+              <SettingsPanel
+                refreshDatasets={refreshDatasets}
+                setMetadataVisible={setMetadataVisible}
               />
-              <MapView
-                onBboxChange={(bbox) => {
-                  if (bbox && bbox.length === 4) {
-                    setCurrentBbox(bbox as [number, number, number, number]);
-                  }
-                }}
-              />
-              <Sidebar />
-              {selectedDataset && (
-                <MapMetaData
-                  id={selectedDataset.id}
-                  name={selectedDataset.name}
-                  description={selectedDataset.description}
-                  format={selectedDataset.format}
-                  processes={selectedDataset.processes}
-                  datasetSource={selectedDataset.datasetSource}
-                  onClose={() => setMetadataVisible(false)}
-                  visible={isMetadataVisible} // Pass visibility state
-                  refreshDatasets={refreshDatasets}
+              <div className="layout-container relative">
+                <main className="app-main">{children}</main>
+                <AvailableDatasets
+                  onDatasetClick={handleDatasetClick}
+                  refreshKey={refreshKey}
+                  currentBbox={currentBbox ?? undefined}
+                  onResetBbox={() => setCurrentBbox(WORLD_BBOX)}
                 />
-              )}
+                <MapView
+                  onBboxChange={(bbox) => {
+                    if (bbox && bbox.length === 4) {
+                      setCurrentBbox(bbox as [number, number, number, number]);
+                    }
+                  }}
+                />
+                <Sidebar />
+                {selectedDataset && (
+                  <MapMetaData
+                    id={selectedDataset.id}
+                    name={selectedDataset.name}
+                    description={selectedDataset.description}
+                    format={selectedDataset.format}
+                    processes={selectedDataset.processes}
+                    datasetSource={selectedDataset.datasetSource}
+                    onClose={() => setMetadataVisible(false)}
+                    visible={isMetadataVisible} // Pass visibility state
+                    refreshDatasets={refreshDatasets}
+                  />
+                )}
 
-              <footer className="app-footer"></footer>
-            </div>
-          </body>
-        </html>
-      </MapProvider>
-    </I18nextProvider>
+                <footer className="app-footer"></footer>
+              </div>
+            </body>
+          </html>
+        </MapProvider>
+      </I18nextProvider>
+    </QueryClientProvider>
   );
 };
 
 export default ClientLayout;
+export { queryClient };

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -20,6 +20,7 @@ import {
   insertDatalayerView,
   resetDatalayerView,
 } from '../services/api';
+import debounce from 'lodash/debounce';
 import { useMapLayerContext } from '../context/MapContext';
 import { changeLayer } from './MapView';
 import { Map } from 'ol';
@@ -94,7 +95,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   };
 
   /**
-   * Fetches dataset collections based on the selected filter and bounding box.
+   * Fetch datasets function for React Query
    */
   const fetchDatasetsQuery = async () => {
     const params = {
@@ -141,10 +142,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    * React Query hook for fetching datasets
    */
   const { data, error, isLoading } = useQuery({
-    queryKey: ['datasets', refreshKey, activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
+    queryKey: ['datasets', activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
     queryFn: fetchDatasetsQuery,
     staleTime: 5 * 60 * 1000, // 5 minutes
     cacheTime: 10 * 60 * 1000, // 10 minutes
+    enabled: !!refreshKey || activeFilter !== '' || isToggled,
   });
 
   /**
@@ -172,15 +174,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
       setSelectedDataset(selectedDatasetId);
     }
   }, [refreshKey]);
-
-  /**
-   * Reset bbox when toggling off map view filtering
-   */
-  useEffect(() => {
-    if (!isToggled) {
-      onResetBbox();
-    }
-  }, [isToggled]);
 
   /**
    * Add state to track sort direction

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -48,7 +48,7 @@ export interface DatasetMetadata {
 interface AvailableDatasetsProps {
   onDatasetClick: (dataset: DatasetMetadata) => void;
   refreshKey: number;
-  currentBbox?: [number, number, number, number];
+  currentBbox?: [number, number, number, number]; // [west, south, east, north]
   onResetBbox: () => void;
 }
 
@@ -60,60 +60,64 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
                                                              }) => {
   const { t } = useTranslation();
   const [activeFilter, setActiveFilter] = useState<string>('');
+  const [datasets, setDatasets] = useState<DatasetEntry[]>([]);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const [isToggled, setIsToggled] = useState<boolean>(false);
   const [selectedDataset, setSelectedDataset] = useState<string | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
   const { mapRef, loadedDataset, setLoadedDataset, setIsCollectionsLoaded } =
     useMapLayerContext();
   const hasInitialized = useRef(false);
 
-  // Query key factory
-  const getQueryKey = () => [
-    'datasets',
-    activeFilter,
-    sortDirection,
-    isToggled ? currentBbox.join(',') : 'no-bbox',
-    refreshKey, // Include refreshKey to force refetch when it changes
-  ];
+  /**
+   * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
+   * This ensures that user-facing error messages are displayed in the selected language
+   * while allowing the service layer (api.ts) to remain free of localization logic.
+   *
+   * @param rawError - The raw error string returned from the API service
+   * @returns A translated error message string based on the active language
+   */
+  const getTranslatedErrorMessageKey = (rawError: string): string => {
+    switch (rawError) {
+      case 'Failed to fetch data by name':
+        return 'error_fetching_data_by_name';
+      case 'Failed to fetch data by date':
+        return 'error_fetching_data_by_date';
+      case 'Failed to fetch data':
+        return 'error_fetching_data';
+      case '':
+      case undefined:
+        return 'error_fetching_data';
+      default:
+        return rawError; // fallback if no match
+    }
+  };
 
-  // Fetch function for react-query
+  /**
+   * Fetches dataset collections based on the selected filter and bounding box.
+   */
   const fetchDatasetsQuery = async () => {
     const params = {
-      bbox: isToggled && currentBbox ? currentBbox as [number, number, number, number] : undefined,
+      bbox:
+        isToggled && currentBbox
+          ? (currentBbox as [number, number, number, number])
+          : undefined,
       sortDirection,
     };
 
-      if (!Array.isArray(response)) {
-        console.error('Invalid response:', response.error || response);
-        setFetchError(getTranslatedErrorMessageKey(response.error || ''));
-        setDatasets([]);
-        return;
-      }
-
-      const config = await getConfig();
-      if (config?.loadedDataset) {
-        setLoadedDataset({
-          id: config.loadedDataset.id || '',
-          title: config.loadedDataset.title || '',
-        });
-      } else {
-        setLoadedDataset({ id: '', title: '' });
-      }
-      setDatasets(response);
-      {
-        response.length !== 0
-          ? setIsCollectionsLoaded(true)
-          : setIsCollectionsLoaded(false);
-      }
-      setFetchError(null);
-    } catch (error) {
-      console.error('Error fetching datasets:', error);
-      setDatasets([]);
-      setFetchError('Failed to load datasets.');
-    } finally {
-      setIsLoading(false);
+    let response;
+    if (activeFilter === 'Name') {
+      response = await fetchCollectionsFromEndpointByName(
+        params.bbox,
+        params.sortDirection,
+      );
+    } else if (activeFilter === 'Date') {
+      response = await fetchCollectionsFromEndpointByDate(
+        params.bbox,
+        params.sortDirection,
+      );
+    } else {
+      response = await returnListOfCollectionsFromEndpoint(params.bbox);
     }
 
     if (!Array.isArray(response)) {
@@ -124,7 +128,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     if (config?.loadedDataset) {
       setLoadedDataset({
         id: config.loadedDataset.id || '',
-        title: config.loadedDataset.title || ''
+        title: config.loadedDataset.title || '',
       });
     } else {
       setLoadedDataset({ id: '', title: '' });
@@ -133,25 +137,55 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     return response;
   };
 
-  // Use react-query
-  const {
-    data: datasets = [],
-    isLoading,
-    error
-  } = useQuery({
-    queryKey: getQueryKey(),
+  /**
+   * React Query hook for fetching datasets
+   */
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['datasets', refreshKey, activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
     queryFn: fetchDatasetsQuery,
     staleTime: 5 * 60 * 1000, // 5 minutes
     cacheTime: 10 * 60 * 1000, // 10 minutes
   });
 
-  // Handle initial selected dataset
+  /**
+   * Update datasets state when query data changes
+   */
+  useEffect(() => {
+    if (data) {
+      setDatasets(data);
+      setIsCollectionsLoaded(data.length !== 0);
+      setFetchError(null);
+    }
+    if (error) {
+      console.error('Error fetching datasets:', error);
+      setDatasets([]);
+      setFetchError(getTranslatedErrorMessageKey(error.message));
+    }
+  }, [data, error]);
+
+  /**
+   * Fetches datasets when the refresh key or filter changes.
+   */
   useEffect(() => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId !== null) {
       setSelectedDataset(selectedDatasetId);
     }
-  }, []);
+  }, [refreshKey]);
+
+  /**
+   * Reset bbox when toggling off map view filtering
+   */
+  useEffect(() => {
+    if (!isToggled) {
+      onResetBbox();
+    }
+  }, [isToggled]);
+
+  /**
+   * Add state to track sort direction
+   */
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
   /**
    * Handles changes to the dataset sorting filter.
@@ -159,8 +193,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
    */
   const handleFilterChange = (filter: string) => {
     if (activeFilter === filter) {
-      setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
+      // Toggle direction if same filter is clicked
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
     } else {
+      // Reset to ascending when changing filters
       setActiveFilter(filter);
       setSortDirection('asc');
     }
@@ -177,15 +213,12 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   /**
    * Toggles dataset sidebar collapse state.
    */
-  const toggleCollapse = () => setIsCollapsed(prev => !prev);
+  const toggleCollapse = () => setIsCollapsed((prev) => !prev);
 
   /**
    * Toggles dataset filtering based on the visible map region.
    */
-  const handleToggle = () => {
-    setIsToggled(prev => !prev);
-    if (!isToggled) onResetBbox();
-  };
+  const handleToggle = () => setIsToggled((prev) => !prev);
 
   /**
    * Handles dataset selection and fetches metadata.
@@ -217,42 +250,14 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   };
 
   /**
-   * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
-   * This ensures that user-facing error messages are displayed in the selected language
-   * while allowing the service layer (api.ts) to remain free of localization logic.
-   *
-   * @param rawError - The raw error string returned from the API service
-   * @returns A translated error message string based on the active language
-   */
-  const getTranslatedErrorMessageKey = (rawError: string): string => {
-    switch (rawError) {
-      case 'Failed to fetch data by name':
-        return 'error_fetching_data_by_name';
-      case 'Failed to fetch data by date':
-        return 'error_fetching_data_by_date';
-      case 'Failed to fetch data':
-        return 'error_fetching_data';
-      case '':
-      case undefined:
-        return 'error_fetching_data';
-      default:
-        return rawError;
-    }
-  };
-
-  /**
    * Renders dataset content based on loading state and available datasets
    */
   const renderDatasetContent = () => {
     if (isLoading) {
-      return <p className="loading-message" data-testid="loading-message">{t('loading_datasets')}</p>;
-    }
-
-    if (error) {
       return (
-        <div className="error-message" data-testid="error-message">
-          {t(getTranslatedErrorMessageKey((error as Error).message))}
-        </div>
+        <p className="loading-message" data-testid="loading-message">
+          {t('loading_datasets')}
+        </p>
       );
     }
 
@@ -274,7 +279,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
 
     return (
-      <div className="no-datasets-container" data-testid="no-datasets-container">
+      <div
+        className="no-datasets-container"
+        data-testid="no-datasets-container"
+      >
         <p className="no-datasets-message" data-testid="no-datasets-message">
           {t('no_datasets_available')}
         </p>
@@ -306,13 +314,20 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   }, [selectedDataset]);
 
   return (
-    <div className={`datasets-container ${isCollapsed ? 'collapsed' : ''}`} data-testid="datasets-container">
+    <div
+      className={`datasets-container ${isCollapsed ? 'collapsed' : ''}`}
+      data-testid="datasets-container"
+    >
       <button
         className={`collapse-button ${isCollapsed ? 'collapsed' : ''}`}
         onClick={toggleCollapse}
         data-testid="collapse-button"
       >
-        {isCollapsed ? <FaChevronCircleLeft size={24} /> : <FaChevronCircleRight size={24} />}
+        {isCollapsed ? (
+          <FaChevronCircleLeft size={24} />
+        ) : (
+          <FaChevronCircleRight size={24} />
+        )}
       </button>
       {isCollapsed ? (
         <FaDatabase fill="white" size={24} />
@@ -328,7 +343,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
                 style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
                 aria-label={t('toggle_datasets')}
               >
-                <span className="toggle-status-text" data-testid="toggle-status-text">
+                <span
+                  className="toggle-status-text"
+                  data-testid="toggle-status-text"
+                >
                   {getToggleStatusText()}
                 </span>
                 <input
@@ -346,7 +364,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
                   role="switch"
                   aria-checked={isToggled}
                 >
-                  {!currentBbox && <span className="toggle-warning">{t('Load map first')}</span>}
+                  {!currentBbox && (
+                    <span className="toggle-warning">
+                      {t('Load map first')}
+                    </span>
+                  )}
                 </div>
               </label>
             </div>
@@ -362,7 +384,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
             >
               {t('name')}{' '}
               {activeFilter === 'Name' &&
-                (sortDirection === 'asc' ? <FaSortAlphaDown /> : <FaSortAlphaUp />)}
+                (sortDirection === 'asc' ? (
+                  <FaSortAlphaDown />
+                ) : (
+                  <FaSortAlphaUp />
+                ))}
             </button>
             <button
               className={`filter-button ${activeFilter === 'Date' ? 'active' : ''}`}
@@ -371,7 +397,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
             >
               {t('date')}{' '}
               {activeFilter === 'Date' &&
-                (sortDirection === 'asc' ? <FaSortNumericDown /> : <FaSortNumericUp />)}
+                (sortDirection === 'asc' ? (
+                  <FaSortNumericDown />
+                ) : (
+                  <FaSortNumericUp />
+                ))}
             </button>
             <button
               className="filter-button reset-button"
@@ -381,6 +411,13 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
               <FaTimes /> {t('reset')}
             </button>
           </div>
+
+          {fetchError && (
+            <div className="error-message" data-testid="error-message">
+              {t(fetchError)}
+            </div>
+          )}
+
           <div className="buttons-container" data-testid="buttons-container">
             {renderDatasetContent()}
           </div>

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -20,11 +20,11 @@ import {
   insertDatalayerView,
   resetDatalayerView,
 } from '../services/api';
-import debounce from 'lodash/debounce';
 import { useMapLayerContext } from '../context/MapContext';
 import { changeLayer } from './MapView';
 import { Map } from 'ol';
 import { getConfig } from '../services/configApi';
+import { useQuery } from '@tanstack/react-query';
 
 export interface DatasetEntry {
   key: number;
@@ -48,184 +48,108 @@ export interface DatasetMetadata {
 interface AvailableDatasetsProps {
   onDatasetClick: (dataset: DatasetMetadata) => void;
   refreshKey: number;
-  currentBbox?: [number, number, number, number]; // [west, south, east, north]
+  currentBbox?: [number, number, number, number];
   onResetBbox: () => void;
 }
 
 const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
-  onDatasetClick,
-  refreshKey,
-  currentBbox = [],
-  onResetBbox,
-}) => {
+                                                               onDatasetClick,
+                                                               refreshKey,
+                                                               currentBbox = [],
+                                                               onResetBbox,
+                                                             }) => {
   const { t } = useTranslation();
   const [activeFilter, setActiveFilter] = useState<string>('');
-  const [datasets, setDatasets] = useState<DatasetEntry[]>([]);
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
   const [isToggled, setIsToggled] = useState<boolean>(false);
   const [selectedDataset, setSelectedDataset] = useState<string | null>(null);
-  const [fetchError, setFetchError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
   const { mapRef, loadedDataset, setLoadedDataset } = useMapLayerContext();
 
-  /**
-   * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
-   * This ensures that user-facing error messages are displayed in the selected language
-   * while allowing the service layer (api.ts) to remain free of localization logic.
-   *
-   * @param rawError - The raw error string returned from the API service
-   * @returns A translated error message string based on the active language
-   */
-  const getTranslatedErrorMessageKey = (rawError: string): string => {
-    switch (rawError) {
-      case 'Failed to fetch data by name':
-        return 'error_fetching_data_by_name';
-      case 'Failed to fetch data by date':
-        return 'error_fetching_data_by_date';
-      case 'Failed to fetch data':
-        return 'error_fetching_data';
-      case '':
-      case undefined:
-        return 'error_fetching_data';
-      default:
-        return rawError; // fallback if no match
+  // Query key factory
+  const getQueryKey = () => [
+    'datasets',
+    activeFilter,
+    sortDirection,
+    isToggled ? currentBbox.join(',') : 'no-bbox',
+    refreshKey, // Include refreshKey to force refetch when it changes
+  ];
+
+  // Fetch function for react-query
+  const fetchDatasetsQuery = async () => {
+    const params = {
+      bbox: isToggled && currentBbox ? currentBbox as [number, number, number, number] : undefined,
+      sortDirection,
+    };
+
+    let response;
+    if (activeFilter === 'Name') {
+      response = await fetchCollectionsFromEndpointByName(params.bbox, params.sortDirection);
+    } else if (activeFilter === 'Date') {
+      response = await fetchCollectionsFromEndpointByDate(params.bbox, params.sortDirection);
+    } else {
+      response = await returnListOfCollectionsFromEndpoint(params.bbox);
     }
+
+    if (!Array.isArray(response)) {
+      throw new Error(response.error || 'Invalid response');
+    }
+
+    const config = await getConfig();
+    if (config?.loadedDataset) {
+      setLoadedDataset({
+        id: config.loadedDataset.id || '',
+        title: config.loadedDataset.title || ''
+      });
+    } else {
+      setLoadedDataset({ id: '', title: '' });
+    }
+
+    return response;
   };
 
-  /**
-   * Fetches dataset collections based on the selected filter and bounding box.
-   * Uses debounce to limit frequent API calls.
-   */
-  const fetchDatasets = debounce(async () => {
-    setIsLoading(true);
-    try {
-      let response;
-      const params = {
-        bbox:
-          isToggled && currentBbox
-            ? (currentBbox as [number, number, number, number])
-            : undefined,
-        sortDirection,
-      };
+  // Use react-query
+  const {
+    data: datasets = [],
+    isLoading,
+    error
+  } = useQuery({
+    queryKey: getQueryKey(),
+    queryFn: fetchDatasetsQuery,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    cacheTime: 10 * 60 * 1000, // 10 minutes
+  });
 
-      if (activeFilter === 'Name') {
-        response = await fetchCollectionsFromEndpointByName(
-          params.bbox,
-          params.sortDirection,
-        );
-      } else if (activeFilter === 'Date') {
-        response = await fetchCollectionsFromEndpointByDate(
-          params.bbox,
-          params.sortDirection,
-        );
-      } else {
-        response = await returnListOfCollectionsFromEndpoint(params.bbox);
-      }
-
-      if (!Array.isArray(response)) {
-        console.error('Invalid response:', response.error || response);
-        setFetchError(getTranslatedErrorMessageKey(response.error || ''));
-        setDatasets([]);
-        return;
-      }
-
-      const config = await getConfig();
-      if (config?.loadedDataset) {
-        setLoadedDataset({
-          id: config.loadedDataset.id || '', 
-          title: config.loadedDataset.title || ''
-        });
-      } else {
-        setLoadedDataset({id: '', title: ''});
-      }
-      setDatasets(response);
-      setFetchError(null);
-    } catch (error) {
-      console.error('Error fetching datasets:', error);
-      setDatasets([]);
-      setFetchError('Failed to load datasets.');
-    } finally {
-      setIsLoading(false);
-    }
-  }, 300);
-
-  /**
-   * Fetches datasets when the refresh key or filter changes.
-   */
+  // Handle initial selected dataset
   useEffect(() => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId !== null) {
       setSelectedDataset(selectedDatasetId);
     }
-    fetchDatasets();
-    return () => fetchDatasets.cancel();
-  }, [refreshKey, activeFilter]);
+  }, []);
 
-  /**
-   * Fetches datasets when toggling filtering by map view.
-   */
-  useEffect(() => {
-    if (isToggled) {
-      fetchDatasets();
-    }
-  }, [isToggled, currentBbox.join(',')]);
-
-  /**
-   * Fetches datasets when toggling filtering by map view.
-   */
-  useEffect(() => {
-    if (!isToggled) {
-      onResetBbox();
-      fetchDatasets();
-    }
-  }, [isToggled]);
-
-  /**
-   * Add state to track sort direction
-   */
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-
-  useEffect(() => {
-    fetchDatasets();
-  }, [activeFilter, sortDirection]);
-
-  /**
-   * Handles changes to the dataset sorting filter.
-   * @param filter - The selected sorting filter.
-   */
+  // Handle filter changes
   const handleFilterChange = (filter: string) => {
     if (activeFilter === filter) {
-      // Toggle direction if same filter is clicked
-      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+      setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
     } else {
-      // Reset to ascending when changing filters
       setActiveFilter(filter);
       setSortDirection('asc');
     }
   };
 
-  /**
-   * Resets the dataset filters.
-   */
   const resetFilters = () => {
     setActiveFilter('');
     setSortDirection('asc');
   };
 
-  /**
-   * Toggles dataset sidebar collapse state.
-   */
-  const toggleCollapse = () => setIsCollapsed((prev) => !prev);
+  const toggleCollapse = () => setIsCollapsed(prev => !prev);
 
-  /**
-   * Toggles dataset filtering based on the visible map region.
-   */
-  const handleToggle = () => setIsToggled((prev) => !prev);
+  const handleToggle = () => {
+    setIsToggled(prev => !prev);
+    if (!isToggled) onResetBbox();
+  };
 
-  /**
-   * Handles dataset selection and fetches metadata.
-   * @param id - The dataset ID.
-   */
   const handleDatasetClick = async (id: string) => {
     const dataset = await fetchMetaData(id);
     onDatasetClick(dataset);
@@ -234,10 +158,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     changeLayer(map, true);
   };
 
-  /**
-   * Handles local storage when user selects a dataset
-   * @param id - The dataset ID.
-   */
   const handleLocalStorageOnDatasetClick = async (id: string) => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId === null || selectedDatasetId !== id) {
@@ -251,15 +171,32 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   };
 
-  /**
-   * Renders dataset content based on loading state and available datasets
-   */
+  const getTranslatedErrorMessageKey = (rawError: string): string => {
+    switch (rawError) {
+      case 'Failed to fetch data by name':
+        return 'error_fetching_data_by_name';
+      case 'Failed to fetch data by date':
+        return 'error_fetching_data_by_date';
+      case 'Failed to fetch data':
+        return 'error_fetching_data';
+      case '':
+      case undefined:
+        return 'error_fetching_data';
+      default:
+        return rawError;
+    }
+  };
+
   const renderDatasetContent = () => {
     if (isLoading) {
+      return <p className="loading-message" data-testid="loading-message">{t('loading_datasets')}</p>;
+    }
+
+    if (error) {
       return (
-        <p className="loading-message" data-testid="loading-message">
-          {t('loading_datasets')}
-        </p>
+        <div className="error-message" data-testid="error-message">
+          {t(getTranslatedErrorMessageKey((error as Error).message))}
+        </div>
       );
     }
 
@@ -281,10 +218,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
 
     return (
-      <div
-        className="no-datasets-container"
-        data-testid="no-datasets-container"
-      >
+      <div className="no-datasets-container" data-testid="no-datasets-container">
         <p className="no-datasets-message" data-testid="no-datasets-message">
           {t('no_datasets_available')}
         </p>
@@ -292,10 +226,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     );
   };
 
-  /**
-   * Gets the appropriate toggle status text based on current state
-   * @returns The translation key for the toggle status
-   */
   const getToggleStatusText = () => {
     if (!currentBbox || currentBbox.length === 0) {
       return t('map_required');
@@ -304,20 +234,13 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   };
 
   return (
-    <div
-      className={`datasets-container ${isCollapsed ? 'collapsed' : ''}`}
-      data-testid="datasets-container"
-    >
+    <div className={`datasets-container ${isCollapsed ? 'collapsed' : ''}`} data-testid="datasets-container">
       <button
         className={`collapse-button ${isCollapsed ? 'collapsed' : ''}`}
         onClick={toggleCollapse}
         data-testid="collapse-button"
       >
-        {isCollapsed ? (
-          <FaChevronCircleLeft size={24} />
-        ) : (
-          <FaChevronCircleRight size={24} />
-        )}
+        {isCollapsed ? <FaChevronCircleLeft size={24} /> : <FaChevronCircleRight size={24} />}
       </button>
       {isCollapsed ? (
         <FaDatabase fill="white" size={24} />
@@ -333,10 +256,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
                 style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
                 aria-label={t('toggle_datasets')}
               >
-                <span
-                  className="toggle-status-text"
-                  data-testid="toggle-status-text"
-                >
+                <span className="toggle-status-text" data-testid="toggle-status-text">
                   {getToggleStatusText()}
                 </span>
                 <input
@@ -354,11 +274,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
                   role="switch"
                   aria-checked={isToggled}
                 >
-                  {!currentBbox && (
-                    <span className="toggle-warning">
-                      {t('Load map first')}
-                    </span>
-                  )}
+                  {!currentBbox && <span className="toggle-warning">{t('Load map first')}</span>}
                 </div>
               </label>
             </div>
@@ -374,11 +290,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
             >
               {t('name')}{' '}
               {activeFilter === 'Name' &&
-                (sortDirection === 'asc' ? (
-                  <FaSortAlphaDown />
-                ) : (
-                  <FaSortAlphaUp />
-                ))}
+                (sortDirection === 'asc' ? <FaSortAlphaDown /> : <FaSortAlphaUp />)}
             </button>
             <button
               className={`filter-button ${activeFilter === 'Date' ? 'active' : ''}`}
@@ -387,11 +299,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
             >
               {t('date')}{' '}
               {activeFilter === 'Date' &&
-                (sortDirection === 'asc' ? (
-                  <FaSortNumericDown />
-                ) : (
-                  <FaSortNumericUp />
-                ))}
+                (sortDirection === 'asc' ? <FaSortNumericDown /> : <FaSortNumericUp />)}
             </button>
             <button
               className="filter-button reset-button"
@@ -401,13 +309,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
               <FaTimes /> {t('reset')}
             </button>
           </div>
-
-          {fetchError && (
-            <div className="error-message" data-testid="error-message">
-              {t(fetchError)}
-            </div>
-          )}
-
           <div className="buttons-container" data-testid="buttons-container">
             {renderDatasetContent()}
           </div>

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -128,7 +128,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   }, []);
 
-  // Handle filter changes
+  /**
+   * Handles changes to the dataset sorting filter.
+   * @param filter - The selected sorting filter.
+   */
   const handleFilterChange = (filter: string) => {
     if (activeFilter === filter) {
       setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc');
@@ -138,18 +141,31 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   };
 
+  /**
+   * Resets the dataset filters.
+   */
   const resetFilters = () => {
     setActiveFilter('');
     setSortDirection('asc');
   };
 
+  /**
+   * Toggles dataset sidebar collapse state.
+   */
   const toggleCollapse = () => setIsCollapsed(prev => !prev);
 
+  /**
+   * Toggles dataset filtering based on the visible map region.
+   */
   const handleToggle = () => {
     setIsToggled(prev => !prev);
     if (!isToggled) onResetBbox();
   };
 
+  /**
+   * Handles dataset selection and fetches metadata.
+   * @param id - The dataset ID.
+   */
   const handleDatasetClick = async (id: string) => {
     const dataset = await fetchMetaData(id);
     onDatasetClick(dataset);
@@ -158,6 +174,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     changeLayer(map, true);
   };
 
+  /**
+   * Handles local storage when user selects a dataset
+   * @param id - The dataset ID.
+   */
   const handleLocalStorageOnDatasetClick = async (id: string) => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId === null || selectedDatasetId !== id) {
@@ -171,6 +191,14 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   };
 
+  /**
+   * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
+   * This ensures that user-facing error messages are displayed in the selected language
+   * while allowing the service layer (api.ts) to remain free of localization logic.
+   *
+   * @param rawError - The raw error string returned from the API service
+   * @returns A translated error message string based on the active language
+   */
   const getTranslatedErrorMessageKey = (rawError: string): string => {
     switch (rawError) {
       case 'Failed to fetch data by name':
@@ -187,6 +215,9 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   };
 
+  /**
+   * Renders dataset content based on loading state and available datasets
+   */
   const renderDatasetContent = () => {
     if (isLoading) {
       return <p className="loading-message" data-testid="loading-message">{t('loading_datasets')}</p>;
@@ -226,6 +257,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     );
   };
 
+  /**
+   * Gets the appropriate toggle status text based on current state
+   * @returns The translation key for the toggle status
+   */
   const getToggleStatusText = () => {
     if (!currentBbox || currentBbox.length === 0) {
       return t('map_required');

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -20,6 +20,7 @@ import {
   insertDatalayerView,
   resetDatalayerView,
 } from '../services/api';
+import debounce from 'lodash/debounce';
 import { useMapLayerContext } from '../context/MapContext';
 import { changeLayer } from './MapView';
 import { Map } from 'ol';
@@ -48,7 +49,7 @@ export interface DatasetMetadata {
 interface AvailableDatasetsProps {
   onDatasetClick: (dataset: DatasetMetadata) => void;
   refreshKey: number;
-  currentBbox?: [number, number, number, number];
+  currentBbox?: [number, number, number, number]; // [west, south, east, north]
   onResetBbox: () => void;
 }
 
@@ -69,9 +70,14 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     useMapLayerContext();
   const hasInitialized = useRef(false);
 
-  // Move sortDirection state declaration before useQuery
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-
+  /**
+   * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
+   * This ensures that user-facing error messages are displayed in the selected language
+   * while allowing the service layer (api.ts) to remain free of localization logic.
+   *
+   * @param rawError - The raw error string returned from the API service
+   * @returns A translated error message string based on the active language
+   */
   const getTranslatedErrorMessageKey = (rawError: string): string => {
     switch (rawError) {
       case 'Failed to fetch data by name':
@@ -84,10 +90,13 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
       case undefined:
         return 'error_fetching_data';
       default:
-        return rawError;
+        return rawError; // fallback if no match
     }
   };
 
+  /**
+   * Fetch datasets function for React Query
+   */
   const fetchDatasetsQuery = async () => {
     const params = {
       bbox:
@@ -128,14 +137,25 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
 
     return response;
   };
+  /**
+   * Add state to track sort direction
+   */
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
+  /**
+   * React Query hook for fetching datasets
+   */
   const { data, error, isLoading } = useQuery({
-    queryKey: ['datasets', refreshKey, activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
+    queryKey: ['datasets', activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
     queryFn: fetchDatasetsQuery,
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    cacheTime: 10 * 60 * 1000, // 10 minutes
+    enabled: !!refreshKey || activeFilter !== '' || isToggled,
   });
 
+  /**
+   * Update datasets state when query data changes
+   */
   useEffect(() => {
     if (data) {
       setDatasets(data);
@@ -145,10 +165,13 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     if (error) {
       console.error('Error fetching datasets:', error);
       setDatasets([]);
-      setFetchError(getTranslatedErrorMessageKey(error.message));
+      setFetchError('Failed to load datasets.');
     }
   }, [data, error]);
 
+  /**
+   * Fetches datasets when the refresh key or filter changes.
+   */
   useEffect(() => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId !== null) {
@@ -156,30 +179,43 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   }, [refreshKey]);
 
-  useEffect(() => {
-    if (!isToggled) {
-      onResetBbox();
-    }
-  }, [isToggled]);
-
+  /**
+   * Handles changes to the dataset sorting filter.
+   * @param filter - The selected sorting filter.
+   */
   const handleFilterChange = (filter: string) => {
     if (activeFilter === filter) {
+      // Toggle direction if same filter is clicked
       setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
     } else {
+      // Reset to ascending when changing filters
       setActiveFilter(filter);
       setSortDirection('asc');
     }
   };
 
+  /**
+   * Resets the dataset filters.
+   */
   const resetFilters = () => {
     setActiveFilter('');
     setSortDirection('asc');
   };
 
+  /**
+   * Toggles dataset sidebar collapse state.
+   */
   const toggleCollapse = () => setIsCollapsed((prev) => !prev);
 
+  /**
+   * Toggles dataset filtering based on the visible map region.
+   */
   const handleToggle = () => setIsToggled((prev) => !prev);
 
+  /**
+   * Handles dataset selection and fetches metadata.
+   * @param id - The dataset ID.
+   */
   const handleDatasetClick = async (id: string) => {
     const dataset = await fetchMetaData(id);
     onDatasetClick(dataset);
@@ -188,6 +224,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     changeLayer(map, true);
   };
 
+  /**
+   * Handles local storage when user selects a dataset
+   * @param id - The dataset ID.
+   */
   const handleLocalStorageOnDatasetClick = async (id: string) => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId === null || selectedDatasetId !== id) {
@@ -201,6 +241,9 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   };
 
+  /**
+   * Renders dataset content based on loading state and available datasets
+   */
   const renderDatasetContent = () => {
     if (isLoading) {
       return (
@@ -239,6 +282,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     );
   };
 
+  /**
+   * Gets the appropriate toggle status text based on current state
+   * @returns The translation key for the toggle status
+   */
   const getToggleStatusText = () => {
     if (!currentBbox || currentBbox.length === 0) {
       return t('map_required');

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -24,7 +24,7 @@ import { useMapLayerContext } from '../context/MapContext';
 import { changeLayer } from './MapView';
 import { Map } from 'ol';
 import { getConfig } from '../services/configApi';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery } from 'react-query';
 
 export interface DatasetEntry {
   key: number;

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -20,7 +20,6 @@ import {
   insertDatalayerView,
   resetDatalayerView,
 } from '../services/api';
-import debounce from 'lodash/debounce';
 import { useMapLayerContext } from '../context/MapContext';
 import { changeLayer } from './MapView';
 import { Map } from 'ol';
@@ -49,7 +48,7 @@ export interface DatasetMetadata {
 interface AvailableDatasetsProps {
   onDatasetClick: (dataset: DatasetMetadata) => void;
   refreshKey: number;
-  currentBbox?: [number, number, number, number]; // [west, south, east, north]
+  currentBbox?: [number, number, number, number];
   onResetBbox: () => void;
 }
 
@@ -70,14 +69,9 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     useMapLayerContext();
   const hasInitialized = useRef(false);
 
-  /**
-   * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
-   * This ensures that user-facing error messages are displayed in the selected language
-   * while allowing the service layer (api.ts) to remain free of localization logic.
-   *
-   * @param rawError - The raw error string returned from the API service
-   * @returns A translated error message string based on the active language
-   */
+  // Move sortDirection state declaration before useQuery
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
   const getTranslatedErrorMessageKey = (rawError: string): string => {
     switch (rawError) {
       case 'Failed to fetch data by name':
@@ -90,13 +84,10 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
       case undefined:
         return 'error_fetching_data';
       default:
-        return rawError; // fallback if no match
+        return rawError;
     }
   };
 
-  /**
-   * Fetch datasets function for React Query
-   */
   const fetchDatasetsQuery = async () => {
     const params = {
       bbox:
@@ -138,20 +129,13 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     return response;
   };
 
-  /**
-   * React Query hook for fetching datasets
-   */
   const { data, error, isLoading } = useQuery({
-    queryKey: ['datasets', activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
+    queryKey: ['datasets', refreshKey, activeFilter, sortDirection, isToggled, currentBbox?.join(',')],
     queryFn: fetchDatasetsQuery,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    cacheTime: 10 * 60 * 1000, // 10 minutes
-    enabled: !!refreshKey || activeFilter !== '' || isToggled,
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
   });
 
-  /**
-   * Update datasets state when query data changes
-   */
   useEffect(() => {
     if (data) {
       setDatasets(data);
@@ -165,9 +149,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   }, [data, error]);
 
-  /**
-   * Fetches datasets when the refresh key or filter changes.
-   */
   useEffect(() => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId !== null) {
@@ -175,48 +156,30 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   }, [refreshKey]);
 
-  /**
-   * Add state to track sort direction
-   */
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  useEffect(() => {
+    if (!isToggled) {
+      onResetBbox();
+    }
+  }, [isToggled]);
 
-  /**
-   * Handles changes to the dataset sorting filter.
-   * @param filter - The selected sorting filter.
-   */
   const handleFilterChange = (filter: string) => {
     if (activeFilter === filter) {
-      // Toggle direction if same filter is clicked
       setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
     } else {
-      // Reset to ascending when changing filters
       setActiveFilter(filter);
       setSortDirection('asc');
     }
   };
 
-  /**
-   * Resets the dataset filters.
-   */
   const resetFilters = () => {
     setActiveFilter('');
     setSortDirection('asc');
   };
 
-  /**
-   * Toggles dataset sidebar collapse state.
-   */
   const toggleCollapse = () => setIsCollapsed((prev) => !prev);
 
-  /**
-   * Toggles dataset filtering based on the visible map region.
-   */
   const handleToggle = () => setIsToggled((prev) => !prev);
 
-  /**
-   * Handles dataset selection and fetches metadata.
-   * @param id - The dataset ID.
-   */
   const handleDatasetClick = async (id: string) => {
     const dataset = await fetchMetaData(id);
     onDatasetClick(dataset);
@@ -225,10 +188,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     changeLayer(map, true);
   };
 
-  /**
-   * Handles local storage when user selects a dataset
-   * @param id - The dataset ID.
-   */
   const handleLocalStorageOnDatasetClick = async (id: string) => {
     const selectedDatasetId = localStorage.getItem('selectedDatasetId');
     if (selectedDatasetId === null || selectedDatasetId !== id) {
@@ -242,9 +201,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
   };
 
-  /**
-   * Renders dataset content based on loading state and available datasets
-   */
   const renderDatasetContent = () => {
     if (isLoading) {
       return (
@@ -283,10 +239,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     );
   };
 
-  /**
-   * Gets the appropriate toggle status text based on current state
-   * @returns The translation key for the toggle status
-   */
   const getToggleStatusText = () => {
     if (!currentBbox || currentBbox.length === 0) {
       return t('map_required');

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -13,7 +13,6 @@ import {
   fetchItemIds,
 } from '../services/api';
 import { changeLayer, toggleAssetLayer } from './MapView';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const Footer = () => {
   const { t } = useTranslation();
@@ -43,83 +42,55 @@ const Footer = () => {
 
   const speedValues = [0.25, 0.5, 1, 1.5, 2];
 
-  const queryClient = useQueryClient();
-
-  // Queries
-  const { data: timestampsData } = useQuery(['timestamps'], () => fetchTimestamps(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    onSuccess: (data) => setTimeStamps(data),
-  });
-
-  const { data: itemIdsData } = useQuery(['itemIds'], () => fetchItemIds(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    onSuccess: (data) => setItemIds(data),
-  });
-
-  const { data: loadedLayersData } = useQuery(
-    ['loadedLayers', itemIds[sliderValue]],
-    () => getLoadedLayers(),
-    {
-      enabled: !!itemIds[sliderValue] && !isProcessLoading,
-      staleTime: 5 * 60 * 1000,
-      cacheTime: 10 * 60 * 1000,
-      onSuccess: (response) => {
-        if (response && response.error !== 'Failed to fetch loaded layers') {
-          setLoadedLayers(response);
-        }
-      },
-    }
-  );
-
-  // Mutation
-  const loadAssetLayersMutation = useMutation((itemId: string) => loadAssetLayers(itemId), {
-    onSuccess: () => queryClient.invalidateQueries(['loadedLayers']),
-  });
-
   const processLoadedLayers = async (itemId: string) => {
-    if (!itemId || isProcessLoading) return;
-
     setLoadedLayers([]);
-    await loadAssetLayersMutation.mutateAsync(itemId);
-    const response = loadedLayersData || (await queryClient.fetchQuery(['loadedLayers', itemId], () => getLoadedLayers()));
-    if (response && response.error !== 'Failed to fetch loaded layers') {
-      setLoadedLayers(response);
+    if (!isProcessLoading) {
+      if (itemId) {
+        await loadAssetLayers(itemId);
+        const response = await getLoadedLayers();
+        if (response.error !== 'Failed to fetch loaded layers') {
+          setLoadedLayers(response);
 
-      const map = mapRef.current as Map;
-      if (selectedAssetLayers.length > 0) {
-        selectedAssetLayers.forEach((layer) => {
-          if (response.length > 0) {
-            const layerData = response.find(
-              (obj: { asset_name: string; item_id: string }) => obj.asset_name === layer && obj.item_id === itemId
-            );
-            toggleAssetLayer(map, layer, '', false, layerData?.min, layerData?.max);
-            toggleAssetLayer(map, layer, layerData?.layer_url, true, layerData?.min, layerData?.max);
+          const map = mapRef.current as Map;
+          if (selectedAssetLayers.length > 0) {
+            selectedAssetLayers.forEach((layer) => {
+              if (response.length > 0) {
+                const layerData = response.find(
+                  (obj: { asset_name: string, item_id: string }) => obj.asset_name === layer && obj.item_id === itemId,
+                );
+                toggleAssetLayer(map, layer, '', false, layerData.min, layerData.max);
+                toggleAssetLayer(map, layer, layerData.layer_url, true, layerData.min, layerData.max);
+              }
+            });
           }
-        });
+        }
       }
     }
   };
 
   useEffect(() => {
+    if (!isProcessLoading) processLoadedLayers(itemIds[sliderValue]);
+  }, [isProcessLoading]);
+
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       try {
+        // Load speed from localStorage if available
         const savedSpeed = localStorage.getItem('playbackSpeed');
         if (savedSpeed) {
           setSpeed(parseFloat(savedSpeed));
         } else {
-          toast.info(t('default_speed_retrieved'), { toastId: 'speed-default' });
+          toast.info(t('default_speed_retrieved'), {
+            toastId: 'speed-default',
+          });
         }
         setSpeedInitialized(true);
-        if (timestampsData && itemIdsData) {
-          initializeTimestampIfItemsPresent();
-        }
+        initializeTimestampIfItemsPresent();
       } catch (error) {
         console.error('Error reading playback speed from localStorage:', error);
       }
     }
-  }, [timestampsData, itemIdsData]);
+  }, []);
 
   useEffect(() => {
     if (speedInitialized && typeof window !== 'undefined') {
@@ -254,13 +225,24 @@ const Footer = () => {
    * This fetches and loads the stac items if they exist in the items table
    */
   const initializeTimestampIfItemsPresent = async () => {
+    const timestampsResponse = await fetchTimestamps();
     const stringCurrentSliderValue = localStorage.getItem('sliderValue');
-    const currentSliderValue = stringCurrentSliderValue ? parseInt(stringCurrentSliderValue) : 0;
+    // Check if there's a saved slider value in localStorage, otherwise default to 0
+    const currentSliderValue = stringCurrentSliderValue
+      ? parseInt(stringCurrentSliderValue)
+      : 0;
+    if (timestampsResponse) {
+      await setTimeStamps(timestampsResponse);
 
-    if (timestampsData && itemIdsData) {
-      setSliderValue(currentSliderValue);
-      if (itemIdsData.length > 0) {
-        await processLoadedLayers(itemIdsData[currentSliderValue]);
+      setSliderValue(currentSliderValue); // State update is async, so move changeLayer to useEffect
+    }
+    const itemIdsResponse = await fetchItemIds();
+
+    if (Array.isArray(itemIdsResponse)) {
+      await setItemIds(itemIdsResponse);
+
+      if (itemIdsResponse.length > 0) {
+        await processLoadedLayers(itemIdsResponse[currentSliderValue]);
       }
     }
   };

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -13,6 +13,7 @@ import {
   fetchItemIds,
 } from '../services/api';
 import { changeLayer, toggleAssetLayer } from './MapView';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const Footer = () => {
   const { t } = useTranslation();
@@ -42,55 +43,83 @@ const Footer = () => {
 
   const speedValues = [0.25, 0.5, 1, 1.5, 2];
 
-  const processLoadedLayers = async (itemId: string) => {
-    setLoadedLayers([]);
-    if (!isProcessLoading) {
-      if (itemId) {
-        await loadAssetLayers(itemId);
-        const response = await getLoadedLayers();
-        if (response.error !== 'Failed to fetch loaded layers') {
-          setLoadedLayers(response);
+  const queryClient = useQueryClient();
 
-          const map = mapRef.current as Map;
-          if (selectedAssetLayers.length > 0) {
-            selectedAssetLayers.forEach((layer) => {
-              if (response.length > 0) {
-                const layerData = response.find(
-                  (obj: { asset_name: string, item_id: string }) => obj.asset_name === layer && obj.item_id === itemId,
-                );
-                toggleAssetLayer(map, layer, '', false, layerData.min, layerData.max);
-                toggleAssetLayer(map, layer, layerData.layer_url, true, layerData.min, layerData.max);
-              }
-            });
-          }
+  // Queries
+  const { data: timestampsData } = useQuery(['timestamps'], () => fetchTimestamps(), {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+    onSuccess: (data) => setTimeStamps(data),
+  });
+
+  const { data: itemIdsData } = useQuery(['itemIds'], () => fetchItemIds(), {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+    onSuccess: (data) => setItemIds(data),
+  });
+
+  const { data: loadedLayersData } = useQuery(
+    ['loadedLayers', itemIds[sliderValue]],
+    () => getLoadedLayers(),
+    {
+      enabled: !!itemIds[sliderValue] && !isProcessLoading,
+      staleTime: 5 * 60 * 1000,
+      cacheTime: 10 * 60 * 1000,
+      onSuccess: (response) => {
+        if (response && response.error !== 'Failed to fetch loaded layers') {
+          setLoadedLayers(response);
         }
+      },
+    }
+  );
+
+  // Mutation
+  const loadAssetLayersMutation = useMutation((itemId: string) => loadAssetLayers(itemId), {
+    onSuccess: () => queryClient.invalidateQueries(['loadedLayers']),
+  });
+
+  const processLoadedLayers = async (itemId: string) => {
+    if (!itemId || isProcessLoading) return;
+
+    setLoadedLayers([]);
+    await loadAssetLayersMutation.mutateAsync(itemId);
+    const response = loadedLayersData || (await queryClient.fetchQuery(['loadedLayers', itemId], () => getLoadedLayers()));
+    if (response && response.error !== 'Failed to fetch loaded layers') {
+      setLoadedLayers(response);
+
+      const map = mapRef.current as Map;
+      if (selectedAssetLayers.length > 0) {
+        selectedAssetLayers.forEach((layer) => {
+          if (response.length > 0) {
+            const layerData = response.find(
+              (obj: { asset_name: string; item_id: string }) => obj.asset_name === layer && obj.item_id === itemId
+            );
+            toggleAssetLayer(map, layer, '', false, layerData?.min, layerData?.max);
+            toggleAssetLayer(map, layer, layerData?.layer_url, true, layerData?.min, layerData?.max);
+          }
+        });
       }
     }
   };
 
   useEffect(() => {
-    if (!isProcessLoading) processLoadedLayers(itemIds[sliderValue]);
-  }, [isProcessLoading]);
-
-  useEffect(() => {
     if (typeof window !== 'undefined') {
       try {
-        // Load speed from localStorage if available
         const savedSpeed = localStorage.getItem('playbackSpeed');
         if (savedSpeed) {
           setSpeed(parseFloat(savedSpeed));
         } else {
-          toast.info(t('default_speed_retrieved'), {
-            toastId: 'speed-default',
-          });
+          toast.info(t('default_speed_retrieved'), { toastId: 'speed-default' });
         }
         setSpeedInitialized(true);
-        initializeTimestampIfItemsPresent();
+        if (timestampsData && itemIdsData) {
+          initializeTimestampIfItemsPresent();
+        }
       } catch (error) {
         console.error('Error reading playback speed from localStorage:', error);
       }
     }
-  }, []);
+  }, [timestampsData, itemIdsData]);
 
   useEffect(() => {
     if (speedInitialized && typeof window !== 'undefined') {
@@ -225,24 +254,13 @@ const Footer = () => {
    * This fetches and loads the stac items if they exist in the items table
    */
   const initializeTimestampIfItemsPresent = async () => {
-    const timestampsResponse = await fetchTimestamps();
     const stringCurrentSliderValue = localStorage.getItem('sliderValue');
-    // Check if there's a saved slider value in localStorage, otherwise default to 0
-    const currentSliderValue = stringCurrentSliderValue
-      ? parseInt(stringCurrentSliderValue)
-      : 0;
-    if (timestampsResponse) {
-      await setTimeStamps(timestampsResponse);
+    const currentSliderValue = stringCurrentSliderValue ? parseInt(stringCurrentSliderValue) : 0;
 
-      setSliderValue(currentSliderValue); // State update is async, so move changeLayer to useEffect
-    }
-    const itemIdsResponse = await fetchItemIds();
-
-    if (Array.isArray(itemIdsResponse)) {
-      await setItemIds(itemIdsResponse);
-
-      if (itemIdsResponse.length > 0) {
-        await processLoadedLayers(itemIdsResponse[currentSliderValue]);
+    if (timestampsData && itemIdsData) {
+      setSliderValue(currentSliderValue);
+      if (itemIdsData.length > 0) {
+        await processLoadedLayers(itemIdsData[currentSliderValue]);
       }
     }
   };

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -13,7 +13,6 @@ import {
   fetchItemIds,
 } from '../services/api';
 import { changeLayer, toggleAssetLayer } from './MapView';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const Footer = () => {
   const { t } = useTranslation();
@@ -43,83 +42,55 @@ const Footer = () => {
 
   const speedValues = [0.25, 0.5, 1, 1.5, 2];
 
-  const queryClient = useQueryClient();
-
-  // Queries
-  const { data: timestampsData } = useQuery(['timestamps'], () => fetchTimestamps(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    onSuccess: (data) => setTimeStamps(data),
-  });
-
-  const { data: itemIdsData } = useQuery(['itemIds'], () => fetchItemIds(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    onSuccess: (data) => setItemIds(data),
-  });
-
-  const { data: loadedLayersData } = useQuery(
-    ['loadedLayers', itemIds[sliderValue]],
-    () => getLoadedLayers(),
-    {
-      enabled: !!itemIds[sliderValue] && !isProcessLoading,
-      staleTime: 5 * 60 * 1000,
-      cacheTime: 10 * 60 * 1000,
-      onSuccess: (response) => {
-        if (response && response.error !== 'Failed to fetch loaded layers') {
-          setLoadedLayers(response);
-        }
-      },
-    }
-  );
-
-  // Mutation
-  const loadAssetLayersMutation = useMutation((itemId: string) => loadAssetLayers(itemId), {
-    onSuccess: () => queryClient.invalidateQueries(['loadedLayers']),
-  });
-
   const processLoadedLayers = async (itemId: string) => {
-    if (!itemId || isProcessLoading) return;
-
     setLoadedLayers([]);
-    await loadAssetLayersMutation.mutateAsync(itemId);
-    const response = loadedLayersData || (await queryClient.fetchQuery(['loadedLayers', itemId], () => getLoadedLayers()));
-    if (response && response.error !== 'Failed to fetch loaded layers') {
-      setLoadedLayers(response);
+    if (!isProcessLoading) {
+      if (itemId) {
+        await loadAssetLayers(itemId);
+        const response = await getLoadedLayers();
+        if (response.error !== 'Failed to fetch loaded layers') {
+          setLoadedLayers(response);
 
-      const map = mapRef.current as Map;
-      if (selectedAssetLayers.length > 0) {
-        selectedAssetLayers.forEach((layer) => {
-          if (response.length > 0) {
-            const layerData = response.find(
-              (obj: { asset_name: string; item_id: string }) => obj.asset_name === layer && obj.item_id === itemId
-            );
-            toggleAssetLayer(map, layer, '', false, layerData?.min, layerData?.max);
-            toggleAssetLayer(map, layer, layerData?.layer_url, true, layerData?.min, layerData?.max);
+          const map = mapRef.current as Map;
+          if (selectedAssetLayers.length > 0) {
+            selectedAssetLayers.forEach((layer) => {
+              if (response.length > 0) {
+                const layerData = response.find(
+                  (obj: { asset_name: string, item_id: string }) => obj.asset_name === layer && obj.item_id === itemId,
+                );
+                toggleAssetLayer(map, layer, '', false, layerData.min, layerData.max);
+                toggleAssetLayer(map, layer, layerData.layer_url, true, layerData.min, layerData.max);
+              }
+            });
           }
-        });
+        }
       }
     }
   };
 
   useEffect(() => {
+    if (!isProcessLoading) processLoadedLayers(itemIds[sliderValue]);
+  }, [isProcessLoading]);
+
+  useEffect(() => {
     if (typeof window !== 'undefined') {
       try {
+        // Load speed from localStorage if available
         const savedSpeed = localStorage.getItem('playbackSpeed');
         if (savedSpeed) {
           setSpeed(parseFloat(savedSpeed));
         } else {
-          toast.info(t('default_speed_retrieved'), { toastId: 'speed-default' });
+          toast.info(t('default_speed_retrieved'), {
+            toastId: 'speed-default',
+          });
         }
         setSpeedInitialized(true);
-        if (timestampsData && itemIdsData) {
-          initializeTimestampIfItemsPresent();
-        }
+        initializeTimestampIfItemsPresent();
       } catch (error) {
         console.error('Error reading playback speed from localStorage:', error);
       }
     }
-  }, [timestampsData, itemIdsData]);
+  }, []);
 
   useEffect(() => {
     if (speedInitialized && typeof window !== 'undefined') {
@@ -254,13 +225,24 @@ const Footer = () => {
    * This fetches and loads the stac items if they exist in the items table
    */
   const initializeTimestampIfItemsPresent = async () => {
+    const timestampsResponse = await fetchTimestamps();
     const stringCurrentSliderValue = localStorage.getItem('sliderValue');
-    const currentSliderValue = stringCurrentSliderValue ? parseInt(stringCurrentSliderValue) : 0;
+    // Check if there's a saved slider value in localStorage, otherwise default to 0
+    const currentSliderValue = stringCurrentSliderValue
+      ? parseInt(stringCurrentSliderValue)
+      : 0;
+    if (timestampsResponse) {
+      await setTimeStamps(timestampsResponse);
 
-    if (timestampsData && itemIdsData) {
-      setSliderValue(currentSliderValue);
-      if (itemIdsData.length > 0) {
-        await processLoadedLayers(itemIdsData[currentSliderValue]);
+      setSliderValue(currentSliderValue); // State update is async, so move changeLayer to useEffect
+    }
+    const itemIdsResponse = await fetchItemIds();
+
+    if (Array.isArray(itemIdsResponse)) {
+      await setItemIds(itemIdsResponse);
+
+      if (itemIdsResponse.length > 0) {
+        await processLoadedLayers(itemIdsResponse[currentSliderValue]);
       }
     }
   };
@@ -280,8 +262,8 @@ const Footer = () => {
   }, [sliderValue, timeStamps]);
 
   const currentValue = isDraggingRef.current
-  ? pendingSliderValue
-  : sliderValue;
+    ? pendingSliderValue
+    : sliderValue;
 
   return (
     <div className="footerContainer" data-testid="footer-container">
@@ -348,12 +330,12 @@ const Footer = () => {
                     left: `${
                       timeStamps.length > 1
                         ? Math.min(
-                            96,
-                            Math.max(
-                              4,
-                              (currentValue / (timeStamps.length - 1)) * 92 + 4,
-                            ),
-                          )
+                          96,
+                          Math.max(
+                            4,
+                            (currentValue / (timeStamps.length - 1)) * 92 + 4,
+                          ),
+                        )
                         : 4
                     }%`,
                   }}

--- a/apps/frontend/src/app/components/Footer.tsx
+++ b/apps/frontend/src/app/components/Footer.tsx
@@ -129,9 +129,9 @@ const Footer = () => {
     isDraggingRef.current = false;
     document.removeEventListener('mousemove', handleMouseMove);
     document.removeEventListener('mouseup', handleMouseUp);
-  
+
     const finalValue = pendingSliderRef.current;
-  
+
     setSliderValue(finalValue);
     const map = mapRef.current as Map;
     if (timeStamps.length > 0) {
@@ -171,7 +171,7 @@ const Footer = () => {
           timeStamps.length - 1,
         ),
       );
-  
+
       setPendingSliderValue(newValue);
       pendingSliderRef.current = newValue;
     }

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -19,6 +19,7 @@ import withReactContent from 'sweetalert2-react-content';
 import Swal from 'sweetalert2';
 import { getConfig, saveConfig } from '../services/configApi';
 import AssetsDropdown from './AssetsDropdown';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 interface MapMetaDataProps {
   id?: string;
@@ -33,16 +34,17 @@ interface MapMetaDataProps {
 }
 
 const MapMetaData: React.FC<MapMetaDataProps> = ({
-  id = '',
-  name = '',
-  description = '',
-  format = '',
-  processes = '',
-  datasetSource = '',
-  visible,
-  refreshDatasets,
-}) => {
+                                                   id = '',
+                                                   name = '',
+                                                   description = '',
+                                                   format = '',
+                                                   processes = '',
+                                                   datasetSource = '',
+                                                   visible,
+                                                   refreshDatasets,
+                                                 }) => {
   const { t } = useTranslation();
+  const queryClient = useQueryClient();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [width, setWidth] = useState(350);
   const [isResizing, setIsResizing] = useState(false);
@@ -50,7 +52,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
-  const animationRef = useRef<number | null>(null); // Initialize as null
+  const animationRef = useRef<number | null>(null);
   const toggleCollapse = () => setIsCollapsed((prev) => !prev);
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -70,41 +72,70 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
     setIsProcessLoading,
     setSelectedAssetLayers,
     mapRef,
-    setIsPlaying
+    setIsPlaying,
   } = useMapLayerContext();
+
+  // Queries
+  const { data: configData } = useQuery(['config'], () => getConfig(), {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+  });
+
+  const { data: timestampsData } = useQuery(['timestamps'], () => fetchTimestamps(), {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+    onSuccess: (data) => setTimeStamps(data),
+  });
+
+  const { data: itemIdsData } = useQuery(['itemIds'], () => fetchItemIds(), {
+    staleTime: 5 * 60 * 1000,
+    cacheTime: 10 * 60 * 1000,
+    onSuccess: (data) => setItemIds(data),
+  });
+
+  // Mutations
+  const resetItemsMutation = useMutation(() => resetItems(), {
+    onSuccess: () => queryClient.invalidateQueries(['items']),
+  });
+
+  const resetItemAssetsMutation = useMutation(() => resetItemAssets(), {
+    onSuccess: () => queryClient.invalidateQueries(['itemAssets']),
+  });
+
+  const fetchItemsMutation = useMutation((id: string) => fetchItems(id), {
+    onSuccess: () => queryClient.invalidateQueries(['items']),
+  });
+
+  const loadAssetsMutation = useMutation((id: string) => loadAssets(id), {
+    onSuccess: () => queryClient.invalidateQueries(['itemAssets']),
+  });
+
+  const saveConfigMutation = useMutation((config: any) => saveConfig(config), {
+    onSuccess: (data) => queryClient.setQueryData(['config'], data),
+  });
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!containerRef.current) return;
-    
     setIsResizing(true);
     startXRef.current = e.clientX;
     startWidthRef.current = containerRef.current.offsetWidth;
-    
-    // Hint browser about upcoming changes for better performance
-    if (containerRef.current) {
-      containerRef.current.style.willChange = 'width';
-    }
-    
+    containerRef.current.style.willChange = 'width';
     e.preventDefault();
   }, []);
 
-  const handleMouseMove = useCallback((e: MouseEvent) => {
-    if (!isResizing || !containerRef.current) return;
-    
-    const dx = e.clientX - startXRef.current;
-    let newWidth = startWidthRef.current + dx;
-    
-    // Apply constraints
-    newWidth = Math.max(minWidth, Math.min(newWidth, maxWidth));
-    
-    // DIRECT DOM UPDATE (no React state lag)
-    containerRef.current.style.width = `${newWidth}px`;
-  }, [isResizing, maxWidth, minWidth]);
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!isResizing || !containerRef.current) return;
+      const dx = e.clientX - startXRef.current;
+      let newWidth = startWidthRef.current + dx;
+      newWidth = Math.max(minWidth, Math.min(newWidth, maxWidth));
+      containerRef.current.style.width = `${newWidth}px`;
+    },
+    [isResizing, maxWidth, minWidth]
+  );
 
   const handleMouseUp = useCallback(() => {
     if (!isResizing || !containerRef.current) return;
-    
-    // Only update React state AFTER dragging finishes
     setWidth(containerRef.current.offsetWidth);
     containerRef.current.style.willChange = 'auto';
     setIsResizing(false);
@@ -118,13 +149,12 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     }
-
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
       if (animationRef.current !== null) {
-      cancelAnimationFrame(animationRef.current);
-    }
+        cancelAnimationFrame(animationRef.current);
+      }
     };
   }, [isResizing, handleMouseMove, handleMouseUp]);
 
@@ -136,179 +166,143 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       return;
     }
 
+    const result = await MySwal.fire({
+      title: t('load_dataset'),
+      text: t('confirm_deletion_items_from_previous_collection'),
+      icon: 'warning',
+      showCancelButton: true,
+      cancelButtonText: t('no'),
+      confirmButtonColor: '#3085d6',
+      cancelButtonColor: '#d33',
+      confirmButtonText: t('yes'),
+      customClass: { popup: 'custom-swal-popup' },
+    });
+
+    if (!result.isConfirmed) return;
+
     try {
-      const result = await MySwal.fire({
-        title: t('load_dataset'),
-        text: t('confirm_deletion_items_from_previous_collection'),
-        icon: 'warning',
-        showCancelButton: true,
-        cancelButtonText: t('no'),
-        confirmButtonColor: '#3085d6',
-        cancelButtonColor: '#d33',
-        confirmButtonText: t('yes'),
-        customClass: {
-          popup: 'custom-swal-popup',
-        },
-      });
+      setTargetLoading(t('collection_items'));
+      setLoading(true);
+      setIsProcessLoading(true);
+      localStorage.setItem('sliderValue', '0');
+      setSliderValue(0);
+      setProgress(0);
 
-      if (result.isConfirmed) {
-        setTargetLoading(t('collection_items'));
-        setLoading(true); // Show loading overlay
-        setIsProcessLoading(true);
-        localStorage.setItem('sliderValue', '0');
-        setSliderValue(0);
-        setProgress(0);
-        await resetItems();
-        await resetItemAssets();
-        setLoadedLayers([]);
-        setSelectedAssetLayers([]);
-        setIsPlaying(false);
-        if (mapRef.current) {
-          const map = mapRef.current;
+      await resetItemsMutation.mutateAsync();
+      await resetItemAssetsMutation.mutateAsync();
+      setLoadedLayers([]);
+      setSelectedAssetLayers([]);
+      setIsPlaying(false);
 
-          // Remove all layers except those with ID 'baseLayer' or 'dataLayer'
-          const layersToRemove = map.getLayers().getArray().filter((layer) => {
+      if (mapRef.current) {
+        const map = mapRef.current;
+        const layersToRemove = map
+          .getLayers()
+          .getArray()
+          .filter((layer) => {
             const id = layer.get('id');
             return id !== 'baseLayer' && id !== 'dataLayer';
           });
-
-          layersToRemove.forEach((layer) => {
-            map.removeLayer(layer);
-          });
-        }
-
-        try {
-          // Start fetching items asynchronously
-          const response = await fetchItems(id);
-          if (
-            response !=
-            'Fetching started in the background. Check progress separately.'
-          ) {
-            throw new Error(t('timestamps_fetch_error'));
-          }
-          toast.success(t('timestamps_fetch_success'), {
-            toastId: 'timestamps-success',
-          });
-
-          const pollProgress = async () => {
-            let lastProgress = -1;
-            let stableCount = 0;
-            const maxStableCount = 10; // e.g., 10 seconds with 1s interval
-
-            // Set the config attribute for loadedDataset and refreshDatasets list to update state
-            try {
-              const config = await getConfig();
-              config.loadedDataset = { id: "", title: "" };
-              await saveConfig(config);
-              refreshDatasets?.();
-            } catch (err) {
-              console.error(
-                'Error updating loadedDataset in config:',
-                err,
-              );
-            }
-
-            while (true) {
-              const progressResponse = await fetchProgress(id);
-
-              if ('progress' in progressResponse) {
-                const currentProgress = progressResponse.progress;
-                setProgress(currentProgress);
-
-                const timestamps = await fetchTimestamps();
-                setTimeStamps(timestamps);
-                const itemIds = await fetchItemIds();
-                setItemIds(itemIds);
-                setCollectionId(id);
-
-                if (currentProgress === lastProgress) {
-                  stableCount++;
-                } else {
-                  stableCount = 0;
-                  lastProgress = currentProgress;
-                }
-
-                // Consider done if stable for too long or if progress reaches 100
-                if (currentProgress >= 100 || stableCount >= maxStableCount) {
-                  // Optional: Set progress to 100 if stuck
-                  if (currentProgress < 100) {
-                    setProgress(100);
-                  }
-
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
-                  setLoading(false);
-                  toast.success(t('items_fetch_success'), {
-                    toastId: 'items-success',
-                  });
-
-                  return;
-                }
-              }
-
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-            }
-          };
-
-          await pollProgress();
-          setTargetLoading(t('collection_item_assets'));
-          setLoading(true);
-          setProgress(0);
-
-          await loadAssets(id); // triggers backend async processing
-
-          // Now start polling for progress on the asset load
-          const pollAssetProgress = async () => {
-            // eslint-disable-next-line no-constant-condition
-            while (true) {
-              const progressResponse = await fetchProgress(id + '_assets');
-
-              if ('progress' in progressResponse) {
-                setProgress(progressResponse.progress);
-
-                if (progressResponse.progress >= 100) {
-                  await new Promise((resolve) => setTimeout(resolve, 1000));
-                  setLoading(false);
-                  toast.success(t('assets_fetch_success'), {
-                    toastId: 'assets-success',
-                  });
-
-                  // Set the config attribute for loadedDataset and refreshDatasets list to update state
-                  try {
-                    const config = await getConfig();
-                    config.loadedDataset = { id: id, title: name };
-                    await saveConfig(config);
-                    refreshDatasets?.();
-                    setIsProcessLoading(false);
-                  } catch (err) {
-                    console.error(
-                      'Error updating loadedDataset in config:',
-                      err,
-                    );
-                  }
-
-                  return;
-                }
-              }
-
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-            }
-          };
-
-          pollAssetProgress();
-        } catch (error) {
-          toast.error(`Error loading dataset: ${error}`, {
-            toastId: 'loading-dataset-error'
-          });
-          setLoading(false);
-        }
+        layersToRemove.forEach((layer) => map.removeLayer(layer));
       }
+
+      const response = await fetchItemsMutation.mutateAsync(id);
+      if (response !== 'Fetching started in the background. Check progress separately.') {
+        throw new Error(t('timestamps_fetch_error'));
+      }
+      toast.success(t('timestamps_fetch_success'), { toastId: 'timestamps-success' });
+
+      // Poll progress for items
+      const pollProgress = async () => {
+        let lastProgress = -1;
+        let stableCount = 0;
+        const maxStableCount = 10;
+
+        const config = configData || (await queryClient.fetchQuery(['config'], () => getConfig()));
+        config.loadedDataset = { id: '', title: '' };
+        await saveConfigMutation.mutateAsync(config);
+        refreshDatasets?.();
+
+        while (true) {
+          const progressResponse = await queryClient.fetchQuery(
+            ['progress', id],
+            () => fetchProgress(id),
+            { staleTime: 1000 } // Short stale time for polling
+          );
+
+          if ('progress' in progressResponse) {
+            const currentProgress = progressResponse.progress;
+            setProgress(currentProgress);
+
+            if (timestampsData) setTimeStamps(timestampsData);
+            if (itemIdsData) setItemIds(itemIdsData);
+            setCollectionId(id);
+
+            if (currentProgress === lastProgress) {
+              stableCount++;
+            } else {
+              stableCount = 0;
+              lastProgress = currentProgress;
+            }
+
+            if (currentProgress >= 100 || stableCount >= maxStableCount) {
+              if (currentProgress < 100) setProgress(100);
+              await new Promise((resolve) => setTimeout(resolve, 1000));
+              setLoading(false);
+              toast.success(t('items_fetch_success'), { toastId: 'items-success' });
+              break;
+            }
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+      };
+
+      await pollProgress();
+      setTargetLoading(t('collection_item_assets'));
+      setLoading(true);
+      setProgress(0);
+
+      await loadAssetsMutation.mutateAsync(id);
+
+      // Poll progress for assets
+      const pollAssetProgress = async () => {
+        while (true) {
+          const progressResponse = await queryClient.fetchQuery(
+            ['progress', id + '_assets'],
+            () => fetchProgress(id + '_assets'),
+            { staleTime: 1000 }
+          );
+
+          if ('progress' in progressResponse) {
+            setProgress(progressResponse.progress);
+            if (progressResponse.progress >= 100) {
+              await new Promise((resolve) => setTimeout(resolve, 1000));
+              setLoading(false);
+              toast.success(t('assets_fetch_success'), { toastId: 'assets-success' });
+
+              const config = configData || (await queryClient.fetchQuery(['config'], () => getConfig()));
+              config.loadedDataset = { id, title: name };
+              await saveConfigMutation.mutateAsync(config);
+              refreshDatasets?.();
+              setIsProcessLoading(false);
+              break;
+            }
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+      };
+
+      await pollAssetProgress();
     } catch (error) {
-      console.error('Error loading dataset:', error);
+      toast.error(`Error loading dataset: ${error.message}`, {
+        toastId: 'loading-dataset-error',
+      });
       setLoading(false);
+      setIsProcessLoading(false);
     }
   };
 
-  if (!visible) return null; // Return null if not visible
+  if (!visible) return null;
 
   const CollapsedMetaData = (
     <div
@@ -322,7 +316,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   );
 
   const NonCollapsedMetaData = (
-    <div 
+    <div
       className="metadata-container"
       ref={containerRef}
       style={{ width: `${width}px` }}
@@ -336,22 +330,10 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       </div>
       <div className="content">
         {[
-          {
-            label: t('description'),
-            value: description,
-            testId: 'dataset-description',
-          },
+          { label: t('description'), value: description, testId: 'dataset-description' },
           { label: t('format'), value: format, testId: 'dataset-format' },
-          {
-            label: t('processes'),
-            value: processes,
-            testId: 'dataset-processes',
-          },
-          {
-            label: t('dataset_source'),
-            value: datasetSource,
-            testId: 'dataset-datasource',
-          },
+          { label: t('processes'), value: processes, testId: 'dataset-processes' },
+          { label: t('dataset_source'), value: datasetSource, testId: 'dataset-datasource' },
         ].map(({ label, value, testId }) => (
           <div className="data-row" key={label}>
             <div className="label">{label}:</div>
@@ -378,13 +360,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
         />
         <AssetsDropdown />
       </div>
-      {/* Resize handle */}
-      <div 
-        className="resize-handle"
-        ref={resizeRef}
-        onMouseDown={handleMouseDown}
-        title="Drag to resize"
-      />
+      <div className="resize-handle" ref={resizeRef} onMouseDown={handleMouseDown} title="Drag to resize" />
     </div>
   );
 

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -33,6 +33,10 @@ interface MapMetaDataProps {
   refreshDatasets: () => void;
 }
 
+/**
+ * Renders metadata for a map dataset with collapsible and resizable UI.
+ * @param props - Properties including dataset details and control functions.
+ */
 const MapMetaData: React.FC<MapMetaDataProps> = ({
                                                    id = '',
                                                    name = '',
@@ -76,17 +80,29 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   } = useMapLayerContext();
 
   // Queries
+  /**
+   * Fetches and caches the application configuration.
+   * @returns Cached config data.
+   */
   const { data: configData } = useQuery(['config'], () => getConfig(), {
     staleTime: 5 * 60 * 1000,
     cacheTime: 10 * 60 * 1000,
   });
 
+  /**
+   * Fetches and caches timestamps for the dataset.
+   * @returns Cached timestamps data.
+   */
   const { data: timestampsData } = useQuery(['timestamps'], () => fetchTimestamps(), {
     staleTime: 5 * 60 * 1000,
     cacheTime: 10 * 60 * 1000,
     onSuccess: (data) => setTimeStamps(data),
   });
 
+  /**
+   * Fetches and caches item IDs for the dataset.
+   * @returns Cached item IDs data.
+   */
   const { data: itemIdsData } = useQuery(['itemIds'], () => fetchItemIds(), {
     staleTime: 5 * 60 * 1000,
     cacheTime: 10 * 60 * 1000,
@@ -94,26 +110,53 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   });
 
   // Mutations
+  /**
+   * Resets items in the dataset and invalidates related cache.
+   * @returns Promise resolving when items are reset.
+   */
   const resetItemsMutation = useMutation(() => resetItems(), {
     onSuccess: () => queryClient.invalidateQueries(['items']),
   });
 
+  /**
+   * Resets item assets and invalidates related cache.
+   * @returns Promise resolving when assets are reset.
+   */
   const resetItemAssetsMutation = useMutation(() => resetItemAssets(), {
     onSuccess: () => queryClient.invalidateQueries(['itemAssets']),
   });
 
+  /**
+   * Fetches items for a given dataset ID and invalidates related cache.
+   * @param id - The dataset ID to fetch items for.
+   * @returns Promise resolving with fetch response.
+   */
   const fetchItemsMutation = useMutation((id: string) => fetchItems(id), {
     onSuccess: () => queryClient.invalidateQueries(['items']),
   });
 
+  /**
+   * Loads assets for a given dataset ID and invalidates related cache.
+   * @param id - The dataset ID to load assets for.
+   * @returns Promise resolving when assets are loaded.
+   */
   const loadAssetsMutation = useMutation((id: string) => loadAssets(id), {
     onSuccess: () => queryClient.invalidateQueries(['itemAssets']),
   });
 
+  /**
+   * Saves the application configuration and updates the cache.
+   * @param config - The configuration object to save.
+   * @returns Promise resolving with saved config data.
+   */
   const saveConfigMutation = useMutation((config: any) => saveConfig(config), {
     onSuccess: (data) => queryClient.setQueryData(['config'], data),
   });
 
+  /**
+   * Initiates resizing of the metadata container on mouse down.
+   * @param e - The mouse event triggering the resize.
+   */
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!containerRef.current) return;
     setIsResizing(true);
@@ -123,19 +166,32 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
     e.preventDefault();
   }, []);
 
+  /**
+   * Updates the width of the metadata container during resize.
+   * @param e - The mouse event with current position.
+   */
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       if (!isResizing || !containerRef.current) return;
       const dx = e.clientX - startXRef.current;
       let newWidth = startWidthRef.current + dx;
+
+      // Apply constraints
       newWidth = Math.max(minWidth, Math.min(newWidth, maxWidth));
+
+      // DIRECT DOM UPDATE (no React state lag)
       containerRef.current.style.width = `${newWidth}px`;
     },
     [isResizing, maxWidth, minWidth]
   );
 
+  /**
+   * Finalizes resizing of the metadata container on mouse up.
+   */
   const handleMouseUp = useCallback(() => {
     if (!isResizing || !containerRef.current) return;
+
+    // Only update React state AFTER dragging finishes
     setWidth(containerRef.current.offsetWidth);
     containerRef.current.style.willChange = 'auto';
     setIsResizing(false);
@@ -158,6 +214,9 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
     };
   }, [isResizing, handleMouseMove, handleMouseUp]);
 
+  /**
+   * Loads the dataset, resetting previous data and polling progress.
+   */
   const onLoadDataset = async () => {
     if (!isOnline) {
       toast.error(`${t('disabled')} - ${t('no_internet_access')}`, {
@@ -196,6 +255,8 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
 
       if (mapRef.current) {
         const map = mapRef.current;
+
+        // Remove all layers except those with ID 'baseLayer' or 'dataLayer'
         const layersToRemove = map
           .getLayers()
           .getArray()
@@ -212,7 +273,9 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       }
       toast.success(t('timestamps_fetch_success'), { toastId: 'timestamps-success' });
 
-      // Poll progress for items
+      /**
+       * Polls the progress of fetching items until complete or stable.
+       */
       const pollProgress = async () => {
         let lastProgress = -1;
         let stableCount = 0;
@@ -264,7 +327,9 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
 
       await loadAssetsMutation.mutateAsync(id);
 
-      // Poll progress for assets
+      /**
+       * Polls the progress of loading assets until complete.
+       */
       const pollAssetProgress = async () => {
         while (true) {
           const progressResponse = await queryClient.fetchQuery(

--- a/apps/frontend/src/app/components/MapMetaData.tsx
+++ b/apps/frontend/src/app/components/MapMetaData.tsx
@@ -19,7 +19,6 @@ import withReactContent from 'sweetalert2-react-content';
 import Swal from 'sweetalert2';
 import { getConfig, saveConfig } from '../services/configApi';
 import AssetsDropdown from './AssetsDropdown';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 interface MapMetaDataProps {
   id?: string;
@@ -33,10 +32,6 @@ interface MapMetaDataProps {
   refreshDatasets: () => void;
 }
 
-/**
- * Renders metadata for a map dataset with collapsible and resizable UI.
- * @param props - Properties including dataset details and control functions.
- */
 const MapMetaData: React.FC<MapMetaDataProps> = ({
                                                    id = '',
                                                    name = '',
@@ -48,7 +43,6 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
                                                    refreshDatasets,
                                                  }) => {
   const { t } = useTranslation();
-  const queryClient = useQueryClient();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [width, setWidth] = useState(350);
   const [isResizing, setIsResizing] = useState(false);
@@ -56,7 +50,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
-  const animationRef = useRef<number | null>(null);
+  const animationRef = useRef<number | null>(null); // Initialize as null
   const toggleCollapse = () => setIsCollapsed((prev) => !prev);
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -76,118 +70,37 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
     setIsProcessLoading,
     setSelectedAssetLayers,
     mapRef,
-    setIsPlaying,
+    setIsPlaying
   } = useMapLayerContext();
 
-  // Queries
-  /**
-   * Fetches and caches the application configuration.
-   * @returns Cached config data.
-   */
-  const { data: configData } = useQuery(['config'], () => getConfig(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-  });
-
-  /**
-   * Fetches and caches timestamps for the dataset.
-   * @returns Cached timestamps data.
-   */
-  const { data: timestampsData } = useQuery(['timestamps'], () => fetchTimestamps(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    onSuccess: (data) => setTimeStamps(data),
-  });
-
-  /**
-   * Fetches and caches item IDs for the dataset.
-   * @returns Cached item IDs data.
-   */
-  const { data: itemIdsData } = useQuery(['itemIds'], () => fetchItemIds(), {
-    staleTime: 5 * 60 * 1000,
-    cacheTime: 10 * 60 * 1000,
-    onSuccess: (data) => setItemIds(data),
-  });
-
-  // Mutations
-  /**
-   * Resets items in the dataset and invalidates related cache.
-   * @returns Promise resolving when items are reset.
-   */
-  const resetItemsMutation = useMutation(() => resetItems(), {
-    onSuccess: () => queryClient.invalidateQueries(['items']),
-  });
-
-  /**
-   * Resets item assets and invalidates related cache.
-   * @returns Promise resolving when assets are reset.
-   */
-  const resetItemAssetsMutation = useMutation(() => resetItemAssets(), {
-    onSuccess: () => queryClient.invalidateQueries(['itemAssets']),
-  });
-
-  /**
-   * Fetches items for a given dataset ID and invalidates related cache.
-   * @param id - The dataset ID to fetch items for.
-   * @returns Promise resolving with fetch response.
-   */
-  const fetchItemsMutation = useMutation((id: string) => fetchItems(id), {
-    onSuccess: () => queryClient.invalidateQueries(['items']),
-  });
-
-  /**
-   * Loads assets for a given dataset ID and invalidates related cache.
-   * @param id - The dataset ID to load assets for.
-   * @returns Promise resolving when assets are loaded.
-   */
-  const loadAssetsMutation = useMutation((id: string) => loadAssets(id), {
-    onSuccess: () => queryClient.invalidateQueries(['itemAssets']),
-  });
-
-  /**
-   * Saves the application configuration and updates the cache.
-   * @param config - The configuration object to save.
-   * @returns Promise resolving with saved config data.
-   */
-  const saveConfigMutation = useMutation((config: any) => saveConfig(config), {
-    onSuccess: (data) => queryClient.setQueryData(['config'], data),
-  });
-
-  /**
-   * Initiates resizing of the metadata container on mouse down.
-   * @param e - The mouse event triggering the resize.
-   */
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     if (!containerRef.current) return;
+
     setIsResizing(true);
     startXRef.current = e.clientX;
     startWidthRef.current = containerRef.current.offsetWidth;
-    containerRef.current.style.willChange = 'width';
+
+    // Hint browser about upcoming changes for better performance
+    if (containerRef.current) {
+      containerRef.current.style.willChange = 'width';
+    }
+
     e.preventDefault();
   }, []);
 
-  /**
-   * Updates the width of the metadata container during resize.
-   * @param e - The mouse event with current position.
-   */
-  const handleMouseMove = useCallback(
-    (e: MouseEvent) => {
-      if (!isResizing || !containerRef.current) return;
-      const dx = e.clientX - startXRef.current;
-      let newWidth = startWidthRef.current + dx;
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (!isResizing || !containerRef.current) return;
 
-      // Apply constraints
-      newWidth = Math.max(minWidth, Math.min(newWidth, maxWidth));
+    const dx = e.clientX - startXRef.current;
+    let newWidth = startWidthRef.current + dx;
 
-      // DIRECT DOM UPDATE (no React state lag)
-      containerRef.current.style.width = `${newWidth}px`;
-    },
-    [isResizing, maxWidth, minWidth]
-  );
+    // Apply constraints
+    newWidth = Math.max(minWidth, Math.min(newWidth, maxWidth));
 
-  /**
-   * Finalizes resizing of the metadata container on mouse up.
-   */
+    // DIRECT DOM UPDATE (no React state lag)
+    containerRef.current.style.width = `${newWidth}px`;
+  }, [isResizing, maxWidth, minWidth]);
+
   const handleMouseUp = useCallback(() => {
     if (!isResizing || !containerRef.current) return;
 
@@ -205,6 +118,7 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     }
+
     return () => {
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
@@ -214,9 +128,6 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
     };
   }, [isResizing, handleMouseMove, handleMouseUp]);
 
-  /**
-   * Loads the dataset, resetting previous data and polling progress.
-   */
   const onLoadDataset = async () => {
     if (!isOnline) {
       toast.error(`${t('disabled')} - ${t('no_internet_access')}`, {
@@ -225,149 +136,179 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       return;
     }
 
-    const result = await MySwal.fire({
-      title: t('load_dataset'),
-      text: t('confirm_deletion_items_from_previous_collection'),
-      icon: 'warning',
-      showCancelButton: true,
-      cancelButtonText: t('no'),
-      confirmButtonColor: '#3085d6',
-      cancelButtonColor: '#d33',
-      confirmButtonText: t('yes'),
-      customClass: { popup: 'custom-swal-popup' },
-    });
-
-    if (!result.isConfirmed) return;
-
     try {
-      setTargetLoading(t('collection_items'));
-      setLoading(true);
-      setIsProcessLoading(true);
-      localStorage.setItem('sliderValue', '0');
-      setSliderValue(0);
-      setProgress(0);
+      const result = await MySwal.fire({
+        title: t('load_dataset'),
+        text: t('confirm_deletion_items_from_previous_collection'),
+        icon: 'warning',
+        showCancelButton: true,
+        cancelButtonText: t('no'),
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        confirmButtonText: t('yes'),
+        customClass: {
+          popup: 'custom-swal-popup',
+        },
+      });
 
-      await resetItemsMutation.mutateAsync();
-      await resetItemAssetsMutation.mutateAsync();
-      setLoadedLayers([]);
-      setSelectedAssetLayers([]);
-      setIsPlaying(false);
+      if (result.isConfirmed) {
+        setTargetLoading(t('collection_items'));
+        setLoading(true); // Show loading overlay
+        setIsProcessLoading(true);
+        localStorage.setItem('sliderValue', '0');
+        setSliderValue(0);
+        setProgress(0);
+        await resetItems();
+        await resetItemAssets();
+        setLoadedLayers([]);
+        setSelectedAssetLayers([]);
+        setIsPlaying(false);
+        if (mapRef.current) {
+          const map = mapRef.current;
 
-      if (mapRef.current) {
-        const map = mapRef.current;
-
-        // Remove all layers except those with ID 'baseLayer' or 'dataLayer'
-        const layersToRemove = map
-          .getLayers()
-          .getArray()
-          .filter((layer) => {
+          // Remove all layers except those with ID 'baseLayer' or 'dataLayer'
+          const layersToRemove = map.getLayers().getArray().filter((layer) => {
             const id = layer.get('id');
             return id !== 'baseLayer' && id !== 'dataLayer';
           });
-        layersToRemove.forEach((layer) => map.removeLayer(layer));
-      }
 
-      const response = await fetchItemsMutation.mutateAsync(id);
-      if (response !== 'Fetching started in the background. Check progress separately.') {
-        throw new Error(t('timestamps_fetch_error'));
-      }
-      toast.success(t('timestamps_fetch_success'), { toastId: 'timestamps-success' });
-
-      /**
-       * Polls the progress of fetching items until complete or stable.
-       */
-      const pollProgress = async () => {
-        let lastProgress = -1;
-        let stableCount = 0;
-        const maxStableCount = 10;
-
-        const config = configData || (await queryClient.fetchQuery(['config'], () => getConfig()));
-        config.loadedDataset = { id: '', title: '' };
-        await saveConfigMutation.mutateAsync(config);
-        refreshDatasets?.();
-
-        while (true) {
-          const progressResponse = await queryClient.fetchQuery(
-            ['progress', id],
-            () => fetchProgress(id),
-            { staleTime: 1000 } // Short stale time for polling
-          );
-
-          if ('progress' in progressResponse) {
-            const currentProgress = progressResponse.progress;
-            setProgress(currentProgress);
-
-            if (timestampsData) setTimeStamps(timestampsData);
-            if (itemIdsData) setItemIds(itemIdsData);
-            setCollectionId(id);
-
-            if (currentProgress === lastProgress) {
-              stableCount++;
-            } else {
-              stableCount = 0;
-              lastProgress = currentProgress;
-            }
-
-            if (currentProgress >= 100 || stableCount >= maxStableCount) {
-              if (currentProgress < 100) setProgress(100);
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-              setLoading(false);
-              toast.success(t('items_fetch_success'), { toastId: 'items-success' });
-              break;
-            }
-          }
-          await new Promise((resolve) => setTimeout(resolve, 1000));
+          layersToRemove.forEach((layer) => {
+            map.removeLayer(layer);
+          });
         }
-      };
 
-      await pollProgress();
-      setTargetLoading(t('collection_item_assets'));
-      setLoading(true);
-      setProgress(0);
+        try {
+          // Start fetching items asynchronously
+          const response = await fetchItems(id);
+          if (
+            response !=
+            'Fetching started in the background. Check progress separately.'
+          ) {
+            throw new Error(t('timestamps_fetch_error'));
+          }
+          toast.success(t('timestamps_fetch_success'), {
+            toastId: 'timestamps-success',
+          });
 
-      await loadAssetsMutation.mutateAsync(id);
+          const pollProgress = async () => {
+            let lastProgress = -1;
+            let stableCount = 0;
+            const maxStableCount = 10; // e.g., 10 seconds with 1s interval
 
-      /**
-       * Polls the progress of loading assets until complete.
-       */
-      const pollAssetProgress = async () => {
-        while (true) {
-          const progressResponse = await queryClient.fetchQuery(
-            ['progress', id + '_assets'],
-            () => fetchProgress(id + '_assets'),
-            { staleTime: 1000 }
-          );
-
-          if ('progress' in progressResponse) {
-            setProgress(progressResponse.progress);
-            if (progressResponse.progress >= 100) {
-              await new Promise((resolve) => setTimeout(resolve, 1000));
-              setLoading(false);
-              toast.success(t('assets_fetch_success'), { toastId: 'assets-success' });
-
-              const config = configData || (await queryClient.fetchQuery(['config'], () => getConfig()));
-              config.loadedDataset = { id, title: name };
-              await saveConfigMutation.mutateAsync(config);
+            // Set the config attribute for loadedDataset and refreshDatasets list to update state
+            try {
+              const config = await getConfig();
+              config.loadedDataset = { id: "", title: "" };
+              await saveConfig(config);
               refreshDatasets?.();
-              setIsProcessLoading(false);
-              break;
+            } catch (err) {
+              console.error(
+                'Error updating loadedDataset in config:',
+                err,
+              );
             }
-          }
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-        }
-      };
 
-      await pollAssetProgress();
+            while (true) {
+              const progressResponse = await fetchProgress(id);
+
+              if ('progress' in progressResponse) {
+                const currentProgress = progressResponse.progress;
+                setProgress(currentProgress);
+
+                const timestamps = await fetchTimestamps();
+                setTimeStamps(timestamps);
+                const itemIds = await fetchItemIds();
+                setItemIds(itemIds);
+                setCollectionId(id);
+
+                if (currentProgress === lastProgress) {
+                  stableCount++;
+                } else {
+                  stableCount = 0;
+                  lastProgress = currentProgress;
+                }
+
+                // Consider done if stable for too long or if progress reaches 100
+                if (currentProgress >= 100 || stableCount >= maxStableCount) {
+                  // Optional: Set progress to 100 if stuck
+                  if (currentProgress < 100) {
+                    setProgress(100);
+                  }
+
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                  setLoading(false);
+                  toast.success(t('items_fetch_success'), {
+                    toastId: 'items-success',
+                  });
+
+                  return;
+                }
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, 1000));
+            }
+          };
+
+          await pollProgress();
+          setTargetLoading(t('collection_item_assets'));
+          setLoading(true);
+          setProgress(0);
+
+          await loadAssets(id); // triggers backend async processing
+
+          // Now start polling for progress on the asset load
+          const pollAssetProgress = async () => {
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              const progressResponse = await fetchProgress(id + '_assets');
+
+              if ('progress' in progressResponse) {
+                setProgress(progressResponse.progress);
+
+                if (progressResponse.progress >= 100) {
+                  await new Promise((resolve) => setTimeout(resolve, 1000));
+                  setLoading(false);
+                  toast.success(t('assets_fetch_success'), {
+                    toastId: 'assets-success',
+                  });
+
+                  // Set the config attribute for loadedDataset and refreshDatasets list to update state
+                  try {
+                    const config = await getConfig();
+                    config.loadedDataset = { id: id, title: name };
+                    await saveConfig(config);
+                    refreshDatasets?.();
+                    setIsProcessLoading(false);
+                  } catch (err) {
+                    console.error(
+                      'Error updating loadedDataset in config:',
+                      err,
+                    );
+                  }
+
+                  return;
+                }
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, 1000));
+            }
+          };
+
+          pollAssetProgress();
+        } catch (error) {
+          toast.error(`Error loading dataset: ${error}`, {
+            toastId: 'loading-dataset-error'
+          });
+          setLoading(false);
+        }
+      }
     } catch (error) {
-      toast.error(`Error loading dataset: ${error.message}`, {
-        toastId: 'loading-dataset-error',
-      });
+      console.error('Error loading dataset:', error);
       setLoading(false);
-      setIsProcessLoading(false);
     }
   };
 
-  if (!visible) return null;
+  if (!visible) return null; // Return null if not visible
 
   const CollapsedMetaData = (
     <div
@@ -395,10 +336,22 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
       </div>
       <div className="content">
         {[
-          { label: t('description'), value: description, testId: 'dataset-description' },
+          {
+            label: t('description'),
+            value: description,
+            testId: 'dataset-description',
+          },
           { label: t('format'), value: format, testId: 'dataset-format' },
-          { label: t('processes'), value: processes, testId: 'dataset-processes' },
-          { label: t('dataset_source'), value: datasetSource, testId: 'dataset-datasource' },
+          {
+            label: t('processes'),
+            value: processes,
+            testId: 'dataset-processes',
+          },
+          {
+            label: t('dataset_source'),
+            value: datasetSource,
+            testId: 'dataset-datasource',
+          },
         ].map(({ label, value, testId }) => (
           <div className="data-row" key={label}>
             <div className="label">{label}:</div>
@@ -425,7 +378,13 @@ const MapMetaData: React.FC<MapMetaDataProps> = ({
         />
         <AssetsDropdown />
       </div>
-      <div className="resize-handle" ref={resizeRef} onMouseDown={handleMouseDown} title="Drag to resize" />
+      {/* Resize handle */}
+      <div
+        className="resize-handle"
+        ref={resizeRef}
+        onMouseDown={handleMouseDown}
+        title="Drag to resize"
+      />
     </div>
   );
 

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -34,6 +34,15 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const MySwal = withReactContent(Swal);
 
+interface Config {
+  endpoint?: string;
+  language?: string;
+  onlineMode?: boolean;
+  loadedDataset?: { id: string; title: string };
+  error?: string;
+  [key: string]: any;
+}
+
 const SettingsPanel: React.FC<{
   refreshDatasets: () => void;
   setMetadataVisible: (visible: boolean) => void;
@@ -90,12 +99,20 @@ const SettingsPanel: React.FC<{
   /**
    * Saves the application configuration and updates the cache.
    * @param config - The configuration object to save.
-   * @returns Promise resolving with saved config data.
+   * @returns Promise resolving with void (no return data assumed).
    */
-  const saveConfigMutation = useMutation((config: any) => saveConfig(config), {
-    onSuccess: (data) => queryClient.setQueryData(['config'], data), // Update cache directly
-    onError: () => toast.error(t('error_saving_config')),
-  });
+  const saveConfigMutation = useMutation<void, unknown, Config>(
+    (config: Config) => saveConfig(config),
+    {
+      onSuccess: () => {
+        // Update the cache with the latest configData if available
+        if (configData) {
+          queryClient.setQueryData(['config'], configData);
+        }
+      },
+      onError: (error: unknown) => toast.error(t('error_saving_config')),
+    }
+  );
 
   /**
    * Initializes language from local storage and syncs with config.

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -30,6 +30,7 @@ import { getConfig, saveConfig } from '../services/configApi';
 import { changeLayer, updateLayerStyle } from './MapView';
 import { Map } from 'ol';
 import { LuPalette } from 'react-icons/lu';
+import { useQuery, useQueryClient } from 'react-query';
 
 const MySwal = withReactContent(Swal);
 
@@ -38,6 +39,7 @@ const SettingsPanel: React.FC<{
   setMetadataVisible: (visible: boolean) => void;
 }> = ({ refreshDatasets, setMetadataVisible }) => {
   const { t, i18n } = useTranslation();
+  const queryClient = useQueryClient(); // Access the QueryClient from ClientLayout
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
     isOpen: boolean;
@@ -61,68 +63,71 @@ const SettingsPanel: React.FC<{
   );
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [languageInitialized, setLanguageInitialized] = useState(false);
-  // Initialize language from local storage and handle toast messages
+
+  // UseQuery for fetching config
+  const {
+    data: configData,
+    isLoading: configLoading,
+    error: configError,
+  } = useQuery(
+    ['config'],
+    () => getConfig(),
+    {
+      staleTime: 5 * 60 * 1000, // 5 minutes
+      cacheTime: 10 * 60 * 1000, // 10 minutes
+      onSuccess: (config) => {
+        if (config.endpoint) setNewApiEndpoint(config.endpoint);
+        if (config.language && config.language !== i18n.language) {
+          i18n.changeLanguage(config.language);
+        }
+        if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
+        setLanguageInitialized(true);
+      },
+    }
+  );
+
+  // Initialize language from local storage
   useEffect(() => {
     if (
       typeof window !== 'undefined' &&
       window.localStorage &&
-      !languageInitialized
+      !languageInitialized &&
+      !configLoading &&
+      !configError
     ) {
       const savedLanguage = localStorage.getItem('language');
-      if (savedLanguage) {
-        // If a language is saved in localStorage, use it
-        if (savedLanguage !== i18n.language) {
-          i18n.changeLanguage(savedLanguage); // Change language only if different from current one
-        }
-      } else {
-        // If no language is saved, use the default language
+      if (savedLanguage && savedLanguage !== i18n.language) {
+        i18n.changeLanguage(savedLanguage);
+      } else if (!savedLanguage) {
         localStorage.setItem('language', 'en');
-        toast.info(t('default_language_retrieved')); // Show default language message
-      }
-      setLanguageInitialized(true); // Mark language initialization as done
-    }
-  }, [i18n, t, languageInitialized]);
-
-  useEffect(() => {
-    const fetchConfig = async () => {
-      const config = await getConfig();
-      if (config.endpoint) {
-        setNewApiEndpoint(config.endpoint);
-      }
-      if (config.language && config.language !== i18n.language) {
-        i18n.changeLanguage(config.language);
+        toast.info(t('default_language_retrieved'));
       }
       setLanguageInitialized(true);
+    }
+  }, [i18n, t, languageInitialized, configLoading, configError]);
 
-      if (config.onlineMode != undefined) {
-        setIsOnline(config.onlineMode);
-      }
+  // Prompt for endpoint if none is saved
+  useEffect(() => {
+    if (
+      !configLoading &&
+      !configError &&
+      (configData?.endpoint === 'No endpoint saved' || !configData?.endpoint)
+    ) {
+      promptForEndpoint(
+        refreshDatasets,
+        t,
+        MySwal,
+        handleSaveAndFetchEndpoint,
+        getConfig,
+        saveConfig,
+      );
+    }
+  }, [configLoading, configError, configData]);
 
-      // Check if endpoint is "No endpoint saved" and prompt user to enter a new one
-      if (
-        config.endpoint === 'No endpoint saved' ||
-        config.endpoint === undefined
-      ) {
-        await promptForEndpoint(
-          refreshDatasets,
-          t,
-          MySwal,
-          handleSaveAndFetchEndpoint,
-          getConfig,
-          saveConfig,
-        );
-      }
-    };
-    fetchConfig();
-  }, [i18n]);
-
-  // Toggles dropdown state
+  // Toggle dropdown state
   const toggleDropdown = async (buttonName: string) => {
-    if (buttonName === 'settings') {
-      const config = await getConfig();
-      if (config.endpoint) {
-        setNewApiEndpoint(config.endpoint);
-      }
+    if (buttonName === 'settings' && configData?.endpoint) {
+      setNewApiEndpoint(configData.endpoint);
     }
     setDropdownState((prevState) => ({
       activeButton: prevState.activeButton === buttonName ? null : buttonName,
@@ -133,56 +138,66 @@ const SettingsPanel: React.FC<{
   const handleSaveAndFetchEndpoint = async (
     endpointUrl: string,
   ): Promise<boolean> => {
-    if (isValidUrl(endpointUrl)) {
-      try {
-        // Check if the URL retrieves collections
-        const verificationMessage =
-          await verifyIfEndpointHasCollections(endpointUrl);
-        if (verificationMessage !== 'Collections found') {
-          toast.error(t('no_collections_found'));
-          return false;
-        }
+    if (!isValidUrl(endpointUrl)) {
+      toast.error(t('invalid_url'));
+      return false;
+    }
 
-        // Reset collections before fetching new ones
-        await resetCollections();
-        await resetItems();
-        await resetItemAssets();
-        setSelectedAssetLayers([]);
-
-        const message = await fetchCollectionsFromEndpoint(endpointUrl);
-        if (message === 'Collections fetched and saved successfully') {
-          toast.success(t('collections_fetched_saved'));
-        }
-
-        // Save the new endpoint to config file
-        const config = await getConfig();
-        // If an error occurred during fetching config, show error and do not save changes
-        if (config.error) {
-          toast.error(t('error_fetching_config_file'));
-          return false;
-        }
-
-        config.endpoint = endpointUrl;
-        config.loadedDataset = { id: '', title: '' };
-        await saveConfig(config);
-
-        refreshDatasets(); // Trigger the refresh
-
-        setDropdownState({ activeButton: null, isOpen: false });
-        return true;
-      } catch (error: any) {
-        toast.error(t('error_fetching_collections'));
+    try {
+      // Use fetchQuery to cache verifyIfEndpointHasCollections
+      const verificationMessage = await queryClient.fetchQuery(
+        ['verifyEndpoint', endpointUrl],
+        () => verifyIfEndpointHasCollections(endpointUrl),
+        { staleTime: 5 * 60 * 1000 }
+      );
+      if (verificationMessage !== 'Collections found') {
+        toast.error(t('no_collections_found'));
         return false;
       }
-    } else {
-      toast.error(t('invalid_url'));
+
+      // Reset collections
+      await resetCollections();
+      await resetItems();
+      await resetItemAssets();
+      setSelectedAssetLayers([]);
+
+      // Use fetchQuery to cache fetchCollectionsFromEndpoint
+      const message = await queryClient.fetchQuery(
+        ['fetchCollections', endpointUrl],
+        () => fetchCollectionsFromEndpoint(endpointUrl),
+        { staleTime: 5 * 60 * 1000 }
+      );
+      if (message === 'Collections fetched and saved successfully') {
+        toast.success(t('collections_fetched_saved'));
+      }
+
+      // Update config
+      const config = configData || (await getConfig());
+      if (config.error) {
+        toast.error(t('error_fetching_config_file'));
+        return false;
+      }
+      config.endpoint = endpointUrl;
+      config.loadedDataset = { id: '', title: '' };
+      await saveConfig(config);
+      queryClient.setQueryData(['config'], config); // Update cache manually
+
+      refreshDatasets();
+      setDropdownState({ activeButton: null, isOpen: false });
+      return true;
+    } catch (error) {
+      toast.error(t('error_fetching_collections'));
       return false;
     }
   };
 
-  const handleLanguageSelect = (language: string) => {
+  const handleLanguageSelect = async (language: string) => {
     i18n.changeLanguage(language);
     localStorage.setItem('language', language);
+    const config = configData || (await getConfig());
+    config.language = language;
+    await saveConfig(config);
+    queryClient.setQueryData(['config'], config);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -195,12 +210,9 @@ const SettingsPanel: React.FC<{
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
-      customClass: {
-        popup: 'custom-swal-popup',
-      },
-    }).then(async (result: { isConfirmed: any }) => {
+      customClass: { popup: 'custom-swal-popup' },
+    }).then(async (result) => {
       if (result.isConfirmed) {
-        // reset localStorage properties to default properties
         localStorage.setItem('language', 'en');
         localStorage.setItem('playbackSpeed', '1');
         localStorage.setItem('sliderValue', '0');
@@ -208,11 +220,9 @@ const SettingsPanel: React.FC<{
         setSliderValue(0);
         setSpeed(1);
         handleResetLayerStyle(true);
-
         toast.success(t('reset_completed'));
       }
     });
-
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -232,44 +242,36 @@ const SettingsPanel: React.FC<{
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
-      customClass: {
-        popup: 'custom-swal-popup',
-      },
-    }).then(async (result: { isConfirmed: any }) => {
+      customClass: { popup: 'custom-swal-popup' },
+    }).then(async (result) => {
       if (result.isConfirmed) {
         resetView();
         setSelectedAssetLayers([]);
-        try {
-          await resetConfig();
-          await promptForEndpoint(
-            refreshDatasets,
-            t,
-            MySwal,
-            handleSaveAndFetchEndpoint,
-            getConfig,
-            saveConfig,
-          );
-          setMetadataVisible(false); // Hide metadata container
-        } catch (error: any) {
-          toast.error(error.message);
-        }
+        await resetConfig();
+        await promptForEndpoint(
+          refreshDatasets,
+          t,
+          MySwal,
+          handleSaveAndFetchEndpoint,
+          getConfig,
+          saveConfig,
+        );
+        setMetadataVisible(false);
       }
     });
-
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
   const handleSelectOnlineMode = async (onlineMode: boolean) => {
     setIsOnline(onlineMode);
-
-    const config = await getConfig();
-    // If an error occurred during fetching config, show error and do not save changes
+    const config = configData || (await getConfig());
     if (config.error) {
       toast.error(t('error_fetching_config_file'));
-      return false;
+      return;
     }
     config.onlineMode = onlineMode;
     await saveConfig(config);
+    queryClient.setQueryData(['config'], config);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -285,18 +287,18 @@ const SettingsPanel: React.FC<{
       setTimeStamps([]);
       setCollectionId('');
       setSpeed(1);
-
       await resetCollections();
       await resetItems();
       await resetDatalayerView();
       await resetItemAssets();
       const map = mapRef.current as Map;
       changeLayer(map, true);
-      changeLayer(map, false, "reset");
+      changeLayer(map, false, 'reset');
       setSpeed(1);
       handleResetLayerStyle(true);
+      queryClient.invalidateQueries(['config']); // Invalidate config cache
       return 'Reset was successful';
-    } catch (error: any) {
+    } catch (error) {
       throw new Error(`Error resetting config: ${error.message}`);
     }
   };
@@ -325,19 +327,17 @@ const SettingsPanel: React.FC<{
       if (inputResult.isConfirmed) {
         success = await handleSaveAndFetchEndpoint(inputResult.value);
       } else {
-        const config = await getConfig();
-        // If an error occurred during fetching config, show error and do not save changes
+        const config = configData || (await getConfig());
         if (config.error) {
           toast.error(t('error_fetching_config_file'));
           break;
         }
-
         config.endpoint = 'No endpoint saved';
         config.loadedDataset = { id: '', title: '' };
         await saveConfig(config);
-
-        refreshDatasets(); // Trigger the refresh
-        break; // Exit the loop if the user cancels the input dialog
+        queryClient.setQueryData(['config'], config);
+        refreshDatasets();
+        break;
       }
     }
   };
@@ -360,52 +360,32 @@ const SettingsPanel: React.FC<{
         setDropdownState({ activeButton: null, isOpen: false });
       }
     };
-
     if (dropdownState.isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
     }
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [dropdownState.isOpen]);
-
-  useEffect(() => {
-    const fetchConfig = async () => {
-      const config = await getConfig();
-      if (config.endpoint) {
-        setNewApiEndpoint(config.endpoint);
-      }
-    };
-    fetchConfig();
-  }, [dropdownState.activeButton === 'settings']);
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(newApiEndpoint);
     toast.success(t('copied_to_clipboard'));
   };
 
-  // Default style values for Polygon
-  const DEFAULT_FILL_COLOR = '#ff0000'; // Red
+  // Default style values
+  const DEFAULT_FILL_COLOR = '#ff0000';
   const DEFAULT_FILL_OPACITY = '0.1';
-  const DEFAULT_STROKE_COLOR = '#ff0000'; // Red
+  const DEFAULT_STROKE_COLOR = '#ff0000';
   const DEFAULT_STROKE_WIDTH = '2';
-
-// Default style values for DataLayer
-  const DEFAULT_DATA_FILL_COLOR = '#0000ff'; // Blue
+  const DEFAULT_DATA_FILL_COLOR = '#0000ff';
   const DEFAULT_DATA_FILL_OPACITY = '0.1';
-  const DEFAULT_DATA_STROKE_COLOR = '#0000ff'; // Blue
+  const DEFAULT_DATA_STROKE_COLOR = '#0000ff';
   const DEFAULT_DATA_STROKE_WIDTH = '2';
 
-  // Tab selection state
   const [selectedStyleTab, setSelectedStyleTab] = useState<'polygon' | 'dataLayer'>('polygon');
-
-  // Polygon style state
   const [polygonFillColor, setPolygonFillColor] = useState(DEFAULT_FILL_COLOR);
   const [polygonFillOpacity, setPolygonFillOpacity] = useState(DEFAULT_FILL_OPACITY);
   const [polygonStrokeColor, setPolygonStrokeColor] = useState(DEFAULT_STROKE_COLOR);
   const [polygonStrokeWidth, setPolygonStrokeWidth] = useState(DEFAULT_STROKE_WIDTH);
-
-  // DataLayer style state
   const [dataLayerFillColor, setDataLayerFillColor] = useState(DEFAULT_DATA_FILL_COLOR);
   const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(DEFAULT_DATA_FILL_OPACITY);
   const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(DEFAULT_DATA_STROKE_COLOR);
@@ -418,10 +398,8 @@ const SettingsPanel: React.FC<{
       : 'rgb(0,0,0)';
   };
 
-  // Update polygon and dataLayer style
   const handleUpdateLayerStyle = () => {
     if (!mapRef.current) return;
-
     if (selectedStyleTab === 'polygon') {
       updateLayerStyle(
         mapRef.current,
@@ -429,7 +407,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(polygonFillColor),
         polygonFillOpacity,
         hexToRgb(polygonStrokeColor),
-        polygonStrokeWidth
+        polygonStrokeWidth,
       );
     } else {
       updateLayerStyle(
@@ -438,46 +416,39 @@ const SettingsPanel: React.FC<{
         hexToRgb(dataLayerFillColor),
         dataLayerFillOpacity,
         hexToRgb(dataLayerStrokeColor),
-        dataLayerStrokeWidth
+        dataLayerStrokeWidth,
       );
     }
   };
 
-  // Reset polygon and dataLayer style
   const handleResetLayerStyle = (resetBoth = false) => {
     if (!mapRef.current) return;
-
     if (resetBoth || selectedStyleTab === 'polygon') {
-      // Reset polygon state
       setPolygonFillColor(DEFAULT_FILL_COLOR);
       setPolygonFillOpacity(DEFAULT_FILL_OPACITY);
       setPolygonStrokeColor(DEFAULT_STROKE_COLOR);
       setPolygonStrokeWidth(DEFAULT_STROKE_WIDTH);
-
       updateLayerStyle(
         mapRef.current,
         'itemLayer',
         hexToRgb(DEFAULT_FILL_COLOR),
         DEFAULT_FILL_OPACITY,
         hexToRgb(DEFAULT_STROKE_COLOR),
-        DEFAULT_STROKE_WIDTH
+        DEFAULT_STROKE_WIDTH,
       );
     }
-
     if (resetBoth || selectedStyleTab === 'dataLayer') {
-      // Reset data layer state with blue defaults
-      setDataLayerFillColor('#0000ff');
-      setDataLayerFillOpacity('0.1');
-      setDataLayerStrokeColor('#0000ff');
-      setDataLayerStrokeWidth('2');
-
+      setDataLayerFillColor(DEFAULT_DATA_FILL_COLOR);
+      setDataLayerFillOpacity(DEFAULT_DATA_FILL_OPACITY);
+      setDataLayerStrokeColor(DEFAULT_DATA_STROKE_COLOR);
+      setDataLayerStrokeWidth(DEFAULT_DATA_STROKE_WIDTH);
       updateLayerStyle(
         mapRef.current,
         'dataLayer',
-        hexToRgb('#0000ff'),
-        '0.1',
-        hexToRgb('#0000ff'),
-        '2'
+        hexToRgb(DEFAULT_DATA_FILL_COLOR),
+        DEFAULT_DATA_FILL_OPACITY,
+        hexToRgb(DEFAULT_DATA_STROKE_COLOR),
+        DEFAULT_DATA_STROKE_WIDTH,
       );
     }
   };
@@ -581,158 +552,142 @@ const SettingsPanel: React.FC<{
         )}
       </div>
 
-      {/* Customize Polygon and DataLayer colors */}
       {timeStamps && timeStamps.length > 0 && (
         <div className="dropdown-button">
-        <button
-          className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
-          onClick={() => toggleDropdown('style')}
-          aria-expanded={dropdownState.activeButton === 'style'}
-          aria-label="style"
-          data-testid="style-dropdown-button"
-        >
-          <LuPalette size={32} />
-        </button>
-        {dropdownState.activeButton === 'style' && (
-          <div className="dropdown-content show">
-            <div className="style-options">
-              <div className="style-tabs">
-                <button
-                  className={`style-tab ${selectedStyleTab === 'polygon' ? 'active' : ''}`}
-                  onClick={() => setSelectedStyleTab('polygon')}
-                >
-                  {t('polygon')}
-                </button>
-                <button
-                  className={`style-tab ${selectedStyleTab === 'dataLayer' ? 'active' : ''}`}
-                  onClick={() => setSelectedStyleTab('dataLayer')}
-                >
-                  {t('data_layer')}
-                </button>
-              </div>
-
-              <h2>
-                {selectedStyleTab === 'polygon' ? t('polygon_style') : t('data_layer_style')}
-              </h2>
-
-              {selectedStyleTab === 'polygon' ? (
-                // Polygon style controls
-                <>
-                  <div className="style-option">
-                    <label>{t('fill')}:</label>
-                    <input
-                      type="color"
-                      value={polygonFillColor}
-                      onChange={(e) => setPolygonFillColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('fill_opacity')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.1"
-                      value={polygonFillOpacity}
-                      onChange={(e) => setPolygonFillOpacity(e.target.value)}
-                    />
-                    <span>{polygonFillOpacity}</span>
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke')}:</label>
-                    <input
-                      type="color"
-                      value={polygonStrokeColor}
-                      onChange={(e) => setPolygonStrokeColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke_width')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="5"
-                      step="0.5"
-                      value={polygonStrokeWidth}
-                      onChange={(e) => setPolygonStrokeWidth(e.target.value)}
-                    />
-                    <span>{polygonStrokeWidth}</span>
-                  </div>
-                </>
-              ) : (
-                // Data layer style controls
-                <>
-                  <div className="style-option">
-                    <label>{t('fill')}:</label>
-                    <input
-                      type="color"
-                      value={dataLayerFillColor}
-                      onChange={(e) => setDataLayerFillColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('fill_opacity')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.1"
-                      value={dataLayerFillOpacity}
-                      onChange={(e) => setDataLayerFillOpacity(e.target.value)}
-                    />
-                    <span>{dataLayerFillOpacity}</span>
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke')}:</label>
-                    <input
-                      type="color"
-                      value={dataLayerStrokeColor}
-                      onChange={(e) => setDataLayerStrokeColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke_width')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="5"
-                      step="0.5"
-                      value={dataLayerStrokeWidth}
-                      onChange={(e) => setDataLayerStrokeWidth(e.target.value)}
-                    />
-                    <span>{dataLayerStrokeWidth}</span>
-                  </div>
-                </>
-              )}
-
-              <div className="style-buttons">
-                <button
-                  className="update-style-btn"
-                  onClick={handleUpdateLayerStyle}
-                >
-                  {t('update_style')}
-                </button>
-                <button
-                  className="reset-style-btn"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleResetLayerStyle();
-                  }}
-                >
-                  {t('reset_style')}
-                </button>
+          <button
+            className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
+            onClick={() => toggleDropdown('style')}
+            aria-expanded={dropdownState.activeButton === 'style'}
+            aria-label="style"
+            data-testid="style-dropdown-button"
+          >
+            <LuPalette size={32} />
+          </button>
+          {dropdownState.activeButton === 'style' && (
+            <div className="dropdown-content show">
+              <div className="style-options">
+                <div className="style-tabs">
+                  <button
+                    className={`style-tab ${selectedStyleTab === 'polygon' ? 'active' : ''}`}
+                    onClick={() => setSelectedStyleTab('polygon')}
+                  >
+                    {t('polygon')}
+                  </button>
+                  <button
+                    className={`style-tab ${selectedStyleTab === 'dataLayer' ? 'active' : ''}`}
+                    onClick={() => setSelectedStyleTab('dataLayer')}
+                  >
+                    {t('data_layer')}
+                  </button>
+                </div>
+                <h2>
+                  {selectedStyleTab === 'polygon' ? t('polygon_style') : t('data_layer_style')}
+                </h2>
+                {selectedStyleTab === 'polygon' ? (
+                  <>
+                    <div className="style-option">
+                      <label>{t('fill')}:</label>
+                      <input
+                        type="color"
+                        value={polygonFillColor}
+                        onChange={(e) => setPolygonFillColor(e.target.value)}
+                      />
+                    </div>
+                    <div className="style-option">
+                      <label>{t('fill_opacity')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={polygonFillOpacity}
+                        onChange={(e) => setPolygonFillOpacity(e.target.value)}
+                      />
+                      <span>{polygonFillOpacity}</span>
+                    </div>
+                    <div className="style-option">
+                      <label>{t('stroke')}:</label>
+                      <input
+                        type="color"
+                        value={polygonStrokeColor}
+                        onChange={(e) => setPolygonStrokeColor(e.target.value)}
+                      />
+                    </div>
+                    <div className="style-option">
+                      <label>{t('stroke_width')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="5"
+                        step="0.5"
+                        value={polygonStrokeWidth}
+                        onChange={(e) => setPolygonStrokeWidth(e.target.value)}
+                      />
+                      <span>{polygonStrokeWidth}</span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="style-option">
+                      <label>{t('fill')}:</label>
+                      <input
+                        type="color"
+                        value={dataLayerFillColor}
+                        onChange={(e) => setDataLayerFillColor(e.target.value)}
+                      />
+                    </div>
+                    <div className="style-option">
+                      <label>{t('fill_opacity')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={dataLayerFillOpacity}
+                        onChange={(e) => setDataLayerFillOpacity(e.target.value)}
+                      />
+                      <span>{dataLayerFillOpacity}</span>
+                    </div>
+                    <div className="style-option">
+                      <label>{t('stroke')}:</label>
+                      <input
+                        type="color"
+                        value={dataLayerStrokeColor}
+                        onChange={(e) => setDataLayerStrokeColor(e.target.value)}
+                      />
+                    </div>
+                    <div className="style-option">
+                      <label>{t('stroke_width')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="5"
+                        step="0.5"
+                        value={dataLayerStrokeWidth}
+                        onChange={(e) => setDataLayerStrokeWidth(e.target.value)}
+                      />
+                      <span>{dataLayerStrokeWidth}</span>
+                    </div>
+                  </>
+                )}
+                <div className="style-buttons">
+                  <button className="update-style-btn" onClick={handleUpdateLayerStyle}>
+                    {t('update_style')}
+                  </button>
+                  <button
+                    className="reset-style-btn"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleResetLayerStyle();
+                    }}
+                  >
+                    {t('reset_style')}
+                  </button>
+                </div>
               </div>
             </div>
-
-          </div>
-        )}
-      </div>
+          )}
+        </div>
       )}
 
       <div className="dropdown-button">

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -33,21 +33,11 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const MySwal = withReactContent(Swal);
 
-interface Config {
-  endpoint?: string;
-  language?: string;
-  onlineMode?: boolean;
-  loadedDataset?: { id: string; title: string };
-  error?: string;
-  [key: string]: any;
-}
-
 const SettingsPanel: React.FC<{
   refreshDatasets: () => void;
   setMetadataVisible: (visible: boolean) => void;
 }> = ({ refreshDatasets, setMetadataVisible }) => {
   const { t, i18n } = useTranslation();
-  const queryClient = useQueryClient();
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
     isOpen: boolean;
@@ -73,79 +63,114 @@ const SettingsPanel: React.FC<{
   );
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [languageInitialized, setLanguageInitialized] = useState(false);
+  const queryClient = useQueryClient();
 
-  /**
-   * Fetches and caches the application configuration once on mount.
-   * @returns Cached config data or undefined if fetch fails.
-   */
-  const { data: configData, isLoading: configLoading } = useQuery(
-    ['config'],
-    () => getConfig(),
-    {
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      cacheTime: 10 * 60 * 1000, // 10 minutes
-      onError: () => toast.error(t('error_fetching_config_file')),
-      onSuccess: (config) => {
-        if (config && typeof config === 'object') {
-          setNewApiEndpoint(config.endpoint || 'https://default-api-endpoint.com');
-          if (config.language && config.language !== i18n.language) {
-            i18n.changeLanguage(config.language);
-          }
-          if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
-        }
-      },
+  // Fetch config query function
+  const fetchConfigQuery = async () => {
+    const config = await getConfig();
+    if (config.error) {
+      throw new Error('Error fetching config');
     }
-  );
+    return config;
+  };
 
-  /**
-   * Saves the application configuration and updates the cache.
-   * @param config - The configuration object to save.
-   * @returns Promise resolving with void (no return data assumed).
-   */
-  const saveConfigMutation = useMutation<void, unknown, Config>(
-    (config: Config) => saveConfig(config),
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries(['config']);
-      },
-      onError: (error: unknown, _variables: Config, _context: unknown) => {
-        toast.error(t('error_saving_config'));
-      },
-    }
-  );
+  // React Query hook for fetching config
+  const { data: configData } = useQuery({
+    queryKey: ['config'],
+    queryFn: fetchConfigQuery,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    cacheTime: 10 * 60 * 1000, // 10 minutes
+  });
 
-  /**
-   * Initializes language from local storage and syncs with config.
-   */
+  // Mutation for saving and fetching endpoint
+  const saveAndFetchEndpointMutation = useMutation({
+    mutationFn: async (endpointUrl: string) => {
+      if (!isValidUrl(endpointUrl)) {
+        throw new Error('invalid_url');
+      }
+
+      // Check if the URL retrieves collections
+      const verificationMessage = await verifyIfEndpointHasCollections(endpointUrl);
+      if (verificationMessage !== 'Collections found') {
+        throw new Error('no_collections_found');
+      }
+
+      // Reset collections before fetching new ones
+      await resetCollections();
+      await resetItems();
+      await resetItemAssets();
+      setSelectedAssetLayers([]);
+
+      const message = await fetchCollectionsFromEndpoint(endpointUrl);
+      if (message !== 'Collections fetched and saved successfully') {
+        throw new Error('error_fetching_collections');
+      }
+
+      // Save the new endpoint to config file
+      const config = await getConfig();
+      if (config.error) {
+        throw new Error('error_fetching_config_file');
+      }
+
+      config.endpoint = endpointUrl;
+      config.loadedDataset = { id: '', title: '' };
+      await saveConfig(config);
+
+      return true;
+    },
+    onSuccess: () => {
+      toast.success(t('collections_fetched_saved'));
+      refreshDatasets();
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+      setDropdownState({ activeButton: null, isOpen: false });
+    },
+    onError: (error: Error) => {
+      toast.error(t(error.message));
+    },
+  });
+
+  // Initialize language from local storage and handle toast messages
   useEffect(() => {
     if (
       typeof window !== 'undefined' &&
       window.localStorage &&
-      !languageInitialized &&
-      !configLoading &&
-      configData
+      !languageInitialized
     ) {
       const savedLanguage = localStorage.getItem('language');
-      if (savedLanguage && savedLanguage !== i18n.language) {
-        i18n.changeLanguage(savedLanguage);
-      } else if (!savedLanguage) {
-        localStorage.setItem('language', 'en');
-        toast.info(t('default_language_retrieved'));
-        if (configData && typeof configData === 'object') {
-          const newConfig = { ...configData, language: 'en' };
-          saveConfigMutation.mutate(newConfig);
+      if (savedLanguage) {
+        // If a language is saved in localStorage, use it
+        if (savedLanguage !== i18n.language) {
+          i18n.changeLanguage(savedLanguage); // Change language only if different from current one
         }
+      } else {
+        // If no language is saved, use the default language
+        localStorage.setItem('language', 'en');
+        toast.info(t('default_language_retrieved')); // Show default language message
+      }
+      setLanguageInitialized(true); // Mark language initialization as done
+    }
+  }, [i18n, t, languageInitialized]);
+
+  // Handle config data updates
+  useEffect(() => {
+    if (configData) {
+      if (configData.endpoint) {
+        setNewApiEndpoint(configData.endpoint);
+      }
+      if (configData.language && configData.language !== i18n.language) {
+        i18n.changeLanguage(configData.language);
       }
       setLanguageInitialized(true);
-    }
-  }, [i18n, t, languageInitialized, configLoading, configData]);
 
-  /**
-   * Prompts for an endpoint if none is saved in the cached config.
-   */
-  useEffect(() => {
-    if (!configLoading && configData && typeof configData === 'object') {
-      if (!configData.endpoint || configData.endpoint === 'No endpoint saved') {
+      if (configData.onlineMode != undefined) {
+        setIsOnline(configData.onlineMode);
+      }
+
+      // Check if endpoint is "No endpoint saved" and prompt user to enter a new one
+      if (
+        configData.endpoint === 'No endpoint saved' ||
+        configData.endpoint === undefined
+      ) {
         promptForEndpoint(
           refreshDatasets,
           t,
@@ -156,34 +181,14 @@ const SettingsPanel: React.FC<{
         );
       }
     }
-  }, [configLoading, configData, refreshDatasets, t]);
+  }, [configData, i18n]);
 
-  /**
-   * Toggles dropdown state using cached config data for settings.
-   * @param buttonName - The name of the button triggering the dropdown.
-   */
+  // Toggles dropdown state
   const toggleDropdown = (buttonName: string) => {
-    if (buttonName === 'settings' && configData?.endpoint) {
-      setNewApiEndpoint(configData.endpoint); // Use cached data instead of fetching
-    }
     setDropdownState((prevState) => ({
       activeButton: prevState.activeButton === buttonName ? null : buttonName,
       isOpen: prevState.activeButton !== buttonName,
     }));
-  };
-
-  /**
-   * Handles language selection and updates config via mutation.
-   * @param language - The selected language code (e.g., 'en', 'fr').
-   */
-  const handleLanguageSelect = (language: string) => {
-    i18n.changeLanguage(language);
-    localStorage.setItem('language', language);
-    if (configData && typeof configData === 'object') {
-      const newConfig = { ...configData, language };
-      saveConfigMutation.mutate(newConfig);
-    }
-    setDropdownState({ activeButton: null, isOpen: false });
   };
 
   const handleSaveAndFetchEndpoint = async (
@@ -191,12 +196,15 @@ const SettingsPanel: React.FC<{
   ): Promise<boolean> => {
     if (isValidUrl(endpointUrl)) {
       try {
-        const verificationMessage = await verifyIfEndpointHasCollections(endpointUrl);
+        // Check if the URL retrieves collections
+        const verificationMessage =
+          await verifyIfEndpointHasCollections(endpointUrl);
         if (verificationMessage !== 'Collections found') {
           toast.error(t('no_collections_found'));
           return false;
         }
 
+        // Reset collections before fetching new ones
         await resetCollections();
         await resetItems();
         await resetItemAssets();
@@ -207,17 +215,22 @@ const SettingsPanel: React.FC<{
           toast.success(t('collections_fetched_saved'));
         }
 
-        const config = configData || (await getConfig());
+        // Save the new endpoint to config file
+        const config = await getConfig();
+        // If an error occurred during fetching config, show error and do not save changes
         if (config.error) {
           toast.error(t('error_fetching_config_file'));
           return false;
         }
 
-        const newConfig = { ...config, endpoint: endpointUrl, loadedDataset: { id: '', title: '' } };
-        saveConfigMutation.mutate(newConfig);
+        config.endpoint = endpointUrl;
+        config.loadedDataset = { id: '', title: '' };
+        await saveConfig(config);
 
-        refreshDatasets();
+        refreshDatasets(); // Trigger the refresh
+
         setDropdownState({ activeButton: null, isOpen: false });
+
         return true;
       } catch (error: any) {
         toast.error(t('error_fetching_collections'));
@@ -229,6 +242,12 @@ const SettingsPanel: React.FC<{
     }
   };
 
+  const handleLanguageSelect = (language: string) => {
+    i18n.changeLanguage(language);
+    localStorage.setItem('language', language);
+    setDropdownState({ activeButton: null, isOpen: false });
+  };
+
   const handleReset = async () => {
     MySwal.fire({
       title: t('reset'),
@@ -238,9 +257,12 @@ const SettingsPanel: React.FC<{
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
-      customClass: { popup: 'custom-swal-popup' },
+      customClass: {
+        popup: 'custom-swal-popup',
+      },
     }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
+        // reset localStorage properties to default properties
         localStorage.setItem('language', 'en');
         localStorage.setItem('playbackSpeed', '1');
         localStorage.setItem('sliderValue', '0');
@@ -248,10 +270,7 @@ const SettingsPanel: React.FC<{
         setSliderValue(0);
         setSpeed(1);
         handleResetLayerStyle(true);
-        if (configData && typeof configData === 'object') {
-          const newConfig = { ...configData, language: 'en' };
-          saveConfigMutation.mutate(newConfig);
-        }
+
         toast.success(t('reset_completed'));
       }
     });
@@ -275,7 +294,9 @@ const SettingsPanel: React.FC<{
       confirmButtonColor: '#3085d6',
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
-      customClass: { popup: 'custom-swal-popup' },
+      customClass: {
+        popup: 'custom-swal-popup',
+      },
     }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
         try {
@@ -288,7 +309,8 @@ const SettingsPanel: React.FC<{
             getConfig,
             saveConfig,
           );
-          setMetadataVisible(false);
+          setMetadataVisible(false); // Hide metadata container
+          queryClient.invalidateQueries({ queryKey: ['config'] });
         } catch (error: any) {
           toast.error(error.message);
         }
@@ -300,13 +322,16 @@ const SettingsPanel: React.FC<{
 
   const handleSelectOnlineMode = async (onlineMode: boolean) => {
     setIsOnline(onlineMode);
-    const config = configData || (await getConfig());
+
+    const config = await getConfig();
+    // If an error occurred during fetching config, show error and do not save changes
     if (config.error) {
       toast.error(t('error_fetching_config_file'));
       return false;
     }
-    const newConfig = { ...config, onlineMode };
-    saveConfigMutation.mutate(newConfig);
+    config.onlineMode = onlineMode;
+    await saveConfig(config);
+    queryClient.invalidateQueries({ queryKey: ['config'] });
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -372,18 +397,7 @@ const SettingsPanel: React.FC<{
 
       if (inputResult.isConfirmed) {
         success = await handleSaveAndFetchEndpoint(inputResult.value);
-      } else {  
-        const config = configData || (await getConfig());
-        if (config.error) {
-          toast.error(t('error_fetching_config_file'));
-          break;
-        }
-        const newConfig = {
-          ...config,
-          endpoint: 'No endpoint saved',
-          loadedDataset: { id: '', title: '' },
-        };
-        saveConfigMutation.mutate(newConfig);
+      } else {
         refreshDatasets(); // Trigger the refresh
         break; // Exit the loop if the user cancels the input dialog
       }
@@ -422,16 +436,16 @@ const SettingsPanel: React.FC<{
     toast.success(t('copied_to_clipboard'));
   };
 
-  // Default style values for Polygon
-  const DEFAULT_FILL_COLOR = '#ff0000';
+  // Default style values for item_layer
+  const DEFAULT_FILL_COLOR = '#ff0000'; // Red
   const DEFAULT_FILL_OPACITY = '0.1';
-  const DEFAULT_STROKE_COLOR = '#ff0000';
+  const DEFAULT_STROKE_COLOR = '#ff0000'; // Red
   const DEFAULT_STROKE_WIDTH = '2';
 
   // Default style values for DataLayer
   const DEFAULT_DATA_FILL_COLOR = '#0000ff'; // Blue
   const DEFAULT_DATA_FILL_OPACITY = '0.1';
-  const DEFAULT_DATA_STROKE_COLOR = '#0000ff';
+  const DEFAULT_DATA_STROKE_COLOR = '#0000ff'; // Blue
   const DEFAULT_DATA_STROKE_WIDTH = '2';
 
   // Tab selection state
@@ -470,9 +484,11 @@ const SettingsPanel: React.FC<{
       : 'rgb(0,0,0)';
   };
 
+  // Update itemLayer and dataLayer style
   const handleUpdateLayerStyle = () => {
     if (!mapRef.current) return;
-    if (selectedStyleTab === 'polygon') {
+
+    if (selectedStyleTab === 'item_layer') {
       updateLayerStyle(
         mapRef.current,
         'itemLayer',
@@ -493,13 +509,17 @@ const SettingsPanel: React.FC<{
     }
   };
 
+  // Reset itemLayer and dataLayer style
   const handleResetLayerStyle = (resetBoth = false) => {
     if (!mapRef.current) return;
-    if (resetBoth || selectedStyleTab === 'polygon') {
-      setPolygonFillColor(DEFAULT_FILL_COLOR);
-      setPolygonFillOpacity(DEFAULT_FILL_OPACITY);
-      setPolygonStrokeColor(DEFAULT_STROKE_COLOR);
-      setPolygonStrokeWidth(DEFAULT_STROKE_WIDTH);
+
+    if (resetBoth || selectedStyleTab === 'item_layer') {
+      // Reset itemLayer state
+      setItemLayerFillColor(DEFAULT_FILL_COLOR);
+      setItemLayerFillOpacity(DEFAULT_FILL_OPACITY);
+      setItemLayerStrokeColor(DEFAULT_STROKE_COLOR);
+      setItemLayerStrokeWidth(DEFAULT_STROKE_WIDTH);
+
       updateLayerStyle(
         mapRef.current,
         'itemLayer',
@@ -509,11 +529,14 @@ const SettingsPanel: React.FC<{
         DEFAULT_STROKE_WIDTH,
       );
     }
-    if (resetBoth || selectedStyleTab === 'dataLayer') {
+
+    if (resetBoth || selectedStyleTab === 'data_layer') {
+      // Reset data layer state with blue defaults
       setDataLayerFillColor('#0000ff');
       setDataLayerFillOpacity('0.1');
       setDataLayerStrokeColor('#0000ff');
       setDataLayerStrokeWidth('2');
+
       updateLayerStyle(
         mapRef.current,
         'dataLayer',
@@ -546,10 +569,22 @@ const SettingsPanel: React.FC<{
                   type="text"
                   placeholder={t('enter_new_api_endpoint')}
                   value={newApiEndpoint}
-                  disabled
+                  onChange={(e) => setNewApiEndpoint(e.target.value)}
+                  disabled={saveAndFetchEndpointMutation.isPending}
                 />
                 <button onClick={copyToClipboard} aria-label="copy">
                   <IoCopyOutline size={24} />
+                </button>
+                <button
+                  onClick={() => handleSaveAndFetchEndpoint(newApiEndpoint)}
+                  disabled={saveAndFetchEndpointMutation.isPending}
+                  aria-label="save"
+                >
+                  {saveAndFetchEndpointMutation.isPending ? (
+                    <span>Loading...</span>
+                  ) : (
+                    <IoCheckmark size={24} />
+                  )}
                 </button>
               </div>
             </div>
@@ -623,7 +658,6 @@ const SettingsPanel: React.FC<{
           </div>
         )}
       </div>
-
 
       {/* Customize itemLayer and DataLayer colors */}
       {((timeStamps && timeStamps.length > 0) || isCollectionsLoaded) && (

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -30,7 +30,7 @@ import { getConfig, saveConfig } from '../services/configApi';
 import { changeLayer, updateLayerStyle } from './MapView';
 import { Map } from 'ol';
 import { LuPalette } from 'react-icons/lu';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const MySwal = withReactContent(Swal);
 
@@ -39,7 +39,7 @@ const SettingsPanel: React.FC<{
   setMetadataVisible: (visible: boolean) => void;
 }> = ({ refreshDatasets, setMetadataVisible }) => {
   const { t, i18n } = useTranslation();
-  const queryClient = useQueryClient(); // Access the QueryClient from ClientLayout
+  const queryClient = useQueryClient();
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
     isOpen: boolean;
@@ -58,7 +58,7 @@ const SettingsPanel: React.FC<{
     setIsPlaying,
     setSelectedAssetLayers,
     isCollectionsLoaded,
-    setIsCollectionsLoaded
+    setIsCollectionsLoaded,
   } = useMapLayerContext();
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
     'https://default-api-endpoint.com',
@@ -84,6 +84,35 @@ const SettingsPanel: React.FC<{
         }
         if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
         setLanguageInitialized(true);
+      },
+    }
+  );
+
+  // UseMutation for updating language
+  const updateLanguageMutation = useMutation(
+    (newConfig: any) => saveConfig(newConfig),
+    {
+      onMutate: async (newConfig) => {
+        // Cancel any outgoing refetches (to avoid overwriting optimistic update)
+        await queryClient.cancelQueries(['config']);
+
+        // Snapshot the previous value
+        const previousConfig = queryClient.getQueryData(['config']);
+
+        // Optimistically update the cache
+        queryClient.setQueryData(['config'], newConfig);
+
+        // Return context with the previous config for rollback on error
+        return { previousConfig };
+      },
+      onError: (err, newConfig, context) => {
+        // Rollback to previous config on error
+        queryClient.setQueryData(['config'], context?.previousConfig);
+        toast.error(t('error_saving_language'));
+      },
+      onSuccess: () => {
+        // Invalidate to ensure the server state is eventually synced (optional)
+        queryClient.invalidateQueries(['config'], { refetchActive: false });
       },
     }
   );
@@ -146,7 +175,6 @@ const SettingsPanel: React.FC<{
     }
 
     try {
-      // Use fetchQuery to cache verifyIfEndpointHasCollections
       const verificationMessage = await queryClient.fetchQuery(
         ['verifyEndpoint', endpointUrl],
         () => verifyIfEndpointHasCollections(endpointUrl),
@@ -157,13 +185,11 @@ const SettingsPanel: React.FC<{
         return false;
       }
 
-      // Reset collections before fetching new ones
       await resetCollections();
       await resetItems();
       await resetItemAssets();
       setSelectedAssetLayers([]);
 
-      // Use fetchQuery to cache fetchCollectionsFromEndpoint
       const message = await queryClient.fetchQuery(
         ['fetchCollections', endpointUrl],
         () => fetchCollectionsFromEndpoint(endpointUrl),
@@ -173,7 +199,6 @@ const SettingsPanel: React.FC<{
         toast.success(t('collections_fetched_saved'));
       }
 
-      // Update config
       const config = configData || (await getConfig());
       if (config.error) {
         toast.error(t('error_fetching_config_file'));
@@ -182,7 +207,7 @@ const SettingsPanel: React.FC<{
       config.endpoint = endpointUrl;
       config.loadedDataset = { id: '', title: '' };
       await saveConfig(config);
-      queryClient.setQueryData(['config'], config); // Update cache manually
+      queryClient.setQueryData(['config'], config);
 
       refreshDatasets();
       setDropdownState({ activeButton: null, isOpen: false });
@@ -194,13 +219,17 @@ const SettingsPanel: React.FC<{
     }
   };
 
-  const handleLanguageSelect = async (language: string) => {
+  const handleLanguageSelect = (language: string) => {
     i18n.changeLanguage(language);
     localStorage.setItem('language', language);
-    const config = configData || (await getConfig());
-    config.language = language;
-    await saveConfig(config);
-    queryClient.setQueryData(['config'], config);
+
+    // Optimistically update the config in the cache
+    const updatedConfig = {
+      ...configData,
+      language,
+    };
+    updateLanguageMutation.mutate(updatedConfig);
+
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -301,9 +330,9 @@ const SettingsPanel: React.FC<{
       handleResetLayerStyle(true);
       setIsCollectionsLoaded(false);
       setSelectedStyleTab('item_layer');
-      queryClient.invalidateQueries(['config']); // Invalidate config cache
+      queryClient.invalidateQueries(['config']);
       return 'Reset was successful';
-    } catch (error) {
+    } catch (error: Error) {
       throw new Error(`Error resetting config: ${error.message}`);
     }
   };
@@ -387,24 +416,44 @@ const SettingsPanel: React.FC<{
   const DEFAULT_DATA_STROKE_WIDTH = '2';
 
   // Tab selection state
-  const [selectedStyleTab, setSelectedStyleTab] = useState<'item_layer' | 'data_layer'>('data_layer');
+  const [selectedStyleTab, setSelectedStyleTab] = useState<
+    'item_layer' | 'data_layer'
+  >('data_layer');
 
   // ItemLayer style state
-  const [itemLayerFillColor, setItemLayerFillColor] = useState(DEFAULT_FILL_COLOR);
-  const [itemLayerFillOpacity, setItemLayerFillOpacity] = useState(DEFAULT_FILL_OPACITY);
-  const [itemLayerStrokeColor, setItemLayerStrokeColor] = useState(DEFAULT_STROKE_COLOR);
-  const [itemLayerStrokeWidth, setItemLayerStrokeWidth] = useState(DEFAULT_STROKE_WIDTH);
+  const [itemLayerFillColor, setItemLayerFillColor] =
+    useState(DEFAULT_FILL_COLOR);
+  const [itemLayerFillOpacity, setItemLayerFillOpacity] = useState(
+    DEFAULT_FILL_OPACITY,
+  );
+  const [itemLayerStrokeColor, setItemLayerStrokeColor] = useState(
+    DEFAULT_STROKE_COLOR,
+  );
+  const [itemLayerStrokeWidth, setItemLayerStrokeWidth] = useState(
+    DEFAULT_STROKE_WIDTH,
+  );
 
   // DataLayer style state
-  const [dataLayerFillColor, setDataLayerFillColor] = useState(DEFAULT_DATA_FILL_COLOR);
-  const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(DEFAULT_DATA_FILL_OPACITY);
-  const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(DEFAULT_DATA_STROKE_COLOR);
-  const [dataLayerStrokeWidth, setDataLayerStrokeWidth] = useState(DEFAULT_DATA_STROKE_WIDTH);
+  const [dataLayerFillColor, setDataLayerFillColor] = useState(
+    DEFAULT_DATA_FILL_COLOR,
+  );
+  const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(
+    DEFAULT_DATA_FILL_OPACITY,
+  );
+  const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(
+    DEFAULT_DATA_STROKE_COLOR,
+  );
+  const [dataLayerStrokeWidth, setDataLayerStrokeWidth] = useState(
+    DEFAULT_DATA_STROKE_WIDTH,
+  );
 
   const hexToRgb = (hex: string) => {
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result
-      ? `rgb(${parseInt(result[1], 16)},${parseInt(result[2], 16)},${parseInt(result[3], 16)})`
+      ? `rgb(${parseInt(result[1], 16)},${parseInt(result[2], 16)},${parseInt(
+        result[3],
+        16,
+      )})`
       : 'rgb(0,0,0)';
   };
 
@@ -419,7 +468,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(itemLayerFillColor),
         itemLayerFillOpacity,
         hexToRgb(itemLayerStrokeColor),
-        itemLayerStrokeWidth
+        itemLayerStrokeWidth,
       );
     } else {
       updateLayerStyle(
@@ -438,7 +487,6 @@ const SettingsPanel: React.FC<{
     if (!mapRef.current) return;
 
     if (resetBoth || selectedStyleTab === 'item_layer') {
-      // Reset itemLayer state
       setItemLayerFillColor(DEFAULT_FILL_COLOR);
       setItemLayerFillOpacity(DEFAULT_FILL_OPACITY);
       setItemLayerStrokeColor(DEFAULT_STROKE_COLOR);
@@ -455,7 +503,6 @@ const SettingsPanel: React.FC<{
     }
 
     if (resetBoth || selectedStyleTab === 'data_layer') {
-      // Reset data layer state with blue defaults
       setDataLayerFillColor('#0000ff');
       setDataLayerFillOpacity('0.1');
       setDataLayerStrokeColor('#0000ff');
@@ -476,7 +523,9 @@ const SettingsPanel: React.FC<{
     <div className="button-container" ref={dropdownRef}>
       <div className="dropdown-button">
         <button
-          className={`button ${dropdownState.activeButton === 'settings' ? 'active' : ''}`}
+          className={`button ${
+            dropdownState.activeButton === 'settings' ? 'active' : ''
+          }`}
           onClick={() => toggleDropdown('settings')}
           aria-expanded={dropdownState.activeButton === 'settings'}
           aria-label="settings"
@@ -506,7 +555,9 @@ const SettingsPanel: React.FC<{
 
       <div className="dropdown-button">
         <button
-          className={`button ${dropdownState.activeButton === 'language' ? 'active' : ''}`}
+          className={`button ${
+            dropdownState.activeButton === 'language' ? 'active' : ''
+          }`}
           onClick={() => toggleDropdown('language')}
           aria-expanded={dropdownState.activeButton === 'language'}
           aria-label="language"
@@ -537,7 +588,9 @@ const SettingsPanel: React.FC<{
 
       <div className="dropdown-button">
         <button
-          className={`button ${dropdownState.activeButton === 'internet' ? 'active' : ''}`}
+          className={`button ${
+            dropdownState.activeButton === 'internet' ? 'active' : ''
+          }`}
           onClick={() => toggleDropdown('internet')}
           aria-expanded={dropdownState.activeButton === 'internet'}
           aria-label="internet"
@@ -571,165 +624,184 @@ const SettingsPanel: React.FC<{
         )}
       </div>
 
-      {/* Customize itemLayer and DataLayer colors */}
-      {((timeStamps && timeStamps.length > 0) || (isCollectionsLoaded)) && (
+      {((timeStamps && timeStamps.length > 0) || isCollectionsLoaded) && (
         <div className="dropdown-button">
-        <button
-          className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
-          onClick={() => toggleDropdown('style')}
-          aria-expanded={dropdownState.activeButton === 'style'}
-          aria-label="style"
-          data-testid="style-dropdown-button"
-        >
-          <LuPalette size={32} />
-        </button>
-        {dropdownState.activeButton === 'style' && (
-          <div className="dropdown-content show">
-            <div className="style-options">
-              <div className="style-tabs">
-                {(timeStamps && timeStamps.length > 0) && (
-                  <button
-                    className={`style-tab ${selectedStyleTab === 'item_layer' ? 'active' : ''}`}
-                    onClick={() => setSelectedStyleTab('item_layer')}
-                  >
-                    {t('item_layer')}
-                  </button>
+          <button
+            className={`button ${
+              dropdownState.activeButton === 'style' ? 'active' : ''
+            }`}
+            onClick={() => toggleDropdown('style')}
+            aria-expanded={dropdownState.activeButton === 'style'}
+            aria-label="style"
+            data-testid="style-dropdown-button"
+          >
+            <LuPalette size={32} />
+          </button>
+          {dropdownState.activeButton === 'style' && (
+            <div className="dropdown-content show">
+              <div className="style-options">
+                <div className="style-tabs">
+                  {timeStamps && timeStamps.length > 0 && (
+                    <button
+                      className={`style-tab ${
+                        selectedStyleTab === 'item_layer' ? 'active' : ''
+                      }`}
+                      onClick={() => setSelectedStyleTab('item_layer')}
+                    >
+                      {t('item_layer')}
+                    </button>
+                  )}
+                  {isCollectionsLoaded && (
+                    <button
+                      className={`style-tab ${
+                        selectedStyleTab === 'data_layer' ? 'active' : ''
+                      }`}
+                      onClick={() => setSelectedStyleTab('data_layer')}
+                    >
+                      {t('data_layer')}
+                    </button>
+                  )}
+                </div>
+                <h2>
+                  {selectedStyleTab === 'item_layer'
+                    ? t('item_layer_style')
+                    : t('data_layer_style')}
+                </h2>
+
+                {selectedStyleTab === 'item_layer' ? (
+                  <>
+                    <div className="style-option">
+                      <label>{t('fill')}:</label>
+                      <input
+                        type="color"
+                        value={itemLayerFillColor}
+                        onChange={(e) => setItemLayerFillColor(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('fill_opacity')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={itemLayerFillOpacity}
+                        onChange={(e) =>
+                          setItemLayerFillOpacity(e.target.value)
+                        }
+                      />
+                      <span>{itemLayerFillOpacity}</span>
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke')}:</label>
+                      <input
+                        type="color"
+                        value={itemLayerStrokeColor}
+                        onChange={(e) =>
+                          setItemLayerStrokeColor(e.target.value)
+                        }
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke_width')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="5"
+                        step="0.5"
+                        value={itemLayerStrokeWidth}
+                        onChange={(e) =>
+                          setItemLayerStrokeWidth(e.target.value)
+                        }
+                      />
+                      <span>{itemLayerStrokeWidth}</span>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="style-option">
+                      <label>{t('fill')}:</label>
+                      <input
+                        type="color"
+                        value={dataLayerFillColor}
+                        onChange={(e) => setDataLayerFillColor(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('fill_opacity')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={dataLayerFillOpacity}
+                        onChange={(e) =>
+                          setDataLayerFillOpacity(e.target.value)
+                        }
+                      />
+                      <span>{dataLayerFillOpacity}</span>
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke')}:</label>
+                      <input
+                        type="color"
+                        value={dataLayerStrokeColor}
+                        onChange={(e) =>
+                          setDataLayerStrokeColor(e.target.value)
+                        }
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke_width')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="5"
+                        step="0.5"
+                        value={dataLayerStrokeWidth}
+                        onChange={(e) =>
+                          setDataLayerStrokeWidth(e.target.value)
+                        }
+                      />
+                      <span>{dataLayerStrokeWidth}</span>
+                    </div>
+                  </>
                 )}
-                {isCollectionsLoaded && (
+
+                <div className="style-buttons">
                   <button
-                    className={`style-tab ${selectedStyleTab === 'data_layer' ? 'active' : ''}`}
-                    onClick={() => setSelectedStyleTab('data_layer')}
+                    className="update-style-btn"
+                    onClick={handleUpdateLayerStyle}
                   >
-                    {t('data_layer')}
+                    {t('update_style')}
                   </button>
-                )}
-              </div>
-              <h2>
-                {selectedStyleTab === 'item_layer' ? t('item_layer_style') : t('data_layer_style')}
-              </h2>
-
-              {selectedStyleTab === 'item_layer' ? (
-                // itemLayer style controls
-                <>
-                  <div className="style-option">
-                    <label>{t('fill')}:</label>
-                    <input
-                      type="color"
-                      value={itemLayerFillColor}
-                      onChange={(e) => setItemLayerFillColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('fill_opacity')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.1"
-                      value={itemLayerFillOpacity}
-                      onChange={(e) => setItemLayerFillOpacity(e.target.value)}
-                    />
-                    <span>{itemLayerFillOpacity}</span>
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke')}:</label>
-                    <input
-                      type="color"
-                      value={itemLayerStrokeColor}
-                      onChange={(e) => setItemLayerStrokeColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke_width')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="5"
-                      step="0.5"
-                      value={itemLayerStrokeWidth}
-                      onChange={(e) => setItemLayerStrokeWidth(e.target.value)}
-                    />
-                    <span>{itemLayerStrokeWidth}</span>
-                  </div>
-                </>
-              ) : (
-                // Data layer style controls
-                <>
-                  <div className="style-option">
-                    <label>{t('fill')}:</label>
-                    <input
-                      type="color"
-                      value={dataLayerFillColor}
-                      onChange={(e) => setDataLayerFillColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('fill_opacity')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.1"
-                      value={dataLayerFillOpacity}
-                      onChange={(e) => setDataLayerFillOpacity(e.target.value)}
-                    />
-                    <span>{dataLayerFillOpacity}</span>
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke')}:</label>
-                    <input
-                      type="color"
-                      value={dataLayerStrokeColor}
-                      onChange={(e) => setDataLayerStrokeColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke_width')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="5"
-                      step="0.5"
-                      value={dataLayerStrokeWidth}
-                      onChange={(e) => setDataLayerStrokeWidth(e.target.value)}
-                    />
-                    <span>{dataLayerStrokeWidth}</span>
-                  </div>
-                </>
-              )}
-
-              <div className="style-buttons">
-                <button
-                  className="update-style-btn"
-                  onClick={handleUpdateLayerStyle}
-                >
-                  {t('update_style')}
-                </button>
-                <button
-                  className="reset-style-btn"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleResetLayerStyle();
-                  }}
-                >
-                  {t('reset_style')}
-                </button>
+                  <button
+                    className="reset-style-btn"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleResetLayerStyle();
+                    }}
+                  >
+                    {t('reset_style')}
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
         </div>
       )}
 
       <div className="dropdown-button">
         <button
-          className={`button ${dropdownState.activeButton === 'reset' ? 'active' : ''}`}
+          className={`button ${
+            dropdownState.activeButton === 'reset' ? 'active' : ''
+          }`}
           onClick={() => toggleDropdown('reset')}
           aria-expanded={dropdownState.activeButton === 'reset'}
           aria-label="reset"

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -570,17 +570,17 @@ const SettingsPanel: React.FC<{
                   placeholder={t('enter_new_api_endpoint')}
                   value={newApiEndpoint}
                   onChange={(e) => setNewApiEndpoint(e.target.value)}
-                  disabled={saveAndFetchEndpointMutation.isPending}
+                  disabled={saveAndFetchEndpointMutation.isLoading}
                 />
                 <button onClick={copyToClipboard} aria-label="copy">
                   <IoCopyOutline size={24} />
                 </button>
                 <button
                   onClick={() => handleSaveAndFetchEndpoint(newApiEndpoint)}
-                  disabled={saveAndFetchEndpointMutation.isPending}
+                  disabled={saveAndFetchEndpointMutation.isLoading}
                   aria-label="save"
                 >
-                  {saveAndFetchEndpointMutation.isPending ? (
+                  {saveAndFetchEndpointMutation.isLoading ? (
                     <span>Loading...</span>
                   ) : (
                     <IoCheckmark size={24} />

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -105,12 +105,11 @@ const SettingsPanel: React.FC<{
     (config: Config) => saveConfig(config),
     {
       onSuccess: () => {
-        // Update the cache with the latest configData if available
-        if (configData) {
-          queryClient.setQueryData(['config'], configData);
-        }
+        queryClient.invalidateQueries(['config']);
       },
-      onError: (error: unknown) => toast.error(t('error_saving_config')),
+      onError: (error: unknown, _variables: Config, _context: unknown) => {
+        toast.error(t('error_saving_config'));
+      },
     }
   );
 

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -34,6 +34,15 @@ import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const MySwal = withReactContent(Swal);
 
+interface Config {
+  endpoint?: string;
+  language?: string;
+  onlineMode?: boolean;
+  loadedDataset?: { id: string; title: string };
+  error?: string;
+  [key: string]: any;
+}
+
 const SettingsPanel: React.FC<{
   refreshDatasets: () => void;
   setMetadataVisible: (visible: boolean) => void;
@@ -57,8 +66,6 @@ const SettingsPanel: React.FC<{
     setCollectionId,
     setIsPlaying,
     setSelectedAssetLayers,
-    isCollectionsLoaded,
-    setIsCollectionsLoaded,
   } = useMapLayerContext();
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
     'https://default-api-endpoint.com',
@@ -66,65 +73,56 @@ const SettingsPanel: React.FC<{
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [languageInitialized, setLanguageInitialized] = useState(false);
 
-  // UseQuery for fetching config
-  const {
-    data: configData,
-    isLoading: configLoading,
-    error: configError,
-  } = useQuery(
+  /**
+   * Fetches and caches the application configuration once on mount.
+   * @returns Cached config data or undefined if fetch fails.
+   */
+  const { data: configData, isLoading: configLoading } = useQuery(
     ['config'],
     () => getConfig(),
     {
       staleTime: 5 * 60 * 1000, // 5 minutes
       cacheTime: 10 * 60 * 1000, // 10 minutes
+      onError: () => toast.error(t('error_fetching_config_file')),
       onSuccess: (config) => {
-        if (config.endpoint) setNewApiEndpoint(config.endpoint);
-        if (config.language && config.language !== i18n.language) {
-          i18n.changeLanguage(config.language);
+        if (config && typeof config === 'object') {
+          setNewApiEndpoint(config.endpoint || 'https://default-api-endpoint.com');
+          if (config.language && config.language !== i18n.language) {
+            i18n.changeLanguage(config.language);
+          }
+          if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
         }
-        if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
-        setLanguageInitialized(true);
       },
     }
   );
 
-  // UseMutation for updating language
-  const updateLanguageMutation = useMutation(
-    (newConfig: any) => saveConfig(newConfig),
+  /**
+   * Saves the application configuration and updates the cache.
+   * @param config - The configuration object to save.
+   * @returns Promise resolving with void (no return data assumed).
+   */
+  const saveConfigMutation = useMutation<void, unknown, Config>(
+    (config: Config) => saveConfig(config),
     {
-      onMutate: async (newConfig) => {
-        // Cancel any outgoing refetches (to avoid overwriting optimistic update)
-        await queryClient.cancelQueries(['config']);
-
-        // Snapshot the previous value
-        const previousConfig = queryClient.getQueryData(['config']);
-
-        // Optimistically update the cache
-        queryClient.setQueryData(['config'], newConfig);
-
-        // Return context with the previous config for rollback on error
-        return { previousConfig };
-      },
-      onError: (err, newConfig, context) => {
-        // Rollback to previous config on error
-        queryClient.setQueryData(['config'], context?.previousConfig);
-        toast.error(t('error_saving_language'));
-      },
       onSuccess: () => {
-        // Invalidate to ensure the server state is eventually synced (optional)
-        queryClient.invalidateQueries(['config'], { refetchActive: false });
+        queryClient.invalidateQueries(['config']);
+      },
+      onError: (error: unknown, _variables: Config, _context: unknown) => {
+        toast.error(t('error_saving_config'));
       },
     }
   );
 
-  // Initialize language from local storage
+  /**
+   * Initializes language from local storage and syncs with config.
+   */
   useEffect(() => {
     if (
       typeof window !== 'undefined' &&
       window.localStorage &&
       !languageInitialized &&
       !configLoading &&
-      !configError
+      configData
     ) {
       const savedLanguage = localStorage.getItem('language');
       if (savedLanguage && savedLanguage !== i18n.language) {
@@ -132,33 +130,40 @@ const SettingsPanel: React.FC<{
       } else if (!savedLanguage) {
         localStorage.setItem('language', 'en');
         toast.info(t('default_language_retrieved'));
+        if (configData && typeof configData === 'object') {
+          const newConfig = { ...configData, language: 'en' };
+          saveConfigMutation.mutate(newConfig);
+        }
       }
       setLanguageInitialized(true);
     }
-  }, [i18n, t, languageInitialized, configLoading, configError]);
+  }, [i18n, t, languageInitialized, configLoading, configData]);
 
-  // Prompt for endpoint if none is saved
+  /**
+   * Prompts for an endpoint if none is saved in the cached config.
+   */
   useEffect(() => {
-    if (
-      !configLoading &&
-      !configError &&
-      (configData?.endpoint === 'No endpoint saved' || !configData?.endpoint)
-    ) {
-      promptForEndpoint(
-        refreshDatasets,
-        t,
-        MySwal,
-        handleSaveAndFetchEndpoint,
-        getConfig,
-        saveConfig,
-      );
+    if (!configLoading && configData && typeof configData === 'object') {
+      if (!configData.endpoint || configData.endpoint === 'No endpoint saved') {
+        promptForEndpoint(
+          refreshDatasets,
+          t,
+          MySwal,
+          handleSaveAndFetchEndpoint,
+          getConfig,
+          saveConfig,
+        );
+      }
     }
-  }, [configLoading, configError, configData]);
+  }, [configLoading, configData, refreshDatasets, t]);
 
-  // Toggle dropdown state
-  const toggleDropdown = async (buttonName: string) => {
+  /**
+   * Toggles dropdown state using cached config data for settings.
+   * @param buttonName - The name of the button triggering the dropdown.
+   */
+  const toggleDropdown = (buttonName: string) => {
     if (buttonName === 'settings' && configData?.endpoint) {
-      setNewApiEndpoint(configData.endpoint);
+      setNewApiEndpoint(configData.endpoint); // Use cached data instead of fetching
     }
     setDropdownState((prevState) => ({
       activeButton: prevState.activeButton === buttonName ? null : buttonName,
@@ -166,71 +171,61 @@ const SettingsPanel: React.FC<{
     }));
   };
 
-  const handleSaveAndFetchEndpoint = async (
-    endpointUrl: string,
-  ): Promise<boolean> => {
-    if (!isValidUrl(endpointUrl)) {
-      toast.error(t('invalid_url'));
-      return false;
-    }
-
-    try {
-      const verificationMessage = await queryClient.fetchQuery(
-        ['verifyEndpoint', endpointUrl],
-        () => verifyIfEndpointHasCollections(endpointUrl),
-        { staleTime: 5 * 60 * 1000 }
-      );
-      if (verificationMessage !== 'Collections found') {
-        toast.error(t('no_collections_found'));
-        return false;
-      }
-
-      await resetCollections();
-      await resetItems();
-      await resetItemAssets();
-      setSelectedAssetLayers([]);
-
-      const message = await queryClient.fetchQuery(
-        ['fetchCollections', endpointUrl],
-        () => fetchCollectionsFromEndpoint(endpointUrl),
-        { staleTime: 5 * 60 * 1000 }
-      );
-      if (message === 'Collections fetched and saved successfully') {
-        toast.success(t('collections_fetched_saved'));
-      }
-
-      const config = configData || (await getConfig());
-      if (config.error) {
-        toast.error(t('error_fetching_config_file'));
-        return false;
-      }
-      config.endpoint = endpointUrl;
-      config.loadedDataset = { id: '', title: '' };
-      await saveConfig(config);
-      queryClient.setQueryData(['config'], config);
-
-      refreshDatasets();
-      setDropdownState({ activeButton: null, isOpen: false });
-      setIsCollectionsLoaded(true);
-      return true;
-    } catch (error) {
-      toast.error(t('error_fetching_collections'));
-      return false;
-    }
-  };
-
+  /**
+   * Handles language selection and updates config via mutation.
+   * @param language - The selected language code (e.g., 'en', 'fr').
+   */
   const handleLanguageSelect = (language: string) => {
     i18n.changeLanguage(language);
     localStorage.setItem('language', language);
-
-    // Optimistically update the config in the cache
-    const updatedConfig = {
-      ...configData,
-      language,
-    };
-    updateLanguageMutation.mutate(updatedConfig);
-
+    if (configData && typeof configData === 'object') {
+      const newConfig = { ...configData, language };
+      saveConfigMutation.mutate(newConfig);
+    }
     setDropdownState({ activeButton: null, isOpen: false });
+  };
+
+  const handleSaveAndFetchEndpoint = async (
+    endpointUrl: string,
+  ): Promise<boolean> => {
+    if (isValidUrl(endpointUrl)) {
+      try {
+        const verificationMessage = await verifyIfEndpointHasCollections(endpointUrl);
+        if (verificationMessage !== 'Collections found') {
+          toast.error(t('no_collections_found'));
+          return false;
+        }
+
+        await resetCollections();
+        await resetItems();
+        await resetItemAssets();
+        setSelectedAssetLayers([]);
+
+        const message = await fetchCollectionsFromEndpoint(endpointUrl);
+        if (message === 'Collections fetched and saved successfully') {
+          toast.success(t('collections_fetched_saved'));
+        }
+
+        const config = configData || (await getConfig());
+        if (config.error) {
+          toast.error(t('error_fetching_config_file'));
+          return false;
+        }
+
+        const newConfig = { ...config, endpoint: endpointUrl, loadedDataset: { id: '', title: '' } };
+        saveConfigMutation.mutate(newConfig);
+
+        refreshDatasets();
+        setDropdownState({ activeButton: null, isOpen: false });
+        return true;
+      } catch (error: any) {
+        toast.error(t('error_fetching_collections'));
+        return false;
+      }
+    } else {
+      toast.error(t('invalid_url'));
+      return false;
+    }
   };
 
   const handleReset = async () => {
@@ -243,7 +238,7 @@ const SettingsPanel: React.FC<{
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
       customClass: { popup: 'custom-swal-popup' },
-    }).then(async (result) => {
+    }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
         localStorage.setItem('language', 'en');
         localStorage.setItem('playbackSpeed', '1');
@@ -252,9 +247,14 @@ const SettingsPanel: React.FC<{
         setSliderValue(0);
         setSpeed(1);
         handleResetLayerStyle(true);
+        if (configData && typeof configData === 'object') {
+          const newConfig = { ...configData, language: 'en' };
+          saveConfigMutation.mutate(newConfig);
+        }
         toast.success(t('reset_completed'));
       }
     });
+
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -275,22 +275,27 @@ const SettingsPanel: React.FC<{
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
       customClass: { popup: 'custom-swal-popup' },
-    }).then(async (result) => {
+    }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
         resetView();
         setSelectedAssetLayers([]);
-        await resetConfig();
-        await promptForEndpoint(
-          refreshDatasets,
-          t,
-          MySwal,
-          handleSaveAndFetchEndpoint,
-          getConfig,
-          saveConfig,
-        );
-        setMetadataVisible(false);
+        try {
+          await resetConfig();
+          await promptForEndpoint(
+            refreshDatasets,
+            t,
+            MySwal,
+            handleSaveAndFetchEndpoint,
+            getConfig,
+            saveConfig,
+          );
+          setMetadataVisible(false);
+        } catch (error: any) {
+          toast.error(error.message);
+        }
       }
     });
+
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -299,11 +304,10 @@ const SettingsPanel: React.FC<{
     const config = configData || (await getConfig());
     if (config.error) {
       toast.error(t('error_fetching_config_file'));
-      return;
+      return false;
     }
-    config.onlineMode = onlineMode;
-    await saveConfig(config);
-    queryClient.setQueryData(['config'], config);
+    const newConfig = { ...config, onlineMode };
+    saveConfigMutation.mutate(newConfig);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -319,20 +323,18 @@ const SettingsPanel: React.FC<{
       setTimeStamps([]);
       setCollectionId('');
       setSpeed(1);
+
       await resetCollections();
       await resetItems();
       await resetDatalayerView();
       await resetItemAssets();
       const map = mapRef.current as Map;
       changeLayer(map, true);
-      changeLayer(map, false, 'reset');
+      changeLayer(map, false, "reset");
       setSpeed(1);
       handleResetLayerStyle(true);
-      setIsCollectionsLoaded(false);
-      setSelectedStyleTab('item_layer');
-      queryClient.invalidateQueries(['config']);
       return 'Reset was successful';
-    } catch (error: Error) {
+    } catch (error: any) {
       throw new Error(`Error resetting config: ${error.message}`);
     }
   };
@@ -366,10 +368,8 @@ const SettingsPanel: React.FC<{
           toast.error(t('error_fetching_config_file'));
           break;
         }
-        config.endpoint = 'No endpoint saved';
-        config.loadedDataset = { id: '', title: '' };
-        await saveConfig(config);
-        queryClient.setQueryData(['config'], config);
+        const newConfig = { ...config, endpoint: 'No endpoint saved', loadedDataset: { id: '', title: '' } };
+        saveConfigMutation.mutate(newConfig);
         refreshDatasets();
         break;
       }
@@ -394,10 +394,13 @@ const SettingsPanel: React.FC<{
         setDropdownState({ activeButton: null, isOpen: false });
       }
     };
+
     if (dropdownState.isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
     }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
   }, [dropdownState.isOpen]);
 
   const copyToClipboard = () => {
@@ -405,70 +408,45 @@ const SettingsPanel: React.FC<{
     toast.success(t('copied_to_clipboard'));
   };
 
-  // Default style values for item_layer
-  const DEFAULT_FILL_COLOR = '#ff0000'; // Red
+  // Default style values for Polygon
+  const DEFAULT_FILL_COLOR = '#ff0000';
   const DEFAULT_FILL_OPACITY = '0.1';
   const DEFAULT_STROKE_COLOR = '#ff0000';
   const DEFAULT_STROKE_WIDTH = '2';
+
+  // Default style values for DataLayer
   const DEFAULT_DATA_FILL_COLOR = '#0000ff';
   const DEFAULT_DATA_FILL_OPACITY = '0.1';
   const DEFAULT_DATA_STROKE_COLOR = '#0000ff';
   const DEFAULT_DATA_STROKE_WIDTH = '2';
 
-  // Tab selection state
-  const [selectedStyleTab, setSelectedStyleTab] = useState<
-    'item_layer' | 'data_layer'
-  >('data_layer');
-
-  // ItemLayer style state
-  const [itemLayerFillColor, setItemLayerFillColor] =
-    useState(DEFAULT_FILL_COLOR);
-  const [itemLayerFillOpacity, setItemLayerFillOpacity] = useState(
-    DEFAULT_FILL_OPACITY,
-  );
-  const [itemLayerStrokeColor, setItemLayerStrokeColor] = useState(
-    DEFAULT_STROKE_COLOR,
-  );
-  const [itemLayerStrokeWidth, setItemLayerStrokeWidth] = useState(
-    DEFAULT_STROKE_WIDTH,
-  );
-
-  // DataLayer style state
-  const [dataLayerFillColor, setDataLayerFillColor] = useState(
-    DEFAULT_DATA_FILL_COLOR,
-  );
-  const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(
-    DEFAULT_DATA_FILL_OPACITY,
-  );
-  const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(
-    DEFAULT_DATA_STROKE_COLOR,
-  );
-  const [dataLayerStrokeWidth, setDataLayerStrokeWidth] = useState(
-    DEFAULT_DATA_STROKE_WIDTH,
-  );
+  const [selectedStyleTab, setSelectedStyleTab] = useState<'polygon' | 'dataLayer'>('polygon');
+  const [polygonFillColor, setPolygonFillColor] = useState(DEFAULT_FILL_COLOR);
+  const [polygonFillOpacity, setPolygonFillOpacity] = useState(DEFAULT_FILL_OPACITY);
+  const [polygonStrokeColor, setPolygonStrokeColor] = useState(DEFAULT_STROKE_COLOR);
+  const [polygonStrokeWidth, setPolygonStrokeWidth] = useState(DEFAULT_STROKE_WIDTH);
+  const [dataLayerFillColor, setDataLayerFillColor] = useState(DEFAULT_DATA_FILL_COLOR);
+  const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(DEFAULT_DATA_FILL_OPACITY);
+  const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(DEFAULT_DATA_STROKE_COLOR);
+  const [dataLayerStrokeWidth, setDataLayerStrokeWidth] = useState(DEFAULT_DATA_STROKE_WIDTH);
 
   const hexToRgb = (hex: string) => {
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result
-      ? `rgb(${parseInt(result[1], 16)},${parseInt(result[2], 16)},${parseInt(
-        result[3],
-        16,
-      )})`
+      ? `rgb(${parseInt(result[1], 16)},${parseInt(result[2], 16)},${parseInt(result[3], 16)})`
       : 'rgb(0,0,0)';
   };
 
-  // Update itemLayer and dataLayer style
   const handleUpdateLayerStyle = () => {
     if (!mapRef.current) return;
-
-    if (selectedStyleTab === 'item_layer') {
+    if (selectedStyleTab === 'polygon') {
       updateLayerStyle(
         mapRef.current,
         'itemLayer',
-        hexToRgb(itemLayerFillColor),
-        itemLayerFillOpacity,
-        hexToRgb(itemLayerStrokeColor),
-        itemLayerStrokeWidth,
+        hexToRgb(polygonFillColor),
+        polygonFillOpacity,
+        hexToRgb(polygonStrokeColor),
+        polygonStrokeWidth
       );
     } else {
       updateLayerStyle(
@@ -477,44 +455,39 @@ const SettingsPanel: React.FC<{
         hexToRgb(dataLayerFillColor),
         dataLayerFillOpacity,
         hexToRgb(dataLayerStrokeColor),
-        dataLayerStrokeWidth,
+        dataLayerStrokeWidth
       );
     }
   };
 
-  // Reset itemLayer and dataLayer style
   const handleResetLayerStyle = (resetBoth = false) => {
     if (!mapRef.current) return;
-
-    if (resetBoth || selectedStyleTab === 'item_layer') {
-      setItemLayerFillColor(DEFAULT_FILL_COLOR);
-      setItemLayerFillOpacity(DEFAULT_FILL_OPACITY);
-      setItemLayerStrokeColor(DEFAULT_STROKE_COLOR);
-      setItemLayerStrokeWidth(DEFAULT_STROKE_WIDTH);
-
+    if (resetBoth || selectedStyleTab === 'polygon') {
+      setPolygonFillColor(DEFAULT_FILL_COLOR);
+      setPolygonFillOpacity(DEFAULT_FILL_OPACITY);
+      setPolygonStrokeColor(DEFAULT_STROKE_COLOR);
+      setPolygonStrokeWidth(DEFAULT_STROKE_WIDTH);
       updateLayerStyle(
         mapRef.current,
         'itemLayer',
         hexToRgb(DEFAULT_FILL_COLOR),
         DEFAULT_FILL_OPACITY,
         hexToRgb(DEFAULT_STROKE_COLOR),
-        DEFAULT_STROKE_WIDTH,
+        DEFAULT_STROKE_WIDTH
       );
     }
-
-    if (resetBoth || selectedStyleTab === 'data_layer') {
+    if (resetBoth || selectedStyleTab === 'dataLayer') {
       setDataLayerFillColor('#0000ff');
       setDataLayerFillOpacity('0.1');
       setDataLayerStrokeColor('#0000ff');
       setDataLayerStrokeWidth('2');
-
       updateLayerStyle(
         mapRef.current,
         'dataLayer',
-        hexToRgb(DEFAULT_DATA_FILL_COLOR),
-        DEFAULT_DATA_FILL_OPACITY,
-        hexToRgb(DEFAULT_DATA_STROKE_COLOR),
-        DEFAULT_DATA_STROKE_WIDTH,
+        hexToRgb('#0000ff'),
+        '0.1',
+        hexToRgb('#0000ff'),
+        '2'
       );
     }
   };
@@ -523,9 +496,7 @@ const SettingsPanel: React.FC<{
     <div className="button-container" ref={dropdownRef}>
       <div className="dropdown-button">
         <button
-          className={`button ${
-            dropdownState.activeButton === 'settings' ? 'active' : ''
-          }`}
+          className={`button ${dropdownState.activeButton === 'settings' ? 'active' : ''}`}
           onClick={() => toggleDropdown('settings')}
           aria-expanded={dropdownState.activeButton === 'settings'}
           aria-label="settings"
@@ -555,9 +526,7 @@ const SettingsPanel: React.FC<{
 
       <div className="dropdown-button">
         <button
-          className={`button ${
-            dropdownState.activeButton === 'language' ? 'active' : ''
-          }`}
+          className={`button ${dropdownState.activeButton === 'language' ? 'active' : ''}`}
           onClick={() => toggleDropdown('language')}
           aria-expanded={dropdownState.activeButton === 'language'}
           aria-label="language"
@@ -588,9 +557,7 @@ const SettingsPanel: React.FC<{
 
       <div className="dropdown-button">
         <button
-          className={`button ${
-            dropdownState.activeButton === 'internet' ? 'active' : ''
-          }`}
+          className={`button ${dropdownState.activeButton === 'internet' ? 'active' : ''}`}
           onClick={() => toggleDropdown('internet')}
           aria-expanded={dropdownState.activeButton === 'internet'}
           aria-label="internet"
@@ -624,12 +591,10 @@ const SettingsPanel: React.FC<{
         )}
       </div>
 
-      {((timeStamps && timeStamps.length > 0) || isCollectionsLoaded) && (
+      {timeStamps && timeStamps.length > 0 && (
         <div className="dropdown-button">
           <button
-            className={`button ${
-              dropdownState.activeButton === 'style' ? 'active' : ''
-            }`}
+            className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
             onClick={() => toggleDropdown('style')}
             aria-expanded={dropdownState.activeButton === 'style'}
             aria-label="style"
@@ -641,44 +606,32 @@ const SettingsPanel: React.FC<{
             <div className="dropdown-content show">
               <div className="style-options">
                 <div className="style-tabs">
-                  {timeStamps && timeStamps.length > 0 && (
-                    <button
-                      className={`style-tab ${
-                        selectedStyleTab === 'item_layer' ? 'active' : ''
-                      }`}
-                      onClick={() => setSelectedStyleTab('item_layer')}
-                    >
-                      {t('item_layer')}
-                    </button>
-                  )}
-                  {isCollectionsLoaded && (
-                    <button
-                      className={`style-tab ${
-                        selectedStyleTab === 'data_layer' ? 'active' : ''
-                      }`}
-                      onClick={() => setSelectedStyleTab('data_layer')}
-                    >
-                      {t('data_layer')}
-                    </button>
-                  )}
+                  <button
+                    className={`style-tab ${selectedStyleTab === 'polygon' ? 'active' : ''}`}
+                    onClick={() => setSelectedStyleTab('polygon')}
+                  >
+                    {t('polygon')}
+                  </button>
+                  <button
+                    className={`style-tab ${selectedStyleTab === 'dataLayer' ? 'active' : ''}`}
+                    onClick={() => setSelectedStyleTab('dataLayer')}
+                  >
+                    {t('data_layer')}
+                  </button>
                 </div>
                 <h2>
-                  {selectedStyleTab === 'item_layer'
-                    ? t('item_layer_style')
-                    : t('data_layer_style')}
+                  {selectedStyleTab === 'polygon' ? t('polygon_style') : t('data_layer_style')}
                 </h2>
-
-                {selectedStyleTab === 'item_layer' ? (
+                {selectedStyleTab === 'polygon' ? (
                   <>
                     <div className="style-option">
                       <label>{t('fill')}:</label>
                       <input
                         type="color"
-                        value={itemLayerFillColor}
-                        onChange={(e) => setItemLayerFillColor(e.target.value)}
+                        value={polygonFillColor}
+                        onChange={(e) => setPolygonFillColor(e.target.value)}
                       />
                     </div>
-
                     <div className="style-option">
                       <label>{t('fill_opacity')}:</label>
                       <input
@@ -686,25 +639,19 @@ const SettingsPanel: React.FC<{
                         min="0"
                         max="1"
                         step="0.1"
-                        value={itemLayerFillOpacity}
-                        onChange={(e) =>
-                          setItemLayerFillOpacity(e.target.value)
-                        }
+                        value={polygonFillOpacity}
+                        onChange={(e) => setPolygonFillOpacity(e.target.value)}
                       />
-                      <span>{itemLayerFillOpacity}</span>
+                      <span>{polygonFillOpacity}</span>
                     </div>
-
                     <div className="style-option">
                       <label>{t('stroke')}:</label>
                       <input
                         type="color"
-                        value={itemLayerStrokeColor}
-                        onChange={(e) =>
-                          setItemLayerStrokeColor(e.target.value)
-                        }
+                        value={polygonStrokeColor}
+                        onChange={(e) => setPolygonStrokeColor(e.target.value)}
                       />
                     </div>
-
                     <div className="style-option">
                       <label>{t('stroke_width')}:</label>
                       <input
@@ -712,12 +659,10 @@ const SettingsPanel: React.FC<{
                         min="0"
                         max="5"
                         step="0.5"
-                        value={itemLayerStrokeWidth}
-                        onChange={(e) =>
-                          setItemLayerStrokeWidth(e.target.value)
-                        }
+                        value={polygonStrokeWidth}
+                        onChange={(e) => setPolygonStrokeWidth(e.target.value)}
                       />
-                      <span>{itemLayerStrokeWidth}</span>
+                      <span>{polygonStrokeWidth}</span>
                     </div>
                   </>
                 ) : (
@@ -730,7 +675,6 @@ const SettingsPanel: React.FC<{
                         onChange={(e) => setDataLayerFillColor(e.target.value)}
                       />
                     </div>
-
                     <div className="style-option">
                       <label>{t('fill_opacity')}:</label>
                       <input
@@ -739,24 +683,18 @@ const SettingsPanel: React.FC<{
                         max="1"
                         step="0.1"
                         value={dataLayerFillOpacity}
-                        onChange={(e) =>
-                          setDataLayerFillOpacity(e.target.value)
-                        }
+                        onChange={(e) => setDataLayerFillOpacity(e.target.value)}
                       />
                       <span>{dataLayerFillOpacity}</span>
                     </div>
-
                     <div className="style-option">
                       <label>{t('stroke')}:</label>
                       <input
                         type="color"
                         value={dataLayerStrokeColor}
-                        onChange={(e) =>
-                          setDataLayerStrokeColor(e.target.value)
-                        }
+                        onChange={(e) => setDataLayerStrokeColor(e.target.value)}
                       />
                     </div>
-
                     <div className="style-option">
                       <label>{t('stroke_width')}:</label>
                       <input
@@ -765,20 +703,14 @@ const SettingsPanel: React.FC<{
                         max="5"
                         step="0.5"
                         value={dataLayerStrokeWidth}
-                        onChange={(e) =>
-                          setDataLayerStrokeWidth(e.target.value)
-                        }
+                        onChange={(e) => setDataLayerStrokeWidth(e.target.value)}
                       />
                       <span>{dataLayerStrokeWidth}</span>
                     </div>
                   </>
                 )}
-
                 <div className="style-buttons">
-                  <button
-                    className="update-style-btn"
-                    onClick={handleUpdateLayerStyle}
-                  >
+                  <button className="update-style-btn" onClick={handleUpdateLayerStyle}>
                     {t('update_style')}
                   </button>
                   <button
@@ -799,9 +731,7 @@ const SettingsPanel: React.FC<{
 
       <div className="dropdown-button">
         <button
-          className={`button ${
-            dropdownState.activeButton === 'reset' ? 'active' : ''
-          }`}
+          className={`button ${dropdownState.activeButton === 'reset' ? 'active' : ''}`}
           onClick={() => toggleDropdown('reset')}
           aria-expanded={dropdownState.activeButton === 'reset'}
           aria-label="reset"

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -30,7 +30,7 @@ import { getConfig, saveConfig } from '../services/configApi';
 import { changeLayer, updateLayerStyle } from './MapView';
 import { Map } from 'ol';
 import { LuPalette } from 'react-icons/lu';
-import { useQuery, useQueryClient } from 'react-query';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
 
 const MySwal = withReactContent(Swal);
 
@@ -39,7 +39,7 @@ const SettingsPanel: React.FC<{
   setMetadataVisible: (visible: boolean) => void;
 }> = ({ refreshDatasets, setMetadataVisible }) => {
   const { t, i18n } = useTranslation();
-  const queryClient = useQueryClient(); // Access the QueryClient from ClientLayout
+  const queryClient = useQueryClient();
   const [dropdownState, setDropdownState] = useState<{
     activeButton: string | null;
     isOpen: boolean;
@@ -64,36 +64,49 @@ const SettingsPanel: React.FC<{
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [languageInitialized, setLanguageInitialized] = useState(false);
 
-  // UseQuery for fetching config
-  const {
-    data: configData,
-    isLoading: configLoading,
-    error: configError,
-  } = useQuery(
+  /**
+   * Fetches and caches the application configuration once on mount.
+   * @returns Cached config data or undefined if fetch fails.
+   */
+  const { data: configData, isLoading: configLoading } = useQuery(
     ['config'],
     () => getConfig(),
     {
       staleTime: 5 * 60 * 1000, // 5 minutes
       cacheTime: 10 * 60 * 1000, // 10 minutes
+      onError: () => toast.error(t('error_fetching_config_file')),
       onSuccess: (config) => {
-        if (config.endpoint) setNewApiEndpoint(config.endpoint);
-        if (config.language && config.language !== i18n.language) {
-          i18n.changeLanguage(config.language);
+        if (config && typeof config === 'object') {
+          setNewApiEndpoint(config.endpoint || 'https://default-api-endpoint.com');
+          if (config.language && config.language !== i18n.language) {
+            i18n.changeLanguage(config.language);
+          }
+          if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
         }
-        if (config.onlineMode != undefined) setIsOnline(config.onlineMode);
-        setLanguageInitialized(true);
       },
     }
   );
 
-  // Initialize language from local storage
+  /**
+   * Saves the application configuration and updates the cache.
+   * @param config - The configuration object to save.
+   * @returns Promise resolving with saved config data.
+   */
+  const saveConfigMutation = useMutation((config: any) => saveConfig(config), {
+    onSuccess: (data) => queryClient.setQueryData(['config'], data), // Update cache directly
+    onError: () => toast.error(t('error_saving_config')),
+  });
+
+  /**
+   * Initializes language from local storage and syncs with config.
+   */
   useEffect(() => {
     if (
       typeof window !== 'undefined' &&
       window.localStorage &&
       !languageInitialized &&
       !configLoading &&
-      !configError
+      configData
     ) {
       const savedLanguage = localStorage.getItem('language');
       if (savedLanguage && savedLanguage !== i18n.language) {
@@ -101,33 +114,40 @@ const SettingsPanel: React.FC<{
       } else if (!savedLanguage) {
         localStorage.setItem('language', 'en');
         toast.info(t('default_language_retrieved'));
+        if (configData && typeof configData === 'object') {
+          const newConfig = { ...configData, language: 'en' };
+          saveConfigMutation.mutate(newConfig);
+        }
       }
       setLanguageInitialized(true);
     }
-  }, [i18n, t, languageInitialized, configLoading, configError]);
+  }, [i18n, t, languageInitialized, configLoading, configData]);
 
-  // Prompt for endpoint if none is saved
+  /**
+   * Prompts for an endpoint if none is saved in the cached config.
+   */
   useEffect(() => {
-    if (
-      !configLoading &&
-      !configError &&
-      (configData?.endpoint === 'No endpoint saved' || !configData?.endpoint)
-    ) {
-      promptForEndpoint(
-        refreshDatasets,
-        t,
-        MySwal,
-        handleSaveAndFetchEndpoint,
-        getConfig,
-        saveConfig,
-      );
+    if (!configLoading && configData && typeof configData === 'object') {
+      if (!configData.endpoint || configData.endpoint === 'No endpoint saved') {
+        promptForEndpoint(
+          refreshDatasets,
+          t,
+          MySwal,
+          handleSaveAndFetchEndpoint,
+          getConfig,
+          saveConfig,
+        );
+      }
     }
-  }, [configLoading, configError, configData]);
+  }, [configLoading, configData, refreshDatasets, t]);
 
-  // Toggle dropdown state
-  const toggleDropdown = async (buttonName: string) => {
+  /**
+   * Toggles dropdown state using cached config data for settings.
+   * @param buttonName - The name of the button triggering the dropdown.
+   */
+  const toggleDropdown = (buttonName: string) => {
     if (buttonName === 'settings' && configData?.endpoint) {
-      setNewApiEndpoint(configData.endpoint);
+      setNewApiEndpoint(configData.endpoint); // Use cached data instead of fetching
     }
     setDropdownState((prevState) => ({
       activeButton: prevState.activeButton === buttonName ? null : buttonName,
@@ -135,70 +155,61 @@ const SettingsPanel: React.FC<{
     }));
   };
 
+  /**
+   * Handles language selection and updates config via mutation.
+   * @param language - The selected language code (e.g., 'en', 'fr').
+   */
+  const handleLanguageSelect = (language: string) => {
+    i18n.changeLanguage(language);
+    localStorage.setItem('language', language);
+    if (configData && typeof configData === 'object') {
+      const newConfig = { ...configData, language };
+      saveConfigMutation.mutate(newConfig);
+    }
+    setDropdownState({ activeButton: null, isOpen: false });
+  };
+
   const handleSaveAndFetchEndpoint = async (
     endpointUrl: string,
   ): Promise<boolean> => {
-    if (!isValidUrl(endpointUrl)) {
+    if (isValidUrl(endpointUrl)) {
+      try {
+        const verificationMessage = await verifyIfEndpointHasCollections(endpointUrl);
+        if (verificationMessage !== 'Collections found') {
+          toast.error(t('no_collections_found'));
+          return false;
+        }
+
+        await resetCollections();
+        await resetItems();
+        await resetItemAssets();
+        setSelectedAssetLayers([]);
+
+        const message = await fetchCollectionsFromEndpoint(endpointUrl);
+        if (message === 'Collections fetched and saved successfully') {
+          toast.success(t('collections_fetched_saved'));
+        }
+
+        const config = configData || (await getConfig());
+        if (config.error) {
+          toast.error(t('error_fetching_config_file'));
+          return false;
+        }
+
+        const newConfig = { ...config, endpoint: endpointUrl, loadedDataset: { id: '', title: '' } };
+        saveConfigMutation.mutate(newConfig);
+
+        refreshDatasets();
+        setDropdownState({ activeButton: null, isOpen: false });
+        return true;
+      } catch (error: any) {
+        toast.error(t('error_fetching_collections'));
+        return false;
+      }
+    } else {
       toast.error(t('invalid_url'));
       return false;
     }
-
-    try {
-      // Use fetchQuery to cache verifyIfEndpointHasCollections
-      const verificationMessage = await queryClient.fetchQuery(
-        ['verifyEndpoint', endpointUrl],
-        () => verifyIfEndpointHasCollections(endpointUrl),
-        { staleTime: 5 * 60 * 1000 }
-      );
-      if (verificationMessage !== 'Collections found') {
-        toast.error(t('no_collections_found'));
-        return false;
-      }
-
-      // Reset collections
-      await resetCollections();
-      await resetItems();
-      await resetItemAssets();
-      setSelectedAssetLayers([]);
-
-      // Use fetchQuery to cache fetchCollectionsFromEndpoint
-      const message = await queryClient.fetchQuery(
-        ['fetchCollections', endpointUrl],
-        () => fetchCollectionsFromEndpoint(endpointUrl),
-        { staleTime: 5 * 60 * 1000 }
-      );
-      if (message === 'Collections fetched and saved successfully') {
-        toast.success(t('collections_fetched_saved'));
-      }
-
-      // Update config
-      const config = configData || (await getConfig());
-      if (config.error) {
-        toast.error(t('error_fetching_config_file'));
-        return false;
-      }
-      config.endpoint = endpointUrl;
-      config.loadedDataset = { id: '', title: '' };
-      await saveConfig(config);
-      queryClient.setQueryData(['config'], config); // Update cache manually
-
-      refreshDatasets();
-      setDropdownState({ activeButton: null, isOpen: false });
-      return true;
-    } catch (error) {
-      toast.error(t('error_fetching_collections'));
-      return false;
-    }
-  };
-
-  const handleLanguageSelect = async (language: string) => {
-    i18n.changeLanguage(language);
-    localStorage.setItem('language', language);
-    const config = configData || (await getConfig());
-    config.language = language;
-    await saveConfig(config);
-    queryClient.setQueryData(['config'], config);
-    setDropdownState({ activeButton: null, isOpen: false });
   };
 
   const handleReset = async () => {
@@ -211,7 +222,7 @@ const SettingsPanel: React.FC<{
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
       customClass: { popup: 'custom-swal-popup' },
-    }).then(async (result) => {
+    }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
         localStorage.setItem('language', 'en');
         localStorage.setItem('playbackSpeed', '1');
@@ -220,9 +231,14 @@ const SettingsPanel: React.FC<{
         setSliderValue(0);
         setSpeed(1);
         handleResetLayerStyle(true);
+        if (configData && typeof configData === 'object') {
+          const newConfig = { ...configData, language: 'en' };
+          saveConfigMutation.mutate(newConfig);
+        }
         toast.success(t('reset_completed'));
       }
     });
+
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -243,22 +259,27 @@ const SettingsPanel: React.FC<{
       cancelButtonColor: '#d33',
       confirmButtonText: t('yes'),
       customClass: { popup: 'custom-swal-popup' },
-    }).then(async (result) => {
+    }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
         resetView();
         setSelectedAssetLayers([]);
-        await resetConfig();
-        await promptForEndpoint(
-          refreshDatasets,
-          t,
-          MySwal,
-          handleSaveAndFetchEndpoint,
-          getConfig,
-          saveConfig,
-        );
-        setMetadataVisible(false);
+        try {
+          await resetConfig();
+          await promptForEndpoint(
+            refreshDatasets,
+            t,
+            MySwal,
+            handleSaveAndFetchEndpoint,
+            getConfig,
+            saveConfig,
+          );
+          setMetadataVisible(false);
+        } catch (error: any) {
+          toast.error(error.message);
+        }
       }
     });
+
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -267,11 +288,10 @@ const SettingsPanel: React.FC<{
     const config = configData || (await getConfig());
     if (config.error) {
       toast.error(t('error_fetching_config_file'));
-      return;
+      return false;
     }
-    config.onlineMode = onlineMode;
-    await saveConfig(config);
-    queryClient.setQueryData(['config'], config);
+    const newConfig = { ...config, onlineMode };
+    saveConfigMutation.mutate(newConfig);
     setDropdownState({ activeButton: null, isOpen: false });
   };
 
@@ -287,18 +307,18 @@ const SettingsPanel: React.FC<{
       setTimeStamps([]);
       setCollectionId('');
       setSpeed(1);
+
       await resetCollections();
       await resetItems();
       await resetDatalayerView();
       await resetItemAssets();
       const map = mapRef.current as Map;
       changeLayer(map, true);
-      changeLayer(map, false, 'reset');
+      changeLayer(map, false, "reset");
       setSpeed(1);
       handleResetLayerStyle(true);
-      queryClient.invalidateQueries(['config']); // Invalidate config cache
       return 'Reset was successful';
-    } catch (error) {
+    } catch (error: any) {
       throw new Error(`Error resetting config: ${error.message}`);
     }
   };
@@ -332,10 +352,8 @@ const SettingsPanel: React.FC<{
           toast.error(t('error_fetching_config_file'));
           break;
         }
-        config.endpoint = 'No endpoint saved';
-        config.loadedDataset = { id: '', title: '' };
-        await saveConfig(config);
-        queryClient.setQueryData(['config'], config);
+        const newConfig = { ...config, endpoint: 'No endpoint saved', loadedDataset: { id: '', title: '' } };
+        saveConfigMutation.mutate(newConfig);
         refreshDatasets();
         break;
       }
@@ -360,10 +378,13 @@ const SettingsPanel: React.FC<{
         setDropdownState({ activeButton: null, isOpen: false });
       }
     };
+
     if (dropdownState.isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
     }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
   }, [dropdownState.isOpen]);
 
   const copyToClipboard = () => {
@@ -371,11 +392,13 @@ const SettingsPanel: React.FC<{
     toast.success(t('copied_to_clipboard'));
   };
 
-  // Default style values
+  // Default style values for Polygon
   const DEFAULT_FILL_COLOR = '#ff0000';
   const DEFAULT_FILL_OPACITY = '0.1';
   const DEFAULT_STROKE_COLOR = '#ff0000';
   const DEFAULT_STROKE_WIDTH = '2';
+
+  // Default style values for DataLayer
   const DEFAULT_DATA_FILL_COLOR = '#0000ff';
   const DEFAULT_DATA_FILL_OPACITY = '0.1';
   const DEFAULT_DATA_STROKE_COLOR = '#0000ff';
@@ -407,7 +430,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(polygonFillColor),
         polygonFillOpacity,
         hexToRgb(polygonStrokeColor),
-        polygonStrokeWidth,
+        polygonStrokeWidth
       );
     } else {
       updateLayerStyle(
@@ -416,7 +439,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(dataLayerFillColor),
         dataLayerFillOpacity,
         hexToRgb(dataLayerStrokeColor),
-        dataLayerStrokeWidth,
+        dataLayerStrokeWidth
       );
     }
   };
@@ -434,21 +457,21 @@ const SettingsPanel: React.FC<{
         hexToRgb(DEFAULT_FILL_COLOR),
         DEFAULT_FILL_OPACITY,
         hexToRgb(DEFAULT_STROKE_COLOR),
-        DEFAULT_STROKE_WIDTH,
+        DEFAULT_STROKE_WIDTH
       );
     }
     if (resetBoth || selectedStyleTab === 'dataLayer') {
-      setDataLayerFillColor(DEFAULT_DATA_FILL_COLOR);
-      setDataLayerFillOpacity(DEFAULT_DATA_FILL_OPACITY);
-      setDataLayerStrokeColor(DEFAULT_DATA_STROKE_COLOR);
-      setDataLayerStrokeWidth(DEFAULT_DATA_STROKE_WIDTH);
+      setDataLayerFillColor('#0000ff');
+      setDataLayerFillOpacity('0.1');
+      setDataLayerStrokeColor('#0000ff');
+      setDataLayerStrokeWidth('2');
       updateLayerStyle(
         mapRef.current,
         'dataLayer',
-        hexToRgb(DEFAULT_DATA_FILL_COLOR),
-        DEFAULT_DATA_FILL_OPACITY,
-        hexToRgb(DEFAULT_DATA_STROKE_COLOR),
-        DEFAULT_DATA_STROKE_WIDTH,
+        hexToRgb('#0000ff'),
+        '0.1',
+        hexToRgb('#0000ff'),
+        '2'
       );
     }
   };

--- a/apps/geoserver_data/global.xml
+++ b/apps/geoserver_data/global.xml
@@ -60,7 +60,7 @@
     <queueType>UNBOUNDED</queueType>
     <imageIOCacheThreshold>10240</imageIOCacheThreshold>
   </coverageAccess>
-  <updateSequence>111</updateSequence>
+  <updateSequence>463</updateSequence>
   <featureTypeCacheSize>0</featureTypeCacheSize>
   <globalServices>true</globalServices>
   <xmlPostRequestLogBufferSize>1024</xmlPostRequestLogBufferSize>

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   },
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.25.9",
-    "@tanstack/react-query": "^5.69.0",
     "@types/styled-components": "^5.1.34",
-    "axios": "1.7.8",
+    "axios": "^1.7.8",
     "dotenv": "^16.4.5",
     "i18next": "^24.2.1",
     "jest-fetch-mock": "^3.0.3",
@@ -26,6 +25,7 @@
     "react-i18next": "^15.4.0",
     "react-icons": "^5.3.0",
     "react-leaflet": "^4.2.1",
+    "react-query": "^3.39.3",
     "react-toastify": "^11.0.3",
     "styled-components": "^6.1.13",
     "sweetalert2": "^11.15.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@babel/plugin-syntax-jsx": "^7.25.9",
+    "@tanstack/react-query": "^5.69.0",
     "@types/styled-components": "^5.1.34",
     "axios": "1.7.8",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
### Summary

This PR reduces frontend API calls by caching them using react-query.

### Changes Made

- Added react-query Integration
- Optimized API calls in SettingsPanel and AvailableDatasets:
       - Implemented useQuery to fetch and cache data on component mount, optimizing API calls by setting a 5-minute staleTime and a 10-minute cacheTime.
       - Added useMutation to handle data updates and directly sync the cache using setQueryData, ensuring immediate UI updates and reducing unnecessary refetching.

### Testing Instructions
1. Open the app and wait for the initial getConfig request (in Network tab on inspect).
2. Click the Settings button/Language Button (in Settings Panel) or Name/Date filters in Available Datasets 3-5 times within 5 minutes.
3. Check the Network tab for getConfig requests—only one should occur on mount.

### Video Demo
Setting Panel API calls before react-query

https://github.com/user-attachments/assets/1883b2a4-e497-4eb6-9ddc-d6403ea3b057

Setting Panel API calls with react-query

https://github.com/user-attachments/assets/1e3261ea-78a6-4b06-8d3e-4eafbc755206

AvailableDatasets API calls before react-query

https://github.com/user-attachments/assets/9ad9f66d-2393-41c3-af1c-b5c75a61126c

AvailableDatasets API calls with react-query

https://github.com/user-attachments/assets/0a15702a-0e7a-4971-9d7f-709ebe3d5ea2

### Additional Notes
I ran into some issues while implementing the react-query caching in the Footer and MapMetaData components. Since we aim to complete coding ASAP, I decided to leave those out for now. However, there are still opportunities for further optimizations to reduce API calls using react-query. 