### PR TITLE
# 349 - Replaced should be visible with should exist

### DIFF
--- a/apps/frontend-e2e/src/e2e/available_datasets.cy.ts
+++ b/apps/frontend-e2e/src/e2e/available_datasets.cy.ts
@@ -25,7 +25,7 @@ describe('dataset', () => {
     cy.get('button.swal2-confirm').should('exist').click()
 
     //Make sure notfication of success appears
-    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should("be.visible")
+    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should('exist')
     cy.wait(2000)
 
     //Assert that there are more than 0 datasets
@@ -40,7 +40,7 @@ describe('dataset', () => {
     cy.contains('button', 'Save').click()
 
     //Make sure notfication of success appears
-    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should("be.visible")
+    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should('exist')
     cy.wait(2000)
 
     //Click on the collapse button and assert that it collapses
@@ -58,7 +58,7 @@ describe('dataset', () => {
     cy.get('button.swal2-confirm').should('exist').click()
 
     //Make sure notfication of success appears
-    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should("be.visible")
+    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should('exist')
     cy.wait(2000)
 
     cy.get('[data-testid=filter-button-Name]').click({force:true})
@@ -81,7 +81,7 @@ describe('dataset', () => {
     cy.get('button.swal2-confirm').should('exist').click()
 
     //Make sure notfication of success appears
-    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should("be.visible")
+    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should('exist')
     cy.wait(2000)
 
     //Make it sort descending

--- a/apps/frontend-e2e/src/e2e/metadata.cy.ts
+++ b/apps/frontend-e2e/src/e2e/metadata.cy.ts
@@ -22,7 +22,7 @@ describe('metadata', () => {
     cy.get('button.swal2-confirm').should('exist').click()
 
     //Make sure notfication of success appears
-    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should("be.visible")
+    cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should('exist')
     cy.wait(2000)
   });
 

--- a/apps/frontend-e2e/src/e2e/simulation.cy.ts
+++ b/apps/frontend-e2e/src/e2e/simulation.cy.ts
@@ -22,7 +22,7 @@ describe('simulation', () => {
       cy.get('button.swal2-confirm').should('exist').click()
   
       //Make sure notfication of success appears
-      cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should("be.visible")
+      cy.contains("div", "Collections fetched and saved successfully", {timeout: 7000}).should('exist')
       cy.wait(2000)
 
       //Load montreal_2023 dataset
@@ -33,9 +33,9 @@ describe('simulation', () => {
       cy.intercept('GET', 'http://localhost:8080/api/fetch-items-timestamps', { fixture: 'timestampResponse.json' }).as('timestamps');
       cy.wait("@timestamps",{timeout:10000})
 
-      cy.contains("div", 'Timestamps have been fetched successfully', {timeout: 7000}).should("be.visible")
+      cy.contains("div", 'Timestamps have been fetched successfully', {timeout: 7000}).should('exist')
       
-      cy.contains('div', 'Collection\'s items have been fetched successfully', {timeout:20000}).should('be.visible')
+      cy.contains('div', 'Collection\'s items have been fetched successfully', {timeout:20000}).should('exist')
 
       
     });


### PR DESCRIPTION
### Summary
The e2e pipeline was having weird behavior when it came to finding the toastify popups in the tests. The errors would essential tell us that the popups existed, but since they were being blocked by other components they were not visible. So, this PR just simply replaces the .should('be.visible') in the tests with .should('exist') as this check only ensures that it exists in the DOM (not necessarily if its on screen).

### Changes Made
- Replaced .should('be.visible') with .should('exist')

### Testing Instructions
- Run the tests locally, ensure they work
- Run the workflow on GitHub Actions to ensure it works on the repo aswell