### PR TITLE
#340: fix(frontend): Fix Persistance Issue

### DIFF
--- a/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestAvailableDatasetsComponent.spec.tsx
@@ -70,6 +70,7 @@ jest.mock('../src/app/context/MapContext', () => ({
     mapRef: { current: {} },
     loadedDataset: { id: 'dataset-1', title: 'Dataset One' },  
     setLoadedDataset: jest.fn(),
+    setIsCollectionsLoaded: jest.fn(),
   })),
 }));
 

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -916,37 +916,6 @@ describe('Layer Style Tests', () => {
     expect(mockLayer.setStyle).toHaveBeenCalled();
   });
 
-  it('handles layer not found gracefully', () => {
-    // Mock console.error to verify it's called
-    const originalError = console.error;
-    console.error = jest.fn();
-
-    // Empty layers array to simulate layer not found
-    mockMap.getLayers.mockReturnValue({
-      getArray: jest.fn(() => []),
-    });
-
-    const { updateLayerStyle } = require('../src/app/components/MapView');
-
-    // Call updateLayerStyle with a non-existent layer
-    updateLayerStyle(
-      mockMap,
-      'nonExistentLayer',
-      'rgb(255, 0, 0)',
-      '0.5',
-      'rgb(0, 0, 0)',
-      '1'
-    );
-
-    // Verify error was logged
-    expect(console.error).toHaveBeenCalledWith(
-      'Layer "nonExistentLayer" not found'
-    );
-
-    // Restore console.error
-    console.error = originalError;
-  });
-
   it('finds layer by name if id is not matching', () => {
     const { updateLayerStyle } = require('../src/app/components/MapView');
 

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -182,6 +182,7 @@ jest.mock('../src/app/context/MapContext', () => ({
     selectedAssetLayers: [],
     setSelectedAssetLayers: jest.fn(),
     collectionId: 'test-collection',
+    setIsCollectionsLoaded: jest.fn(),
   }),
 }));
 
@@ -425,6 +426,7 @@ describe(MapView, () => {
       setTimeStamps: jest.fn(),
       setLoadedLayers: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
+      setIsCollectionsLoaded: jest.fn(),
     };
 
     useMapLayerContext.mockReturnValue(contextMock);
@@ -482,6 +484,7 @@ describe(MapView, () => {
       setTimeStamps: jest.fn(),
       setLoadedLayers: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     render(
@@ -570,6 +573,7 @@ describe(MapView, () => {
       selectedAssetLayers: [],
       setSelectedAssetLayers: jest.fn(),
       collectionId: 'test-collection',
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     render(<MapView onBboxChange={mockOnBboxChange} />);
@@ -660,6 +664,7 @@ describe(MapView, () => {
       timeStamps: [],
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     render(<MapView onBboxChange={mockOnBboxChange} />);
@@ -706,6 +711,7 @@ describe(MapView, () => {
       timeStamps: [],
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     // Mock the Map constructor to track map initialization
@@ -750,6 +756,7 @@ describe(MapView, () => {
       timeStamps: [],
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
+      setIsCollectionsLoaded: jest.fn(),
     });
 
     const { rerender } = render(<MapView onBboxChange={mockOnBboxChange} />);

--- a/apps/frontend/__tests__/TestMapView.spec.tsx
+++ b/apps/frontend/__tests__/TestMapView.spec.tsx
@@ -182,7 +182,6 @@ jest.mock('../src/app/context/MapContext', () => ({
     selectedAssetLayers: [],
     setSelectedAssetLayers: jest.fn(),
     collectionId: 'test-collection',
-    setIsCollectionsLoaded: jest.fn(),
   }),
 }));
 
@@ -426,7 +425,6 @@ describe(MapView, () => {
       setTimeStamps: jest.fn(),
       setLoadedLayers: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
-      setIsCollectionsLoaded: jest.fn(),
     };
 
     useMapLayerContext.mockReturnValue(contextMock);
@@ -484,7 +482,6 @@ describe(MapView, () => {
       setTimeStamps: jest.fn(),
       setLoadedLayers: jest.fn(),
       setSelectedAssetLayers: jest.fn(),
-      setIsCollectionsLoaded: jest.fn(),
     });
 
     render(
@@ -573,7 +570,6 @@ describe(MapView, () => {
       selectedAssetLayers: [],
       setSelectedAssetLayers: jest.fn(),
       collectionId: 'test-collection',
-      setIsCollectionsLoaded: jest.fn(),
     });
 
     render(<MapView onBboxChange={mockOnBboxChange} />);
@@ -664,7 +660,6 @@ describe(MapView, () => {
       timeStamps: [],
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
-      setIsCollectionsLoaded: jest.fn(),
     });
 
     render(<MapView onBboxChange={mockOnBboxChange} />);
@@ -711,7 +706,6 @@ describe(MapView, () => {
       timeStamps: [],
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
-      setIsCollectionsLoaded: jest.fn(),
     });
 
     // Mock the Map constructor to track map initialization
@@ -756,7 +750,6 @@ describe(MapView, () => {
       timeStamps: [],
       setTimeStamps: jest.fn(),
       setSliderValue: jest.fn(),
-      setIsCollectionsLoaded: jest.fn(),
     });
 
     const { rerender } = render(<MapView onBboxChange={mockOnBboxChange} />);

--- a/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
+++ b/apps/frontend/__tests__/TestSettingsPanelComponent.spec.tsx
@@ -327,7 +327,6 @@ describe('SettingsPanel Component', () => {
     it('prompts for a new endpoint when no valid endpoint is saved', async () => {
       const {
         getConfig,
-        saveConfig,
       } = require('../src/app/services/configApi');
       getConfig.mockResolvedValueOnce({
         endpoint: 'No endpoint saved',
@@ -336,12 +335,10 @@ describe('SettingsPanel Component', () => {
       const Swal = require('sweetalert2');
       Swal.fire.mockResolvedValueOnce({ isConfirmed: false });
       const refreshDatasets = jest.fn();
-      await act(async () => {
+     await act(async () => {
         await renderSettingsPanel(refreshDatasets);
       });
       await waitFor(() => {
-        expect(getConfig).toHaveBeenCalled();
-        expect(saveConfig).toHaveBeenCalled();
         expect(refreshDatasets).toHaveBeenCalled();
       });
     });
@@ -1013,10 +1010,23 @@ describe('SettingsPanel Component', () => {
       // Execute the function
       const result = await resetConfig();
 
+      const {
+        getConfig,
+        saveConfig,
+      } = require('../src/app/services/configApi');
+      getConfig.mockResolvedValueOnce({
+        endpoint: 'No endpoint saved',
+        language: 'en',
+      });
+
       // Verify all functions were called
       expect(resetItemAssets).toHaveBeenCalled();
       expect(changeLayer).toHaveBeenCalledWith(mockMap, true);
       expect(setSpeed).toHaveBeenCalledWith(1);
+      expect(getConfig).toHaveBeenCalled();
+      waitFor(() => {
+        expect(saveConfig).toHaveBeenCalled();
+      })
       expect(result).toBe('Reset was successful');
 
       // Verify localStorage was properly set

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import '../styles/AvailableDatasets.css';
 import {
@@ -67,6 +67,7 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { mapRef, loadedDataset, setLoadedDataset } = useMapLayerContext();
+  const hasInitialized = useRef(false);
 
   /**
    * Maps raw error messages returned from API calls to their corresponding i18n translation keys.
@@ -132,11 +133,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
       const config = await getConfig();
       if (config?.loadedDataset) {
         setLoadedDataset({
-          id: config.loadedDataset.id || '', 
-          title: config.loadedDataset.title || ''
+          id: config.loadedDataset.id || '',
+          title: config.loadedDataset.title || '',
         });
       } else {
-        setLoadedDataset({id: '', title: ''});
+        setLoadedDataset({ id: '', title: '' });
       }
       setDatasets(response);
       setFetchError(null);
@@ -188,6 +189,14 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   useEffect(() => {
     fetchDatasets();
   }, [activeFilter, sortDirection]);
+
+  useEffect(() => {
+    if ((selectedDataset !== null && selectedDataset !== '') && !hasInitialized.current) {
+      const map = mapRef.current as Map;
+      changeLayer(map, true);
+      hasInitialized.current = true;
+    }
+  }, [selectedDataset]);
 
   /**
    * Handles changes to the dataset sorting filter.

--- a/apps/frontend/src/app/components/AvailableDatasets.tsx
+++ b/apps/frontend/src/app/components/AvailableDatasets.tsx
@@ -66,7 +66,8 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   const [selectedDataset, setSelectedDataset] = useState<string | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { mapRef, loadedDataset, setLoadedDataset } = useMapLayerContext();
+  const { mapRef, loadedDataset, setLoadedDataset, setIsCollectionsLoaded } =
+    useMapLayerContext();
   const hasInitialized = useRef(false);
 
   /**
@@ -140,6 +141,11 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
         setLoadedDataset({ id: '', title: '' });
       }
       setDatasets(response);
+      {
+        response.length !== 0
+          ? setIsCollectionsLoaded(true)
+          : setIsCollectionsLoaded(false);
+      }
       setFetchError(null);
     } catch (error) {
       console.error('Error fetching datasets:', error);
@@ -189,14 +195,6 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
   useEffect(() => {
     fetchDatasets();
   }, [activeFilter, sortDirection]);
-
-  useEffect(() => {
-    if ((selectedDataset !== null && selectedDataset !== '') && !hasInitialized.current) {
-      const map = mapRef.current as Map;
-      changeLayer(map, true);
-      hasInitialized.current = true;
-    }
-  }, [selectedDataset]);
 
   /**
    * Handles changes to the dataset sorting filter.
@@ -311,6 +309,18 @@ const AvailableDatasets: React.FC<AvailableDatasetsProps> = ({
     }
     return t('filtering_by_map_view');
   };
+
+  useEffect(() => {
+    if (
+      selectedDataset !== null &&
+      selectedDataset !== '' &&
+      !hasInitialized.current
+    ) {
+      const map = mapRef.current as Map;
+      changeLayer(map, true);
+      hasInitialized.current = true;
+    }
+  }, [selectedDataset]);
 
   return (
     <div

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -415,7 +415,6 @@ export const updateLayerStyle = (
   ) as VectorLayer<VectorSource<any>>;
 
   if (!layer) {
-    console.error(`Layer "${layerName}" not found`);
     return;
   }
 

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -99,7 +99,10 @@ const createCollectionDataLayer = (map: Map | null): VectorLayer => {
     source: vectorSource,
     style: new Style({
       fill: new Fill({ color: currentDataLayerFillColor }),
-      stroke: new Stroke({ color: currentDataLayerStrokeColor, width: currentDataLayerStrokeWidth }),
+      stroke: new Stroke({
+        color: currentDataLayerStrokeColor,
+        width: currentDataLayerStrokeWidth,
+      }),
     }),
   });
 
@@ -141,7 +144,10 @@ export const createItemDataLayer = (timestamp: string): VectorLayer => {
     source: vectorSource,
     style: new Style({
       fill: new Fill({ color: currentItemLayerFillColor }),
-      stroke: new Stroke({ color: currentItemLayerStrokeColor, width: currentItemLayerStrokeWidth }),
+      stroke: new Stroke({
+        color: currentItemLayerStrokeColor,
+        width: currentItemLayerStrokeWidth,
+      }),
     }),
   });
 
@@ -154,6 +160,8 @@ export const createItemDataLayer = (timestamp: string): VectorLayer => {
  * both the collection layer and items layer
  *
  * @param {Map} map - The OpenLayers map instance.
+ * @param collection
+ * @param timestamp
  */
 export const refreshLayer = (
   map: Map,
@@ -194,7 +202,8 @@ interface MapViewProps {
 const MapView = ({ onBboxChange }: MapViewProps) => {
   useGeographic();
   const mapElement = useRef(null);
-  const { layer, mapRef, isOnline } = useMapLayerContext();
+  const { layer, mapRef, isOnline, setIsCollectionsLoaded } =
+    useMapLayerContext();
 
   /**
    * Determines which base layer to use based on network connectivity.
@@ -219,6 +228,22 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
     }
 
     return selectedLayer;
+  };
+
+  // Function to check if the data layer exists on the map
+  const dataLayerExists = (): boolean => {
+    const layers = mapRef.current?.getLayers().getArray();
+    const layer = layers?.find(
+      (layer) =>
+        layer.get('id') === 'dataLayer' || layer.get('name') === 'dataLayer',
+    ) as VectorLayer<VectorSource<any>>;
+    return !!layer;
+  };
+
+  // Function to check and update data layer state
+  const updateDataLayerState = () => {
+    const exists = dataLayerExists();
+    setIsCollectionsLoaded(exists);
   };
 
   useEffect(() => {
@@ -274,6 +299,13 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
     };
   }, [onBboxChange]);
 
+  useEffect(() => {
+    // Only run if mapRef.current exists
+    if (mapRef.current) {
+      updateDataLayerState();
+    }
+  }, []);
+
   return (
     <div id="map-container" ref={mapElement} data-testid="map-container">
       <Footer />
@@ -285,6 +317,8 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
  * Utility function to trigger a refresh of the data layer.
  *
  * @param {Map} map - The OpenLayers map instance.
+ * @param collection
+ * @param timestamp
  */
 export const changeLayer = (
   map: Map,
@@ -292,10 +326,10 @@ export const changeLayer = (
   timestamp?: string,
 ) => {
   if (collection) {
-    refreshLayer(map, (collection = true));
+    refreshLayer(map, true);
   }
   if (timestamp) {
-    refreshLayer(map, (collection = false), timestamp);
+    refreshLayer(map, false, timestamp);
   }
 };
 
@@ -313,24 +347,26 @@ export const toggleAssetLayer = (
   layerUrl: string,
   add: boolean,
   min: number,
-  max: number
+  max: number,
 ): void => {
   // First check if layer already exists
   const layers = map.getLayers().getArray();
   const existingLayer = layers.find((layer) => layer.get('name') === layerName);
 
   const result = /layers=(.*)/.exec(layerUrl);
-    let geoServerLayerName = ''
-    if(result){
-      geoServerLayerName = result[1];
-    }
+  let geoServerLayerName = '';
+  if (result) {
+    geoServerLayerName = result[1];
+  }
 
   if (add && !existingLayer) {
     // Add the layer
     const newLayer = new ImageLayer({
       source: new ImageWMS({
         url: layerUrl,
-        params: { SLD_BODY: createItemAssetStyle(geoServerLayerName, min, max) },
+        params: {
+          SLD_BODY: createItemAssetStyle(geoServerLayerName, min, max),
+        },
         // Add crossOrigin to handle potential CORS issues
         crossOrigin: 'anonymous',
       }),

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -255,7 +255,7 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
           new FullScreen(),
           new Attribution({ collapsible: false }),
         ]),
-        layers: [getLayer(), createCollectionDataLayer(mapRef.current)],
+        layers: [getLayer()],
         view: new View({
           center: [-75.6972, 45.4215], // Ottawa
           zoom: 1,

--- a/apps/frontend/src/app/components/MapView.tsx
+++ b/apps/frontend/src/app/components/MapView.tsx
@@ -117,7 +117,7 @@ const createCollectionDataLayer = (map: Map | null): VectorLayer => {
         const zoom = view.getZoomForResolution(resolution);
         view.animate({
           center: [(extent[0] + extent[2]) / 2, (extent[1] + extent[3]) / 2],
-          zoom: zoom ? zoom - 1 : 1,
+          zoom: zoom ? zoom - 2 : 1,
           duration: 1000,
         });
       }
@@ -202,7 +202,7 @@ interface MapViewProps {
 const MapView = ({ onBboxChange }: MapViewProps) => {
   useGeographic();
   const mapElement = useRef(null);
-  const { layer, mapRef, isOnline, setIsCollectionsLoaded } =
+  const { layer, mapRef, isOnline } =
     useMapLayerContext();
 
   /**
@@ -230,22 +230,6 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
     return selectedLayer;
   };
 
-  // Function to check if the data layer exists on the map
-  const dataLayerExists = (): boolean => {
-    const layers = mapRef.current?.getLayers().getArray();
-    const layer = layers?.find(
-      (layer) =>
-        layer.get('id') === 'dataLayer' || layer.get('name') === 'dataLayer',
-    ) as VectorLayer<VectorSource<any>>;
-    return !!layer;
-  };
-
-  // Function to check and update data layer state
-  const updateDataLayerState = () => {
-    const exists = dataLayerExists();
-    setIsCollectionsLoaded(exists);
-  };
-
   useEffect(() => {
     if (!mapRef.current) {
       // Initialize the map if it hasn't been created yet
@@ -255,7 +239,7 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
           new FullScreen(),
           new Attribution({ collapsible: false }),
         ]),
-        layers: [getLayer()],
+        layers: [getLayer(), createCollectionDataLayer(mapRef.current)],
         view: new View({
           center: [-75.6972, 45.4215], // Ottawa
           zoom: 1,
@@ -299,12 +283,6 @@ const MapView = ({ onBboxChange }: MapViewProps) => {
     };
   }, [onBboxChange]);
 
-  useEffect(() => {
-    // Only run if mapRef.current exists
-    if (mapRef.current) {
-      updateDataLayerState();
-    }
-  }, []);
 
   return (
     <div id="map-container" ref={mapElement} data-testid="map-container">

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -27,7 +27,7 @@ import Swal from 'sweetalert2';
 import withReactContent from 'sweetalert2-react-content';
 import { useMapLayerContext } from '../context/MapContext';
 import { getConfig, saveConfig } from '../services/configApi';
-import { changeLayer, updateLayerStyle } from './MapView';
+import { updateLayerStyle } from './MapView';
 import { LuPalette } from 'react-icons/lu';
 
 const MySwal = withReactContent(Swal);
@@ -294,9 +294,6 @@ const SettingsPanel: React.FC<{
       await resetItems();
       await resetDatalayerView();
       await resetItemAssets();
-      const map = mapRef.current as Map;
-      changeLayer(map, true);
-      changeLayer(map, false, "reset");
       setSpeed(1);
       handleResetLayerStyle(true);
       setIsCollectionsLoaded(false);

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -281,6 +281,16 @@ const SettingsPanel: React.FC<{
       resetView();
       setSelectedAssetLayers([]);
 
+      const config = await getConfig();
+      // If an error occurred during fetching config, show error and do not save changes
+      if (config.error) {
+        toast.error(t('error_fetching_config_file'));
+      }
+
+      config.endpoint = 'No endpoint saved';
+      config.loadedDataset = { id: '', title: '' };
+      await saveConfig(config);
+
       localStorage.setItem('language', 'en');
       localStorage.setItem('playbackSpeed', '1');
       localStorage.setItem('selectedDatasetId', '');
@@ -329,17 +339,6 @@ const SettingsPanel: React.FC<{
       if (inputResult.isConfirmed) {
         success = await handleSaveAndFetchEndpoint(inputResult.value);
       } else {
-        const config = await getConfig();
-        // If an error occurred during fetching config, show error and do not save changes
-        if (config.error) {
-          toast.error(t('error_fetching_config_file'));
-          break;
-        }
-
-        config.endpoint = 'No endpoint saved';
-        config.loadedDataset = { id: '', title: '' };
-        await saveConfig(config);
-
         refreshDatasets(); // Trigger the refresh
         break; // Exit the loop if the user cancels the input dialog
       }

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -171,7 +171,6 @@ const SettingsPanel: React.FC<{
         refreshDatasets(); // Trigger the refresh
 
         setDropdownState({ activeButton: null, isOpen: false });
-        setIsCollectionsLoaded(true);
 
         return true;
       } catch (error: any) {
@@ -307,7 +306,6 @@ const SettingsPanel: React.FC<{
       await resetDatalayerView();
       await resetItemAssets();
       setSpeed(1);
-      setIsCollectionsLoaded(false);
       setSelectedStyleTab('data_layer');
       return 'Reset was successful';
     } catch (error: any) {

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -241,8 +241,6 @@ const SettingsPanel: React.FC<{
       },
     }).then(async (result: { isConfirmed: any }) => {
       if (result.isConfirmed) {
-        resetView();
-        setSelectedAssetLayers([]);
         try {
           await resetConfig();
           await promptForEndpoint(
@@ -279,6 +277,10 @@ const SettingsPanel: React.FC<{
 
   const resetConfig = async () => {
     try {
+      handleResetLayerStyle(true);
+      resetView();
+      setSelectedAssetLayers([]);
+
       localStorage.setItem('language', 'en');
       localStorage.setItem('playbackSpeed', '1');
       localStorage.setItem('selectedDatasetId', '');
@@ -295,7 +297,6 @@ const SettingsPanel: React.FC<{
       await resetDatalayerView();
       await resetItemAssets();
       setSpeed(1);
-      handleResetLayerStyle(true);
       setIsCollectionsLoaded(false);
       setSelectedStyleTab('data_layer');
       return 'Reset was successful';

--- a/apps/frontend/src/app/components/SettingsPanel.tsx
+++ b/apps/frontend/src/app/components/SettingsPanel.tsx
@@ -28,7 +28,6 @@ import withReactContent from 'sweetalert2-react-content';
 import { useMapLayerContext } from '../context/MapContext';
 import { getConfig, saveConfig } from '../services/configApi';
 import { changeLayer, updateLayerStyle } from './MapView';
-import { Map } from 'ol';
 import { LuPalette } from 'react-icons/lu';
 
 const MySwal = withReactContent(Swal);
@@ -56,7 +55,7 @@ const SettingsPanel: React.FC<{
     setIsPlaying,
     setSelectedAssetLayers,
     isCollectionsLoaded,
-    setIsCollectionsLoaded
+    setIsCollectionsLoaded,
   } = useMapLayerContext();
   const [newApiEndpoint, setNewApiEndpoint] = useState<string>(
     'https://default-api-endpoint.com',
@@ -397,26 +396,40 @@ const SettingsPanel: React.FC<{
   const DEFAULT_STROKE_COLOR = '#ff0000'; // Red
   const DEFAULT_STROKE_WIDTH = '2';
 
-// Default style values for DataLayer
+  // Default style values for DataLayer
   const DEFAULT_DATA_FILL_COLOR = '#0000ff'; // Blue
   const DEFAULT_DATA_FILL_OPACITY = '0.1';
   const DEFAULT_DATA_STROKE_COLOR = '#0000ff'; // Blue
   const DEFAULT_DATA_STROKE_WIDTH = '2';
 
   // Tab selection state
-  const [selectedStyleTab, setSelectedStyleTab] = useState<'item_layer' | 'data_layer'>('data_layer');
+  const [selectedStyleTab, setSelectedStyleTab] = useState<
+    'item_layer' | 'data_layer'
+  >('data_layer');
 
   // ItemLayer style state
-  const [itemLayerFillColor, setItemLayerFillColor] = useState(DEFAULT_FILL_COLOR);
-  const [itemLayerFillOpacity, setItemLayerFillOpacity] = useState(DEFAULT_FILL_OPACITY);
-  const [itemLayerStrokeColor, setItemLayerStrokeColor] = useState(DEFAULT_STROKE_COLOR);
-  const [itemLayerStrokeWidth, setItemLayerStrokeWidth] = useState(DEFAULT_STROKE_WIDTH);
+  const [itemLayerFillColor, setItemLayerFillColor] =
+    useState(DEFAULT_FILL_COLOR);
+  const [itemLayerFillOpacity, setItemLayerFillOpacity] =
+    useState(DEFAULT_FILL_OPACITY);
+  const [itemLayerStrokeColor, setItemLayerStrokeColor] =
+    useState(DEFAULT_STROKE_COLOR);
+  const [itemLayerStrokeWidth, setItemLayerStrokeWidth] =
+    useState(DEFAULT_STROKE_WIDTH);
 
   // DataLayer style state
-  const [dataLayerFillColor, setDataLayerFillColor] = useState(DEFAULT_DATA_FILL_COLOR);
-  const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(DEFAULT_DATA_FILL_OPACITY);
-  const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(DEFAULT_DATA_STROKE_COLOR);
-  const [dataLayerStrokeWidth, setDataLayerStrokeWidth] = useState(DEFAULT_DATA_STROKE_WIDTH);
+  const [dataLayerFillColor, setDataLayerFillColor] = useState(
+    DEFAULT_DATA_FILL_COLOR,
+  );
+  const [dataLayerFillOpacity, setDataLayerFillOpacity] = useState(
+    DEFAULT_DATA_FILL_OPACITY,
+  );
+  const [dataLayerStrokeColor, setDataLayerStrokeColor] = useState(
+    DEFAULT_DATA_STROKE_COLOR,
+  );
+  const [dataLayerStrokeWidth, setDataLayerStrokeWidth] = useState(
+    DEFAULT_DATA_STROKE_WIDTH,
+  );
 
   const hexToRgb = (hex: string) => {
     const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -436,7 +449,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(itemLayerFillColor),
         itemLayerFillOpacity,
         hexToRgb(itemLayerStrokeColor),
-        itemLayerStrokeWidth
+        itemLayerStrokeWidth,
       );
     } else {
       updateLayerStyle(
@@ -445,7 +458,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(dataLayerFillColor),
         dataLayerFillOpacity,
         hexToRgb(dataLayerStrokeColor),
-        dataLayerStrokeWidth
+        dataLayerStrokeWidth,
       );
     }
   };
@@ -467,7 +480,7 @@ const SettingsPanel: React.FC<{
         hexToRgb(DEFAULT_FILL_COLOR),
         DEFAULT_FILL_OPACITY,
         hexToRgb(DEFAULT_STROKE_COLOR),
-        DEFAULT_STROKE_WIDTH
+        DEFAULT_STROKE_WIDTH,
       );
     }
 
@@ -484,7 +497,7 @@ const SettingsPanel: React.FC<{
         hexToRgb('#0000ff'),
         '0.1',
         hexToRgb('#0000ff'),
-        '2'
+        '2',
       );
     }
   };
@@ -589,160 +602,173 @@ const SettingsPanel: React.FC<{
       </div>
 
       {/* Customize itemLayer and DataLayer colors */}
-      {((timeStamps && timeStamps.length > 0) || (isCollectionsLoaded)) && (
+      {((timeStamps && timeStamps.length > 0) || isCollectionsLoaded) && (
         <div className="dropdown-button">
-        <button
-          className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
-          onClick={() => toggleDropdown('style')}
-          aria-expanded={dropdownState.activeButton === 'style'}
-          aria-label="style"
-          data-testid="style-dropdown-button"
-        >
-          <LuPalette size={32} />
-        </button>
-        {dropdownState.activeButton === 'style' && (
-          <div className="dropdown-content show">
-            <div className="style-options">
-              <div className="style-tabs">
-                {(timeStamps && timeStamps.length > 0) && (
-                  <button
-                    className={`style-tab ${selectedStyleTab === 'item_layer' ? 'active' : ''}`}
-                    onClick={() => setSelectedStyleTab('item_layer')}
-                  >
-                    {t('item_layer')}
-                  </button>
+          <button
+            className={`button ${dropdownState.activeButton === 'style' ? 'active' : ''}`}
+            onClick={() => toggleDropdown('style')}
+            aria-expanded={dropdownState.activeButton === 'style'}
+            aria-label="style"
+            data-testid="style-dropdown-button"
+          >
+            <LuPalette size={32} />
+          </button>
+          {dropdownState.activeButton === 'style' && (
+            <div className="dropdown-content show">
+              <div className="style-options">
+                <div className="style-tabs">
+                  {timeStamps && timeStamps.length > 0 && (
+                    <button
+                      className={`style-tab ${selectedStyleTab === 'item_layer' ? 'active' : ''}`}
+                      onClick={() => setSelectedStyleTab('item_layer')}
+                    >
+                      {t('item_layer')}
+                    </button>
+                  )}
+                  {isCollectionsLoaded && (
+                    <button
+                      className={`style-tab ${selectedStyleTab === 'data_layer' ? 'active' : ''}`}
+                      onClick={() => setSelectedStyleTab('data_layer')}
+                    >
+                      {t('data_layer')}
+                    </button>
+                  )}
+                </div>
+                <h2>
+                  {selectedStyleTab === 'item_layer'
+                    ? t('item_layer_style')
+                    : t('data_layer_style')}
+                </h2>
+
+                {selectedStyleTab === 'item_layer' ? (
+                  // itemLayer style controls
+                  <>
+                    <div className="style-option">
+                      <label>{t('fill')}:</label>
+                      <input
+                        type="color"
+                        value={itemLayerFillColor}
+                        onChange={(e) => setItemLayerFillColor(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('fill_opacity')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={itemLayerFillOpacity}
+                        onChange={(e) =>
+                          setItemLayerFillOpacity(e.target.value)
+                        }
+                      />
+                      <span>{itemLayerFillOpacity}</span>
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke')}:</label>
+                      <input
+                        type="color"
+                        value={itemLayerStrokeColor}
+                        onChange={(e) =>
+                          setItemLayerStrokeColor(e.target.value)
+                        }
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke_width')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="5"
+                        step="0.5"
+                        value={itemLayerStrokeWidth}
+                        onChange={(e) =>
+                          setItemLayerStrokeWidth(e.target.value)
+                        }
+                      />
+                      <span>{itemLayerStrokeWidth}</span>
+                    </div>
+                  </>
+                ) : (
+                  // Data layer style controls
+                  <>
+                    <div className="style-option">
+                      <label>{t('fill')}:</label>
+                      <input
+                        type="color"
+                        value={dataLayerFillColor}
+                        onChange={(e) => setDataLayerFillColor(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('fill_opacity')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.1"
+                        value={dataLayerFillOpacity}
+                        onChange={(e) =>
+                          setDataLayerFillOpacity(e.target.value)
+                        }
+                      />
+                      <span>{dataLayerFillOpacity}</span>
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke')}:</label>
+                      <input
+                        type="color"
+                        value={dataLayerStrokeColor}
+                        onChange={(e) =>
+                          setDataLayerStrokeColor(e.target.value)
+                        }
+                      />
+                    </div>
+
+                    <div className="style-option">
+                      <label>{t('stroke_width')}:</label>
+                      <input
+                        type="range"
+                        min="0"
+                        max="5"
+                        step="0.5"
+                        value={dataLayerStrokeWidth}
+                        onChange={(e) =>
+                          setDataLayerStrokeWidth(e.target.value)
+                        }
+                      />
+                      <span>{dataLayerStrokeWidth}</span>
+                    </div>
+                  </>
                 )}
-                {isCollectionsLoaded && (
+
+                <div className="style-buttons">
                   <button
-                    className={`style-tab ${selectedStyleTab === 'data_layer' ? 'active' : ''}`}
-                    onClick={() => setSelectedStyleTab('data_layer')}
+                    className="update-style-btn"
+                    onClick={handleUpdateLayerStyle}
                   >
-                    {t('data_layer')}
+                    {t('update_style')}
                   </button>
-                )}
-              </div>
-              <h2>
-                {selectedStyleTab === 'item_layer' ? t('item_layer_style') : t('data_layer_style')}
-              </h2>
-
-              {selectedStyleTab === 'item_layer' ? (
-                // itemLayer style controls
-                <>
-                  <div className="style-option">
-                    <label>{t('fill')}:</label>
-                    <input
-                      type="color"
-                      value={itemLayerFillColor}
-                      onChange={(e) => setItemLayerFillColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('fill_opacity')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.1"
-                      value={itemLayerFillOpacity}
-                      onChange={(e) => setItemLayerFillOpacity(e.target.value)}
-                    />
-                    <span>{itemLayerFillOpacity}</span>
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke')}:</label>
-                    <input
-                      type="color"
-                      value={itemLayerStrokeColor}
-                      onChange={(e) => setItemLayerStrokeColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke_width')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="5"
-                      step="0.5"
-                      value={itemLayerStrokeWidth}
-                      onChange={(e) => setItemLayerStrokeWidth(e.target.value)}
-                    />
-                    <span>{itemLayerStrokeWidth}</span>
-                  </div>
-                </>
-              ) : (
-                // Data layer style controls
-                <>
-                  <div className="style-option">
-                    <label>{t('fill')}:</label>
-                    <input
-                      type="color"
-                      value={dataLayerFillColor}
-                      onChange={(e) => setDataLayerFillColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('fill_opacity')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="1"
-                      step="0.1"
-                      value={dataLayerFillOpacity}
-                      onChange={(e) => setDataLayerFillOpacity(e.target.value)}
-                    />
-                    <span>{dataLayerFillOpacity}</span>
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke')}:</label>
-                    <input
-                      type="color"
-                      value={dataLayerStrokeColor}
-                      onChange={(e) => setDataLayerStrokeColor(e.target.value)}
-                    />
-                  </div>
-
-                  <div className="style-option">
-                    <label>{t('stroke_width')}:</label>
-                    <input
-                      type="range"
-                      min="0"
-                      max="5"
-                      step="0.5"
-                      value={dataLayerStrokeWidth}
-                      onChange={(e) => setDataLayerStrokeWidth(e.target.value)}
-                    />
-                    <span>{dataLayerStrokeWidth}</span>
-                  </div>
-                </>
-              )}
-
-              <div className="style-buttons">
-                <button
-                  className="update-style-btn"
-                  onClick={handleUpdateLayerStyle}
-                >
-                  {t('update_style')}
-                </button>
-                <button
-                  className="reset-style-btn"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleResetLayerStyle();
-                  }}
-                >
-                  {t('reset_style')}
-                </button>
+                  <button
+                    className="reset-style-btn"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleResetLayerStyle();
+                    }}
+                  >
+                    {t('reset_style')}
+                  </button>
+                </div>
               </div>
             </div>
-
-          </div>
-        )}
-      </div>
+          )}
+        </div>
       )}
 
       <div className="dropdown-button">

--- a/apps/frontend/src/app/context/MapContext.tsx
+++ b/apps/frontend/src/app/context/MapContext.tsx
@@ -144,6 +144,7 @@ export const MapProvider: React.FC<PropsWithChildren> = ({ children }) => {
       isProcessLoading,
       loadedDataset,
       loadedDataset,
+      isCollectionsLoaded,
     ],
   );
 


### PR DESCRIPTION
### #340 - Fix Persistance Issue

### Problem
This is related to https://github.com/XavierGuertin/WildfireVisualizationProject/pull/341. When refreshing the page, the `isCollectionsLoaded` variable didn't persist thoughout the sessions.

### Solution
I've updated the behavior of the `isCollectionsLoaded `map in the context state so that it now accurately reflects the loading state of datasets.

As part of this change, I’ve removed all references to this state elsewhere in the code, including in `factoryReset` and the `handleFetchAndSave` endpoint.

![image](https://github.com/user-attachments/assets/09445170-2a3a-4e34-9dce-b2270edd8f0b)
![image](https://github.com/user-attachments/assets/c619f005-675f-4b25-aa12-a7147e3cbb08)
![image](https://github.com/user-attachments/assets/e24daa40-b407-4e41-80ea-a9e6074a95ff)

