### PR TITLE
#340 : bug(frontend) - Visibility and Behavior of Customization Palette

### DIFF
--- a/apps/frontend/__tests__/TestFooterComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestFooterComponent.spec.tsx
@@ -3,13 +3,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import Footer from '../src/app/components/Footer';
 import { MapProvider, useMapLayerContext } from '../src/app/context/MapContext';
-import {
-  fetchTimestamps,
-  getLoadedLayers,
-  loadAssetLayers,
-  loadAssets,
-  resetItemAssets,
-} from '../src/app/services/api';
+import { fetchTimestamps } from '../src/app/services/api';
 import { changeLayer } from '../src/app/components/MapView';
 
 jest.mock('ol/source/XYZ', () => jest.fn().mockImplementation(() => ({})));

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -587,7 +587,7 @@ describe(MapView, () => {
       removeLayer: jest.fn(),
     };
 
-    toggleAssetLayer(mockMap as any, 'testLayer', 'http://test.com/wms', true);
+    toggleAssetLayer(mockMap as any, 'testLayer', 'http://test.com/wms', true, 0, 100);
 
     expect(mockMap.addLayer).toHaveBeenCalled();
     expect(mockMap.renderSync).toHaveBeenCalled();
@@ -801,7 +801,7 @@ describe('Asset Layer Removal Tests', () => {
 
   test('toggleAssetLayer removes an existing asset layer when add is false', () => {
     // Call toggleAssetLayer to remove the existing asset layer
-    toggleAssetLayer(mockMap, 'testLayer', 'http://example.com/wms', false);
+    toggleAssetLayer(mockMap, 'testLayer', 'http://example.com/wms', false, 0, 100);
 
     // Check that removeLayer was called with the dummy asset layer
     expect(mockMap.removeLayer).toHaveBeenCalledWith(mockLayer);
@@ -865,10 +865,10 @@ describe('Layer Style Tests', () => {
     };
   });
 
-  it('updates polygon layer style correctly', () => {
+  it('updates item layer style correctly', () => {
     const { updateLayerStyle } = require('../src/app/components/MapView');
 
-    // Call updateLayerStyle with polygon layer parameters
+    // Call updateLayerStyle with item layer parameters
     updateLayerStyle(
       mockMap,
       'itemLayer',

--- a/apps/frontend/__tests__/TestSettingsPanelComponentCustomizableStyle.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponentCustomizableStyle.spec.tsx
@@ -144,6 +144,8 @@ describe('hexToRgb function in SettingsPanel component', () => {
       setCollectionId: jest.fn(),
       setIsPlaying: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
+      isCollectionsLoaded: true,
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     // Mock the updateLayerStyle function to check its parameters
@@ -154,7 +156,7 @@ describe('hexToRgb function in SettingsPanel component', () => {
     jest.restoreAllMocks();
   });
 
-  it('calls hexToRgb when updating polygon styles', async () => {
+  it('calls hexToRgb when updating item styles', async () => {
     await renderSettingsPanel();
 
     // Open the style dropdown
@@ -163,10 +165,10 @@ describe('hexToRgb function in SettingsPanel component', () => {
       fireEvent.click(styleButton);
     });
 
-    // Make sure we're on the polygon tab (default)
-    const polygonTab = screen.getByText('polygon');
+    // Make sure we're on the item tab (default)
+    const itemLayerTab = screen.getByText('item_layer');
     await act(async () => {
-      fireEvent.click(polygonTab);
+      fireEvent.click(itemLayerTab);
     });
 
     // Change the fill color to trigger hexToRgb conversion
@@ -346,6 +348,8 @@ describe('handleResetLayerStyle function', () => {
       setCollectionId: jest.fn(),
       setIsPlaying: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
+      isCollectionsLoaded: true,
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     // Mock the updateLayerStyle function to check its parameters
@@ -356,7 +360,7 @@ describe('handleResetLayerStyle function', () => {
     jest.restoreAllMocks();
   });
 
-  it('resets polygon styles when polygon tab is selected', async () => {
+  it('resets item layer styles when item_layer tab is selected', async () => {
     await renderSettingsPanel();
 
     // Open the style dropdown
@@ -365,10 +369,10 @@ describe('handleResetLayerStyle function', () => {
       fireEvent.click(styleButton);
     });
 
-    // Make sure we're on the polygon tab (default)
-    const polygonTab = screen.getByText('polygon');
+    // Make sure we're on the item_layer tab (default)
+    const itemLayerTab = screen.getByText('item_layer');
     await act(async () => {
-      fireEvent.click(polygonTab);
+      fireEvent.click(itemLayerTab);
     });
 
     // Click reset button to trigger handleResetLayerStyle
@@ -450,6 +454,8 @@ describe('Reset functionality for layer styles', () => {
       setCollectionId: jest.fn(),
       setIsPlaying: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
+      isCollectionsLoaded: true,
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     // Mock the updateLayerStyle function to check its parameters
@@ -464,7 +470,7 @@ describe('Reset functionality for layer styles', () => {
     jest.restoreAllMocks();
   });
 
-  it('resets both polygon and data layer styles when Reset button is clicked', async () => {
+  it('resets both item_layer and data layer styles when Reset button is clicked', async () => {
     await renderSettingsPanel();
 
     // Open the reset dropdown
@@ -487,7 +493,7 @@ describe('Reset functionality for layer styles', () => {
       expect(updateLayerStyle).toHaveBeenCalledWith(
         mockMap,
         'itemLayer',
-        'rgb(255,0,0)', // Default red for polygon
+        'rgb(255,0,0)', // Default red for item_layer
         '0.1',
         'rgb(255,0,0)',
         '2'

--- a/apps/frontend/__tests__/TestSettingsPanelComponentReset.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponentReset.spec.tsx
@@ -147,6 +147,8 @@ describe('Style Customization Dropdown', () => {
         setCollectionId: jest.fn(),
         setIsPlaying: jest.fn(),
         setSelectedAssetLayers: jest.fn(),
+        setIsCollectionsLoaded: jest.fn(),
+        isCollectionsLoaded: true
       });
 
     // Mock the updateLayerStyle function to check its parameters
@@ -172,17 +174,17 @@ describe('Style Customization Dropdown', () => {
   it('opens the style dropdown when clicked', async () => {
     await renderSettingsPanel();
     const styleButton = screen.getByTestId('style-dropdown-button');
-
     await act(async () => {
       fireEvent.click(styleButton);
     });
 
     expect(styleButton).toHaveClass('active');
-    expect(screen.getByText('polygon')).toBeInTheDocument();
+    expect(screen.getByText('update_style')).toBeInTheDocument();
+    expect(screen.getByText('item_layer')).toBeInTheDocument();
     expect(screen.getByText('data_layer')).toBeInTheDocument();
   });
 
-  it('shows polygon style tab by default', async () => {
+  it('shows data_layer style tab by default', async () => {
     await renderSettingsPanel();
     const styleButton = screen.getByTestId('style-dropdown-button');
 
@@ -190,10 +192,7 @@ describe('Style Customization Dropdown', () => {
       fireEvent.click(styleButton);
     });
 
-    expect(screen.getByText('polygon_style')).toBeInTheDocument();
-    // Check that polygon tab is active
-    const polygonTab = screen.getByText('polygon').closest('button');
-    expect(polygonTab).toHaveClass('active');
+    expect(screen.getByText('data_layer_style')).toBeInTheDocument();
   });
 
   it('switches to data layer tab when clicked', async () => {
@@ -215,7 +214,7 @@ describe('Style Customization Dropdown', () => {
     expect(dataTab).toHaveClass('active');
   });
 
-  it('updates polygon fill color when color picker changes', async () => {
+  it('updates item_layer fill color when color picker changes', async () => {
     await renderSettingsPanel();
     const styleButton = screen.getByTestId('style-dropdown-button');
 
@@ -223,7 +222,7 @@ describe('Style Customization Dropdown', () => {
       fireEvent.click(styleButton);
     });
 
-    // Find the fill color input in the polygon tab
+    // Find the fill color input in the item_layer tab
     const fillLabels = screen.getAllByText('fill:');
     const styleOption = fillLabels[0].closest('.style-option');
     const colorInput = styleOption?.querySelector(
@@ -237,7 +236,7 @@ describe('Style Customization Dropdown', () => {
     expect(colorInput.value).toBe('#00ff00');
   });
 
-  it('updates polygon fill opacity when slider changes', async () => {
+  it('updates item_layer fill opacity when slider changes', async () => {
     await renderSettingsPanel();
     const styleButton = screen.getByTestId('style-dropdown-button');
 
@@ -245,7 +244,7 @@ describe('Style Customization Dropdown', () => {
       fireEvent.click(styleButton);
     });
 
-    // Find the opacity slider in the polygon tab
+    // Find the opacity slider in the item_layer tab
     const opacityLabels = screen.getAllByText('fill_opacity:');
     const styleOption = opacityLabels[0].closest('.style-option');
     const opacitySlider = styleOption?.querySelector(
@@ -282,7 +281,7 @@ describe('Style Customization Dropdown', () => {
       'input[type="color"]',
     ) as HTMLInputElement;
 
-    expect(colorInput.value).toBe('#ff0000'); // Default polygon fill color
+    expect(colorInput.value).toBe('#0000ff'); // Default data_layer fill color
   });
 
   // Test the hexToRgb conversion function
@@ -333,7 +332,7 @@ describe('Style Customization Dropdown', () => {
     expect(mockUpdateLayerStyle).not.toHaveBeenCalled();
   });
 
-  it('does not render style dropdown when timeStamps is empty', async () => {
+  it('does not render data_layer nor item_layer style dropdown when timeStamps is empty and isCollectionsLoaded false', async () => {
     jest
       .spyOn(require('../src/app/context/MapContext'), 'useMapLayerContext')
       .mockReturnValue({
@@ -349,11 +348,15 @@ describe('Style Customization Dropdown', () => {
         setTimeStamps: jest.fn(),
         setCollectionId: jest.fn(),
         setSelectedAssetLayers: jest.fn(),
+        setIsCollectionsLoaded: jest.fn(),
+        isCollectionsLoaded: false
       });
 
     await renderSettingsPanel();
 
     const styleButton = screen.queryByTestId('style-dropdown-button');
     expect(styleButton).not.toBeInTheDocument();
+    expect(screen.queryByText((content) => content.includes("item_Layer"))).not.toBeInTheDocument();
+    expect(screen.queryByText((content) => content.includes("data_layer"))).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -38,10 +38,10 @@ const SATELLITE_LAYER_URL =
   'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
 const TOPOGRAPHIC_LAYER_URL = 'https://tile.opentopomap.org/{z}/{x}/{y}.png';
 
-// Default style values for polygon (itemLayer)
-let currentPolygonFillColor = 'rgba(255, 0, 0, 0.1)';
-let currentPolygonStrokeColor = 'rgba(255, 0, 0, 0.5)';
-let currentPolygonStrokeWidth = 2;
+// Default style values for itemLayer
+let currentItemLayerFillColor = 'rgba(255, 0, 0, 0.1)';
+let currentItemLayerStrokeColor = 'rgba(255, 0, 0, 0.5)';
+let currentItemLayerStrokeWidth = 2;
 
 // Default style values for dataLayer
 let currentDataLayerFillColor = 'rgba(0, 0, 255, 0.1)';
@@ -140,8 +140,8 @@ export const createItemDataLayer = (timestamp: string): VectorLayer => {
   const newLayer = new VectorLayer({
     source: vectorSource,
     style: new Style({
-      fill: new Fill({ color: currentPolygonFillColor }),
-      stroke: new Stroke({ color: currentPolygonStrokeColor, width: currentPolygonStrokeWidth }),
+      fill: new Fill({ color: currentItemLayerFillColor }),
+      stroke: new Stroke({ color: currentItemLayerStrokeColor, width: currentItemLayerStrokeWidth }),
     }),
   });
 
@@ -390,9 +390,9 @@ export const updateLayerStyle = (
 
   // Store current style values based on which layer is being updated
   if (layerName === 'itemLayer') {
-    currentPolygonFillColor = fillRgba;
-    currentPolygonStrokeColor = strokeRgba;
-    currentPolygonStrokeWidth = widthValue;
+    currentItemLayerFillColor = fillRgba;
+    currentItemLayerStrokeColor = strokeRgba;
+    currentItemLayerStrokeWidth = widthValue;
   } else if (layerName === 'dataLayer') {
     currentDataLayerFillColor = fillRgba;
     currentDataLayerStrokeColor = strokeRgba;

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -55,6 +55,8 @@ const SettingsPanel: React.FC<{
     setCollectionId,
     setIsPlaying,
     setSelectedAssetLayers,
+    isCollectionsLoaded,
+    setIsCollectionsLoaded
   } = useMapLayerContext();
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
     'https://default-api-endpoint.com',

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -63,6 +63,7 @@ const SettingsPanel: React.FC<{
   );
   const dropdownRef = useRef<HTMLDivElement>(null);
   const [languageInitialized, setLanguageInitialized] = useState(false);
+
   // Initialize language from local storage and handle toast messages
   useEffect(() => {
     if (
@@ -171,6 +172,8 @@ const SettingsPanel: React.FC<{
         refreshDatasets(); // Trigger the refresh
 
         setDropdownState({ activeButton: null, isOpen: false });
+        setIsCollectionsLoaded(true);
+
         return true;
       } catch (error: any) {
         toast.error(t('error_fetching_collections'));
@@ -297,6 +300,8 @@ const SettingsPanel: React.FC<{
       changeLayer(map, false, "reset");
       setSpeed(1);
       handleResetLayerStyle(true);
+      setIsCollectionsLoaded(false);
+      setSelectedStyleTab('data_layer');
       return 'Reset was successful';
     } catch (error: any) {
       throw new Error(`Error resetting config: ${error.message}`);

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -391,7 +391,7 @@ const SettingsPanel: React.FC<{
     toast.success(t('copied_to_clipboard'));
   };
 
-  // Default style values for Polygon
+  // Default style values for item_layer
   const DEFAULT_FILL_COLOR = '#ff0000'; // Red
   const DEFAULT_FILL_OPACITY = '0.1';
   const DEFAULT_STROKE_COLOR = '#ff0000'; // Red
@@ -471,7 +471,7 @@ const SettingsPanel: React.FC<{
       );
     }
 
-    if (resetBoth || selectedStyleTab === 'dataLayer') {
+    if (resetBoth || selectedStyleTab === 'data_layer') {
       // Reset data layer state with blue defaults
       setDataLayerFillColor('#0000ff');
       setDataLayerFillOpacity('0.1');
@@ -588,8 +588,8 @@ const SettingsPanel: React.FC<{
         )}
       </div>
 
-      {/* Customize Polygon and DataLayer colors */}
-      {timeStamps && timeStamps.length > 0 && (
+      {/* Customize itemLayer and DataLayer colors */}
+      {((timeStamps && timeStamps.length > 0) || (isCollectionsLoaded)) && (
         <div className="dropdown-button">
         <button
           className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
@@ -604,20 +604,23 @@ const SettingsPanel: React.FC<{
           <div className="dropdown-content show">
             <div className="style-options">
               <div className="style-tabs">
-                <button
-                  className={`style-tab ${selectedStyleTab === 'polygon' ? 'active' : ''}`}
-                  onClick={() => setSelectedStyleTab('polygon')}
-                >
-                  {t('polygon')}
-                </button>
-                <button
-                  className={`style-tab ${selectedStyleTab === 'dataLayer' ? 'active' : ''}`}
-                  onClick={() => setSelectedStyleTab('dataLayer')}
-                >
-                  {t('data_layer')}
-                </button>
+                {(timeStamps && timeStamps.length > 0) && (
+                  <button
+                    className={`style-tab ${selectedStyleTab === 'item_layer' ? 'active' : ''}`}
+                    onClick={() => setSelectedStyleTab('item_layer')}
+                  >
+                    {t('item_layer')}
+                  </button>
+                )}
+                {isCollectionsLoaded && (
+                  <button
+                    className={`style-tab ${selectedStyleTab === 'data_layer' ? 'active' : ''}`}
+                    onClick={() => setSelectedStyleTab('data_layer')}
+                  >
+                    {t('data_layer')}
+                  </button>
+                )}
               </div>
-
               <h2>
                 {selectedStyleTab === 'item_layer' ? t('item_layer_style') : t('data_layer_style')}
               </h2>

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -399,7 +399,7 @@ const SettingsPanel: React.FC<{
   const DEFAULT_DATA_STROKE_WIDTH = '2';
 
   // Tab selection state
-  const [selectedStyleTab, setSelectedStyleTab] = useState<'polygon' | 'dataLayer'>('polygon');
+  const [selectedStyleTab, setSelectedStyleTab] = useState<'item_layer' | 'data_layer'>('data_layer');
 
   // ItemLayer style state
   const [itemLayerFillColor, setItemLayerFillColor] = useState(DEFAULT_FILL_COLOR);

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -401,11 +401,11 @@ const SettingsPanel: React.FC<{
   // Tab selection state
   const [selectedStyleTab, setSelectedStyleTab] = useState<'polygon' | 'dataLayer'>('polygon');
 
-  // Polygon style state
-  const [polygonFillColor, setPolygonFillColor] = useState(DEFAULT_FILL_COLOR);
-  const [polygonFillOpacity, setPolygonFillOpacity] = useState(DEFAULT_FILL_OPACITY);
-  const [polygonStrokeColor, setPolygonStrokeColor] = useState(DEFAULT_STROKE_COLOR);
-  const [polygonStrokeWidth, setPolygonStrokeWidth] = useState(DEFAULT_STROKE_WIDTH);
+  // ItemLayer style state
+  const [itemLayerFillColor, setItemLayerFillColor] = useState(DEFAULT_FILL_COLOR);
+  const [itemLayerFillOpacity, setItemLayerFillOpacity] = useState(DEFAULT_FILL_OPACITY);
+  const [itemLayerStrokeColor, setItemLayerStrokeColor] = useState(DEFAULT_STROKE_COLOR);
+  const [itemLayerStrokeWidth, setItemLayerStrokeWidth] = useState(DEFAULT_STROKE_WIDTH);
 
   // DataLayer style state
   const [dataLayerFillColor, setDataLayerFillColor] = useState(DEFAULT_DATA_FILL_COLOR);
@@ -420,18 +420,18 @@ const SettingsPanel: React.FC<{
       : 'rgb(0,0,0)';
   };
 
-  // Update polygon and dataLayer style
+  // Update itemLayer and dataLayer style
   const handleUpdateLayerStyle = () => {
     if (!mapRef.current) return;
 
-    if (selectedStyleTab === 'polygon') {
+    if (selectedStyleTab === 'item_layer') {
       updateLayerStyle(
         mapRef.current,
         'itemLayer',
-        hexToRgb(polygonFillColor),
-        polygonFillOpacity,
-        hexToRgb(polygonStrokeColor),
-        polygonStrokeWidth
+        hexToRgb(itemLayerFillColor),
+        itemLayerFillOpacity,
+        hexToRgb(itemLayerStrokeColor),
+        itemLayerStrokeWidth
       );
     } else {
       updateLayerStyle(
@@ -445,16 +445,16 @@ const SettingsPanel: React.FC<{
     }
   };
 
-  // Reset polygon and dataLayer style
+  // Reset itemLayer and dataLayer style
   const handleResetLayerStyle = (resetBoth = false) => {
     if (!mapRef.current) return;
 
-    if (resetBoth || selectedStyleTab === 'polygon') {
-      // Reset polygon state
-      setPolygonFillColor(DEFAULT_FILL_COLOR);
-      setPolygonFillOpacity(DEFAULT_FILL_OPACITY);
-      setPolygonStrokeColor(DEFAULT_STROKE_COLOR);
-      setPolygonStrokeWidth(DEFAULT_STROKE_WIDTH);
+    if (resetBoth || selectedStyleTab === 'item_layer') {
+      // Reset itemLayer state
+      setItemLayerFillColor(DEFAULT_FILL_COLOR);
+      setItemLayerFillOpacity(DEFAULT_FILL_OPACITY);
+      setItemLayerStrokeColor(DEFAULT_STROKE_COLOR);
+      setItemLayerStrokeWidth(DEFAULT_STROKE_WIDTH);
 
       updateLayerStyle(
         mapRef.current,
@@ -614,18 +614,18 @@ const SettingsPanel: React.FC<{
               </div>
 
               <h2>
-                {selectedStyleTab === 'polygon' ? t('polygon_style') : t('data_layer_style')}
+                {selectedStyleTab === 'item_layer' ? t('item_layer_style') : t('data_layer_style')}
               </h2>
 
-              {selectedStyleTab === 'polygon' ? (
-                // Polygon style controls
+              {selectedStyleTab === 'item_layer' ? (
+                // itemLayer style controls
                 <>
                   <div className="style-option">
                     <label>{t('fill')}:</label>
                     <input
                       type="color"
-                      value={polygonFillColor}
-                      onChange={(e) => setPolygonFillColor(e.target.value)}
+                      value={itemLayerFillColor}
+                      onChange={(e) => setItemLayerFillColor(e.target.value)}
                     />
                   </div>
 
@@ -636,18 +636,18 @@ const SettingsPanel: React.FC<{
                       min="0"
                       max="1"
                       step="0.1"
-                      value={polygonFillOpacity}
-                      onChange={(e) => setPolygonFillOpacity(e.target.value)}
+                      value={itemLayerFillOpacity}
+                      onChange={(e) => setItemLayerFillOpacity(e.target.value)}
                     />
-                    <span>{polygonFillOpacity}</span>
+                    <span>{itemLayerFillOpacity}</span>
                   </div>
 
                   <div className="style-option">
                     <label>{t('stroke')}:</label>
                     <input
                       type="color"
-                      value={polygonStrokeColor}
-                      onChange={(e) => setPolygonStrokeColor(e.target.value)}
+                      value={itemLayerStrokeColor}
+                      onChange={(e) => setItemLayerStrokeColor(e.target.value)}
                     />
                   </div>
 
@@ -658,10 +658,10 @@ const SettingsPanel: React.FC<{
                       min="0"
                       max="5"
                       step="0.5"
-                      value={polygonStrokeWidth}
-                      onChange={(e) => setPolygonStrokeWidth(e.target.value)}
+                      value={itemLayerStrokeWidth}
+                      onChange={(e) => setItemLayerStrokeWidth(e.target.value)}
                     />
-                    <span>{polygonStrokeWidth}</span>
+                    <span>{itemLayerStrokeWidth}</span>
                   </div>
                 </>
               ) : (

--- a/apps/frontend/src/app/context/MapContext.tsx
+++ b/apps/frontend/src/app/context/MapContext.tsx
@@ -39,6 +39,8 @@ interface MapLayerContextValue {
   setIsProcessLoading: React.Dispatch<React.SetStateAction<boolean>>;
   loadedDataset: { id: string; title: string };
   setLoadedDataset: React.Dispatch<React.SetStateAction<{ id: string; title: string }>>;
+  isCollectionsLoaded: boolean;
+  setIsCollectionsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const MapLayerContext = createContext<MapLayerContextValue | undefined>(
@@ -58,6 +60,7 @@ export const MapProvider: React.FC<PropsWithChildren> = ({ children }) => {
   const [itemIds, setItemIds] = useState<string[]>([]);
   const [isProcessLoading, setIsProcessLoading] = useState<boolean>(false);
   const [loadedDataset, setLoadedDataset] = useState<{ id: string; title: string }>({ id: '', title: '' });
+  const [isCollectionsLoaded, setIsCollectionsLoaded] = useState<boolean>(false);
 
   // Timeline playback speed
   const [speed, setSpeed] = useState<number>(1);
@@ -122,6 +125,8 @@ export const MapProvider: React.FC<PropsWithChildren> = ({ children }) => {
       setIsProcessLoading,
       loadedDataset,
       setLoadedDataset,
+      isCollectionsLoaded,
+      setIsCollectionsLoaded,
     }),
     [
       layer,

--- a/apps/frontend/src/app/resources/i18n.tsx
+++ b/apps/frontend/src/app/resources/i18n.tsx
@@ -112,9 +112,9 @@ const resources = {
       weather_assets_label: 'Weather Assets',
       load_assets_button: 'Load Assets',
       loading_label: 'Loading...',
-      // Polygon Style
-      polygon_style: 'Polygon Style',
-      polygon: 'Polygon',
+      // Customize Style
+      item_layer_style: 'Item Layer Style',
+      item_layer: 'Item Layer',
       data_layer: 'Data Layer',
       data_layer_style: 'Data Layer Style',
       fill: 'Fill',
@@ -213,7 +213,7 @@ const resources = {
       error_fetching_data_by_date: 'Échec de la récupération des données par date',
       error_fetching_config_file:
         "Impossible de récupérer le fichier de configuration. Veuillez valider app-config.json.",
-      
+
       error_http_status: "Erreur HTTP ! Statut",
       error_Fetching_collections: "Impossible de récupérer les collections",
       error_failed_fetch_data: "Échec de la récupération des données",
@@ -237,9 +237,9 @@ const resources = {
       weather_assets_label: 'Données Météo',
       load_assets_button: 'Charger les Données',
       loading_label: 'Chargement...',
-      // Polygon Style
-      polygon_style: 'Style du Polygone',
-      polygon: 'Polygone',
+      // Customize Style
+      item_layer_style: 'Style des items',
+      item_layer: 'Items',
       data_layer: 'Couche de données',
       data_layer_style: 'Style de la couche de données',
       fill: 'Remplissage',


### PR DESCRIPTION
## #340 - [Bug] Visibility and Behavior of Customization Palette

### Problem
Currently, the customization palette icon does **not appear until a dataset is loaded**, which makes the customization feature unavailable for data layer at the beginning.

### Related Issue
#254 and #330

### Expected Behavior (Post-Fix)
- The **Palette Icon** for the **data layer** is now visible **immediately after a valid endpoint is set**, even before loading a dataset.
- Only the **data layer tab** is shown initially.
- After loading a dataset and selecting a timestamp, the **item layer tab** becomes visible, allowing full customization of both layers.

---
## Demo

https://github.com/user-attachments/assets/24f37a89-4f74-40b9-a48a-e799d9b497b4

### Code explanation

https://github.com/user-attachments/assets/8c32345c-5f11-435f-a63b-ae9afe752197


---

## Summary of Changes

**Updated all instances of `polygon` variable to `item_layer`**

### `SettingsPanel` (`apps/frontend/src/app/components/SettingsPanel.tsx`)
- Introduced new state: `isCollectionsLoaded` to track dataset loading state.
- Introduced conditions for showing different tabs at different moment
- Set data_layer as the default tab
- Refactored styling variables and tab options:
  - `selectedStyleTab`: `'polygon' | 'dataLayer'` → `'item_layer' | 'data_layer'`
  - Style states like `polygonFillColor`, etc. → `itemLayerFillColor`, etc.
- Updated dropdowns and button labels accordingly for better clarity.

### `MapContext` (`apps/frontend/src/app/context/MapContext.tsx`)
- Added `isCollectionsLoaded` and `setIsCollectionsLoaded` to manage collection load state across components.

### `i18n` (`apps/frontend/src/app/resources/i18n.tsx`)
- Updated translation keys and values to reflect the new terminology:
  - `"polygon"` and `"polygon_style"` → `"item_layer"` and `"item_layer_style"`
  - Updated both **English and French** language strings.

---

## UI Impact
- Users will now see the **customization icon for the data layer** right after setting a valid endpoint.
- The UI progressively reveals customization options based on data availability, improving user experience and reducing confusion.